### PR TITLE
Add 1 to REF-block DP expression in impute_sex_ploidy

### DIFF
--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -599,7 +599,7 @@ def impute_sex_ploidy(
                 f"{chrom}_mean_dp": hl.agg.sum(
                     hl.cond(
                         chr_mt.LGT.is_hom_ref(),
-                        chr_mt.DP * (chr_mt.END - chr_mt.locus.position),
+                        chr_mt.DP * (1 + chr_mt.END - chr_mt.locus.position),
                         chr_mt.DP,
                     )
                 )


### PR DESCRIPTION
A REF-block may have an end equal to its position. The old code
undercounts depth by treating REF-block intervals as half open, when
they are closed. This change adds in order to get their true size.