### PR TITLE
Add changelog to docs site

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,6 @@
-# Generated reST files
+# Generated files
 api_reference
+changelog.md
 
 # sphinx-build output
 html

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -6,5 +6,7 @@ cd "${DOCS_DIR}"
 rm -rf api_reference
 ./generate_api_reference.py
 
+./copy_changelog.py
+
 rm -rf html
 python3 -m sphinx -W -b html . html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,11 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
+    "recommonmark",
 ]
+
+# README.md contains developer documentation for building docs
+exclude_patterns = ["README.md"]
 
 master_doc = "index"
 

--- a/docs/copy_changelog.py
+++ b/docs/copy_changelog.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+"""
+Copy CHANGELOG.md from repository root and remove "Unreleased" section.
+"""
+
+import os
+
+
+docs_directory = os.path.dirname(__file__)
+
+changelog_path = os.path.join(docs_directory, "..", "CHANGELOG.md")
+docs_changelog_path = os.path.join(docs_directory, "changelog.md")
+
+with open(changelog_path) as f_in, open(docs_changelog_path, "w") as f_out:
+    skip = False
+    for line in f_in:
+        is_heading = line.startswith("## ")
+        if is_heading:
+            skip = "unreleased" in line.lower()
+
+        if not skip:
+            f_out.write(line)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,3 +14,4 @@ Contents
    Getting Started <getting_started>
    Examples <examples/index>
    API Reference <api_reference/index>
+   Change Log <changelog.md>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+recommonmark==0.6.0
 Sphinx==2.3.1
 sphinx-autodoc-typehints==1.10.3
 sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
Add CHANGELOG.md (minus the "Unreleased" section) to the docs site.

Resolves #235.