### PR TITLE
Add Black configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Use [Pylint](https://www.pylint.org/) to check for some types of errors.
 
 ```
-python -m pip install pylint
+python -m pip install -r requirements-dev.txt
 ./lint
 ```
 
@@ -13,6 +13,15 @@ To disable warnings, use:
 
 ```
 ./lint --disable=W
+```
+
+## Running Black
+
+Use [Black](https://black.readthedocs.io/) to format code.
+
+```
+python -m pip install -r requirements-dev.txt
+black gnomad
 ```
 
 ## Building documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py36', 'py37', 'py38']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+black==19.10b0
+pylint


### PR DESCRIPTION
So that formatting is consistent, we should all use the same version and configuration for Black.

* https://black.readthedocs.io/en/stable/installation_and_usage.html#command-line-options
* https://black.readthedocs.io/en/stable/pyproject_toml.html