### PR TITLE
Remove Hail from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,11 @@ import setuptools
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()
 
+install_requires = []
 with open("requirements.txt", "r") as requirements_file:
-    install_requires = [line.strip() for line in requirements_file if line.strip()]
+    for req in (line.strip() for line in requirements_file):
+        if req != "hail":
+            install_requires.append(req)
 
 
 setuptools.setup(


### PR DESCRIPTION
Because Hail is included in `install_requires` in setup.py, `hailctl dataproc start a-cluster --packages gnomad` always installs the latest PyPI release of Hail. This overwrites any specific Hail version set by the --wheel argument.

This removes Hail from `install_requires` but leaves it in requirements.txt for Actions workflows and easy development setup. 

Resolves #192