### PR TITLE
Allow specific requester pays bucket in VEP example

### DIFF
--- a/docs/examples/vep.rst
+++ b/docs/examples/vep.rst
@@ -7,7 +7,7 @@ tied to a specific reference genome.
 
 .. code-block:: shell
 
-   hailctl dataproc start cluster-name --vep GRCh37 --requester-pays-allow-all --packages gnomad
+   hailctl dataproc start cluster-name --vep GRCh37 --requester-pays-allow-buckets hail-us-vep --packages gnomad
 
 .. note::
 


### PR DESCRIPTION
The VEP example currently uses `--requester-pays-allow-all` to create a cluster. We actually only need to allow the `hail-us-vep` bucket to read VEP configuration from.

https://github.com/broadinstitute/gnomad_methods/blob/0b8e1007aacabcb81e4093d9e315ac6f7c92651b/gnomad/utils/vep.py#L65-L74