### PR TITLE
Add VersionedVersionedTableResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Updated liftover functions to be more generic [(#246)](https://github.com/broadinstitute/gnomad_methods/pull/246)
 * Changed quality histograms to label histograms calculated on raw and not adj data [(#247)](https://github.com/broadinstitute/gnomad_methods/pull/247)
 * Updated some VCF export constants [(#249)](https://github.com/broadinstitute/gnomad_methods/pull/249)
+* Added VersionedVersionedTableResource [#260](https://github.com/broadinstitute/gnomad_methods/pull/260)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -378,7 +378,9 @@ class VersionedVersionedTableResource(VersionedTableResource):
     :param versions: A dict of version name -> VersionedTableResource.
     """
 
-    def __init__(self, default_version: str, versions: Dict[str, VersionedTableResource]):
+    def __init__(
+        self, default_version: str, versions: Dict[str, VersionedTableResource]
+    ):
         super().__init__(default_version, versions)
 
 

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -367,6 +367,21 @@ class VersionedBlockMatrixResource(BaseVersionedResource, BlockMatrixResource):
         super().__init__(default_version, versions)
 
 
+class VersionedVersionedTableResource(VersionedTableResource):
+    """
+    Versioned Versioned Table resource
+
+    The attributes (path, import_args and import_func) of the versioned resource are those of the default version of the resource.
+    In addition, all versions of the resource are stored in the `versions` attribute.
+
+    :param default_version: The default version of this Versioned Table resource (must to be in the `versions` dict)
+    :param versions: A dict of version name -> VersionedTableResource.
+    """
+
+    def __init__(self, default_version: str, versions: Dict[str, VersionedTableResource]):
+        super().__init__(default_version, versions)
+
+
 class DataException(Exception):
     pass
 


### PR DESCRIPTION
This adds a VersionedVersionedTableResource for cases where gnomAD version iterations each have multiple versions of a table. The use case here is metadata ht. 