### PR TITLE
Updated resource paths to requester pays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Modified `filter_mt_to_trios` to no longer filter to autosomes as this should be handled during the variant QC pipeline [(#223)](https://github.com/broadinstitute/gnomad_methods/pull/223) 
 * Updated `annotate_sex` to add globals to `sex_ht` [(#227)](https://github.com/broadinstitute/gnomad_methods/pull/227)
 * Document `slack_notifications` function [(#228)](https://github.com/broadinstitute/gnomad_methods/pull/228)
+* Updated gnomAD resources paths for hail tables to requester pays buckets [(#233)](https://github.com/broadinstitute/gnomad_methods/pull/233)
 
 ## Version 0.3.0 - April 28th, 2020
 

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -1,6 +1,5 @@
 from gnomad.resources.resource_utils import (
     DataException,
-    PedigreeResource,
     TableResource,
     VersionedTableResource,
 )
@@ -67,7 +66,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: Path to release Table
     """
-    return f"gs://gnomad-public/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
+    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
 
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
@@ -78,7 +77,7 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: path to coverage Table
     """
-    return f"gs://gnomad-public/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
+    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
 
 
 def _public_pca_ht_path(subpop: str) -> str:
@@ -100,7 +99,7 @@ def _liftover_data_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: Path to chosen Table
     """
-    return f"gs://gnomad-public/release/{version}/liftover_grch38/ht/{data_type}/gnomad.{data_type}.r{version}.sites.liftover_grch38.ht"
+    return f"gs://gnomad-public-requester-pays/release/{version}/liftover_grch38/ht/{data_type}/gnomad.{data_type}.r{version}.sites.liftover_grch38.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:

--- a/gnomad/resources/grch37/gnomad_ld.py
+++ b/gnomad/resources/grch37/gnomad_ld.py
@@ -15,7 +15,7 @@ def _ld_matrix_path(
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
     subdir = "sv/" if data_type == "genomes_snv_sv" else ""
-    return f'gs://gnomad-public/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.bm'
+    return f'gs://gnomad-public-requester-pays/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.bm'
 
 
 def _ld_index_path(
@@ -30,15 +30,15 @@ def _ld_index_path(
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
     subdir = "sv/" if data_type == "genomes_snv_sv" else ""
-    return f'gs://gnomad-public/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.variant_indices.ht'
+    return f'gs://gnomad-public-requester-pays/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.variant_indices.ht'
 
 
 def _ld_snv_sv_path(pop):
-    return f"gs://gnomad-public/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.ht"
+    return f"gs://gnomad-public-requester-pays/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.ht"
 
 
 def _ld_snv_sv_index_path(pop, type):
-    return f"gs://gnomad-public/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.{type}.txt.bgz"
+    return f"gs://gnomad-public-requester-pays/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.{type}.txt.bgz"
 
 
 def _cross_pop_ld_scores_path(
@@ -52,7 +52,7 @@ def _cross_pop_ld_scores_path(
         version = (
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
-    return f'gs://gnomad-public/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop1}.{pop2}.{"adj." if adj else ""}ld_scores.ht'
+    return f'gs://gnomad-public-requester-pays/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop1}.{pop2}.{"adj." if adj else ""}ld_scores.ht'
 
 
 def _ld_scores_path(
@@ -62,7 +62,7 @@ def _ld_scores_path(
         version = (
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
-    return f'gs://gnomad-public/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop}.{"adj." if adj else ""}ld_scores.ht'
+    return f'gs://gnomad-public-requester-pays/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop}.{"adj." if adj else ""}ld_scores.ht'
 
 
 def ld_matrix(pop: str) -> BlockMatrixResource:

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -42,7 +42,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh38
     :return: Path to release Table
     """
-    return f"gs://gnomad-public/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
+    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
 
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
@@ -53,7 +53,7 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh38
     :return: path to coverage Table
     """
-    return f"gs://gnomad-public/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
+    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -65,11 +65,11 @@ CSQ_ORDER = (
 VEP_REFERENCE_DATA = {
     "GRCh37": {
         "vep_config": "gs://hail-us-vep/vep85-loftee-gcloud.json",
-        "all_possible": "gs://gnomad-public/papers/2019-flagship-lof/v1.0/context/Homo_sapiens_assembly19.fasta.snps_only.vep_20181129.ht",
+        "all_possible": "gs://gnomad-public-requester-pays/resources/context/grch37_context_vep_annotated.ht",
     },
     "GRCh38": {
         "vep_config": "gs://hail-us-vep/vep95-GRCh38-loftee-gcloud.json",
-        "all_possible": "gs://gnomad-public/resources/context/grch38_context_vep_annotated.ht",
+        "all_possible": "gs://gnomad-public-requester-pays/resources/context/grch38_context_vep_annotated.ht",
     },
 }
 


### PR DESCRIPTION
This is the first resource move to the public requester-pays bucket. The ld resource is 13TB and may take a while to copy. I maintained the same bucket structure as the original bucket. 