### PR TITLE
Allow compute_binned_truth_sample_concordance to compute other bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix for error in `compute_quantile_bin` that caused incorrect binning when a single score overlapped multiple bins. [(#238)](https://github.com/broadinstitute/gnomad_methods/pull/238)
 * Removed assumption of `snv` annotation from `compute_quantile_bin`. [(#238)](https://github.com/broadinstitute/gnomad_methods/pull/238)
 * Fixed `create_binned_ht` because it produced a "Cannot combine expressions from different source objects error". [(#238)](https://github.com/broadinstitute/gnomad_methods/pull/238)
+* Modified `compute_binned_truth_sample_concordance` to handle additional binning for subsets of variants. [(#240)](https://github.com/broadinstitute/gnomad_methods/pull/240)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/variant_qc/evaluation.py
+++ b/gnomad/variant_qc/evaluation.py
@@ -291,7 +291,7 @@ def compute_binned_truth_sample_concordance(
     ht: hl.Table,
     binned_score_ht: hl.Table,
     n_bins: int = 100,
-    add_bins: Optional[Dict[str, hl.expr.BooleanExpression]] = None,
+    add_bins: Dict[str, hl.expr.BooleanExpression] = {},
 ) -> hl.Table:
     """
     Determines the concordance (TP, FP, FN) between a truth sample within the callset and the samples truth data

--- a/gnomad/variant_qc/evaluation.py
+++ b/gnomad/variant_qc/evaluation.py
@@ -307,7 +307,7 @@ def compute_binned_truth_sample_concordance(
              - bin: the full callset quantile bin
 
     'add_bins` can be used to add additional global and truth sample binning to the final binned truth sample
-    concordance HT. The keys in `add_bins` must be present in `indexed_binned_score_ht` and the values in `add_bins`
+    concordance HT. The keys in `add_bins` must be present in `binned_score_ht` and the values in `add_bins`
     should be expressions on `ht` that define a subset of variants to bin in the truth sample. An example is if we want
     to look at the global and truth sample binning on only bi-allelic variants. `add_bins` could be set to
     {'biallelic_bin': ht.biallelic}.
@@ -326,7 +326,6 @@ def compute_binned_truth_sample_concordance(
         **{f"global_{bin_id}": indexed_binned_score_ht[bin_id] for bin_id in add_bins},
         **{f"_{bin_id}": bin_expr for bin_id, bin_expr in add_bins.items()},
         score=indexed_binned_score_ht.score,
-        snv=hl.is_snp(ht.alleles[0], ht.alleles[1]),
         global_bin=indexed_binned_score_ht.bin,
     )
 


### PR DESCRIPTION
Small change so I can perform the binning easily on only well covered intervals