### PR TITLE
Rewrite Slack notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updated capitalization of ambiguous sex annotation [(#208)](https://github.com/broadinstitute/gnomad_methods/pull/208)
 * Updated usage of included intervals in imputing sex ploidy, also updated interval parameter names [(#209)](https://github.com/broadinstitute/gnomad_methods/pull/209)
 * Updated capitalization in relatedness constants [(#217)](https://github.com/broadinstitute/gnomad_methods/pull/217)
+* Changed interface for Slack notifications
 
 ## Version 0.2.0 - April 3rd, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updated capitalization of ambiguous sex annotation [(#208)](https://github.com/broadinstitute/gnomad_methods/pull/208)
 * Updated usage of included intervals in imputing sex ploidy, also updated interval parameter names [(#209)](https://github.com/broadinstitute/gnomad_methods/pull/209)
 * Updated capitalization in relatedness constants [(#217)](https://github.com/broadinstitute/gnomad_methods/pull/217)
-* Changed interface for Slack notifications
+* Changed interface for Slack notifications [(#219)](https://github.com/broadinstitute/gnomad_methods/pull/219)
 
 ## Version 0.2.0 - April 3rd, 2020
 

--- a/lint
+++ b/lint
@@ -2,4 +2,4 @@
 
 cd "$(dirname "$0")"
 
-pylint "$@" gnomad
+PYTHONPATH=$PYTHONPATH:$(pwd) pylint "$@" gnomad

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ hail
 hdbscan
 ipywidgets
 scikit-learn
-slackclient==2.0.0
+slackclient==2.5.0


### PR DESCRIPTION
A few major changes here:
* Instead of `gnomad.utils.slack` attempting to import a Slack token from a predefined path, the consuming script must now provide the token.
* Replace the `try_slack` functions with a `slack_notifications` context manager. `try_slack` took a function and its arguments as arguments. The context manager allows wrapping Slack notifications around an arbitrary block of code.
* Upgrade the Slack client library from 2.0.0 to 2.5.0.

Usage:
```python
from gnomad.utils.slack import slack_notifications

with slack_notifications("TOKEN", "@user"):
    ...
```

The second argument can be a username (prefixed with '@') or a channel name (prefixed with '#') to post notifications to.

Tested with the same [legacy test tokens](https://api.slack.com/legacy/custom-integrations/legacy-tokens) that were used with the old method and with a Slack App's [bot user token](https://api.slack.com/authentication/token-types#bot). I'll add another PR later with instructions for setting up a Slack App.