### PR TITLE
Use local copy of VEP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added `median_impute_features` to variant QC random forest module [(224)](https://github.com/broadinstitute/gnomad_methods/pull/224)
 * Created `training.py` in variant QC and added `sample_training_examples` [(224)](https://github.com/broadinstitute/gnomad_methods/pull/224)
 * Added variant QC pipeline function `train_rf_model` [(224)](https://github.com/broadinstitute/gnomad_methods/pull/224)
+* Use local copy of VEP config instead of reading from bucket [(#231)](https://github.com/broadinstitute/gnomad_methods/pull/231)
 
 ## Version 0.3.0 - April 28th, 2020
 

--- a/docs/examples/vep.rst
+++ b/docs/examples/vep.rst
@@ -7,7 +7,7 @@ tied to a specific reference genome.
 
 .. code-block:: shell
 
-   hailctl dataproc start cluster-name --vep GRCh37 --requester-pays-allow-buckets hail-us-vep --packages gnomad
+   hailctl dataproc start cluster-name --vep GRCh37 --packages gnomad
 
 .. note::
 

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -64,11 +64,11 @@ CSQ_ORDER = (
 
 VEP_REFERENCE_DATA = {
     "GRCh37": {
-        "vep_config": "gs://hail-us-vep/vep85-loftee-gcloud.json",
+        "vep_config": "file:///vep_data/vep-gcloud.json",
         "all_possible": "gs://gnomad-public/papers/2019-flagship-lof/v1.0/context/Homo_sapiens_assembly19.fasta.snps_only.vep_20181129.ht",
     },
     "GRCh38": {
-        "vep_config": "gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json",
+        "vep_config": "file:///vep_data/vep-gcloud.json",
         "all_possible": "gs://gnomad-public/resources/context/grch38_context_vep_annotated.ht",
     },
 }


### PR DESCRIPTION
Currently, VEP configuration is downloaded from Hail's US bucket.
https://github.com/broadinstitute/gnomad_methods/blob/2090cbb6672474cdfbfc6ab0a8fb54275fd03499/gnomad/utils/vep.py#L65-L74

This bucket is requestor pays, so reading from it requires that either `--requester-pays-allow-all` or `--requester-pays-allow-buckets hail-us-vep` is specified when starting the cluster. If someone isn't aware of that, it's easy to start a cluster (which takes a fair amount of time with VEP) that can't run the gnomAD VEP utilities.

`hailctl dataproc`'s VEP init scripts download these configuration files and link them to `/vep_data/vep-gcloud.json`. If VEP configuration was loaded from the local copy downloaded by the init scripts instead of the `hail-us-vep` bucket, then the requestor pays arguments would not be necessary. 

Resolves #226
Resolves #211