### PR TITLE
Support multiple resource buckets and switch to Google Cloud Public Datasets bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 * Added function, `default_generate_gene_lof_matrix`, to generate gene matrix [(#290)](https://github.com/broadinstitute/gnomad_methods/pull/290)
 * Added function `default_generate_gene_lof_summary` to summarize gene matrix results [(#292)](https://github.com/broadinstitute/gnomad_methods/pull/292)
 * Modified `create_truth_sample_ht` to add adj annotation information in the returned Table if present in the supplied MatrixTables [(#300)](https://github.com/broadinstitute/gnomad_methods/pull/300)
+* Added support for loading resources from alternate sources [(#265)](https://github.com/broadinstitute/gnomad_methods/pull/265)
+* Default to loading resources from Google Cloud Public Datasets [(#265)](https://github.com/broadinstitute/gnomad_methods/pull/265)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/docs/examples/vep.rst
+++ b/docs/examples/vep.rst
@@ -7,7 +7,7 @@ tied to a specific reference genome.
 
 .. code-block:: shell
 
-   hailctl dataproc start cluster-name --vep GRCh37 --packages gnomad --requester-pays-allow-buckets gnomad-public-requester-pays
+   hailctl dataproc start cluster-name --vep GRCh37 --packages gnomad
 
 .. note::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,10 +6,10 @@ Getting Started
     pip install hail
 
 2. Use ``hailctl`` to start a `Google Dataproc <https://cloud.google.com/dataproc/>`_ cluster with the
-   ``gnomad`` package installed and allow reading from the ``gnomad-public-requester-pays`` storage bucket
-   (see `Hail on the Cloud <https://hail.is/docs/0.2/hail_on_the_cloud.html>`_ for more detail on hailctl)::
+   ``gnomad`` package installed (see `Hail on the Cloud <https://hail.is/docs/0.2/hail_on_the_cloud.html>`_
+   for more detail on hailctl)::
 
-    hailctl dataproc start cluster-name --packages gnomad --requester-pays-allow-buckets gnomad-public-requester-pays
+    hailctl dataproc start cluster-name --packages gnomad
 
 3. Connect to a `Jupyter Notebook <https://jupyter-notebook.readthedocs.io/en/stable/notebook.html>`_ on the cluster::
 

--- a/gnomad/resources/__init__.py
+++ b/gnomad/resources/__init__.py
@@ -1,1 +1,2 @@
+from .config import GnomadResourceProvider, gnomad_resource_configuration
 from .resource_utils import *

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -1,0 +1,44 @@
+import typing
+from enum import Enum
+
+
+class GnomadResourceProvider(Enum):
+    GNOMAD = "gnomAD"
+
+
+class GnomadResourceConfiguration:
+    """
+    Configuration for gnomAD resources.
+    """
+
+    __default_resource_provider = GnomadResourceProvider.GNOMAD
+
+    @property
+    def default_resource_provider(self) -> GnomadResourceProvider:
+        """
+        Get the default provider for resource files.
+
+        This is used to determine resource URLs when `resources_root` is not specified.
+
+        :returns: Provider name
+        """
+        return self.__default_resource_provider
+
+    @default_resource_provider.setter
+    def default_resource_provider(
+        self, provider: typing.Union[GnomadResourceProvider, str]
+    ) -> None:
+        """
+        Set the default provider for resource files.
+
+        This is used to determine resource URLs when `resources_root` is not specified.
+
+        :param provider: Provider name
+        """
+        if not isinstance(provider, GnomadResourceProvider):
+            provider = GnomadResourceProvider(provider)
+
+        self.__default_resource_provider = provider
+
+
+gnomad_resource_configuration = GnomadResourceConfiguration()

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 class GnomadResourceProvider(Enum):
     GNOMAD = "gnomAD"
+    GOOGLE_CLOUD_PUBLIC_DATASETS = "Google Cloud Public Datasets"
 
 
 class GnomadResourceConfiguration:

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -12,7 +12,7 @@ class GnomadResourceConfiguration:
     Configuration for gnomAD resources.
     """
 
-    __default_resource_provider = GnomadResourceProvider.GNOMAD
+    __default_resource_provider = GnomadResourceProvider.GOOGLE_CLOUD_PUBLIC_DATASETS
 
     @property
     def default_resource_provider(self) -> GnomadResourceProvider:

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -66,7 +66,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: Path to release Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
+    return f"/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
 
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
@@ -77,7 +77,7 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: path to coverage Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
+    return f"/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
 
 
 def _public_pca_ht_path(subpop: str) -> str:
@@ -88,7 +88,7 @@ def _public_pca_ht_path(subpop: str) -> str:
     :return: Path to release Table
     """
     subpop = f".{subpop}" if subpop else ""
-    return f"gs://gnomad-public/release/2.1/pca/gnomad.r2.1.pca_loadings{subpop}.ht"
+    return f"/release/2.1/pca/gnomad.r2.1.pca_loadings{subpop}.ht"
 
 
 def _liftover_data_path(data_type: str, version: str) -> str:
@@ -99,7 +99,7 @@ def _liftover_data_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: Path to chosen Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/liftover_grch38/ht/{data_type}/gnomad.{data_type}.r{version}.sites.liftover_grch38.ht"
+    return f"/release/{version}/liftover_grch38/ht/{data_type}/gnomad.{data_type}.r{version}.sites.liftover_grch38.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -123,7 +123,10 @@ def public_release(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_release_ht_path(data_type, release))
+            release: TableResource(
+                path=_public_release_ht_path(data_type, release),
+                gnomad_bucket="gnomad-public-requester-pays",
+            )
             for release in releases
         },
     )
@@ -150,7 +153,10 @@ def coverage(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_coverage_ht_path(data_type, release))
+            release: TableResource(
+                path=_public_coverage_ht_path(data_type, release),
+                gnomad_bucket="gnomad-public-requester-pays",
+            )
             for release in releases
         },
     )
@@ -177,7 +183,10 @@ def liftover(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_liftover_data_path(data_type, release))
+            release: TableResource(
+                path=_liftover_data_path(data_type, release),
+                gnomad_bucket="gnomad-public-requester-pays",
+            )
             for release in releases
         },
     )

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -2,6 +2,7 @@ from gnomad.resources.resource_utils import (
     DataException,
     TableResource,
     VersionedTableResource,
+    get_resource_url,
 )
 
 DATA_TYPES = ["exomes", "genomes"]
@@ -218,4 +219,5 @@ def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     :return: Path to VCF
     """
     contig = f".{contig}" if contig else ""
-    return f"gs://gnomad-public/release/{version}/vcf/{data_type}/gnomad.{data_type}.r{version}.sites{contig}.vcf.bgz"
+    path = f"/release/{version}/vcf/{data_type}/gnomad.{data_type}.r{version}.sites{contig}.vcf.bgz"
+    return get_resource_url(path, gnomad_bucket="gnomad-public")

--- a/gnomad/resources/grch37/gnomad_ld.py
+++ b/gnomad/resources/grch37/gnomad_ld.py
@@ -66,12 +66,21 @@ def _ld_scores_path(
 
 
 def ld_matrix(pop: str) -> BlockMatrixResource:
-    return BlockMatrixResource(path=_ld_matrix_path("genomes", pop))
+    return BlockMatrixResource(
+        path=_ld_matrix_path("genomes", pop),
+        gnomad_bucket="gnomad-public-requester-pays",
+    )
 
 
 def ld_index(pop: str) -> TableResource:
-    return TableResource(path=_ld_index_path("genomes", pop))
+    return TableResource(
+        path=_ld_index_path("genomes", pop),
+        gnomad_bucket="gnomad-public-requester-pays",
+    )
 
 
 def ld_scores(pop: str) -> TableResource:
-    return TableResource(path=_ld_scores_path("genomes", pop))
+    return TableResource(
+        path=_ld_scores_path("genomes", pop),
+        gnomad_bucket="gnomad-public-requester-pays",
+    )

--- a/gnomad/resources/grch37/gnomad_ld.py
+++ b/gnomad/resources/grch37/gnomad_ld.py
@@ -15,7 +15,7 @@ def _ld_matrix_path(
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
     subdir = "sv/" if data_type == "genomes_snv_sv" else ""
-    return f'gs://gnomad-public-requester-pays/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.bm'
+    return f'/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.bm'
 
 
 def _ld_index_path(
@@ -30,15 +30,15 @@ def _ld_index_path(
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
     subdir = "sv/" if data_type == "genomes_snv_sv" else ""
-    return f'gs://gnomad-public-requester-pays/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.variant_indices.ht'
+    return f'/release/{version}/ld/{subdir}gnomad.{data_type}.r{version}.{pop}.{"common." if common_only else ""}{"adj." if adj else ""}ld.variant_indices.ht'
 
 
 def _ld_snv_sv_path(pop):
-    return f"gs://gnomad-public-requester-pays/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.ht"
+    return f"/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.ht"
 
 
 def _ld_snv_sv_index_path(pop, type):
-    return f"gs://gnomad-public-requester-pays/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.{type}.txt.bgz"
+    return f"/release/2.1.1/ld/sv/gnomad.genomes_snv_sv.r2.1.1.{pop}.snv_sv.ld.{type}.txt.bgz"
 
 
 def _cross_pop_ld_scores_path(
@@ -52,7 +52,7 @@ def _cross_pop_ld_scores_path(
         version = (
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
-    return f'gs://gnomad-public-requester-pays/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop1}.{pop2}.{"adj." if adj else ""}ld_scores.ht'
+    return f'/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop1}.{pop2}.{"adj." if adj else ""}ld_scores.ht'
 
 
 def _ld_scores_path(
@@ -62,7 +62,7 @@ def _ld_scores_path(
         version = (
             CURRENT_EXOME_RELEASE if data_type == "exomes" else CURRENT_GENOME_RELEASE
         )
-    return f'gs://gnomad-public-requester-pays/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop}.{"adj." if adj else ""}ld_scores.ht'
+    return f'/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop}.{"adj." if adj else ""}ld_scores.ht'
 
 
 def ld_matrix(pop: str) -> BlockMatrixResource:

--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -8,7 +8,7 @@ from gnomad.resources.resource_utils import (
 import hail as hl
 
 na12878_giab = MatrixTableResource(
-    path="gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.mt",
+    path="/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.mt",
     import_func=hl.import_vcf,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.vcf.bgz",
@@ -19,7 +19,7 @@ na12878_giab = MatrixTableResource(
 )
 
 hapmap = TableResource(
-    path="gs://gnomad-public/resources/grch37/hapmap/hapmap_3.3.b37.ht",
+    path="/resources/grch37/hapmap/hapmap_3.3.b37.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/hapmap/hapmap_3.3.b37.vcf.bgz",
@@ -30,7 +30,7 @@ hapmap = TableResource(
 )
 
 kgp_omni = TableResource(
-    path="gs://gnomad-public/resources/grch37/kgp/1000G_omni2.5.b37.ht",
+    path="/resources/grch37/kgp/1000G_omni2.5.b37.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/kgp/1000G_omni2.5.b37.vcf.bgz",
@@ -41,7 +41,7 @@ kgp_omni = TableResource(
 )
 
 mills = TableResource(
-    path="gs://gnomad-public/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.ht",
+    path="/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.vcf.bgz",
@@ -52,7 +52,7 @@ mills = TableResource(
 )
 
 syndip = MatrixTableResource(
-    path="gs://gnomad-public/resources/grch37/syndip/hybrid.m37m.mt",
+    path="/resources/grch37/syndip/hybrid.m37m.mt",
     import_func=hl.import_vcf,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/syndip/hybrid.m37m.vcf.bgz",
@@ -66,7 +66,8 @@ vep_context = VersionedTableResource(
     default_version="85",
     versions={
         "85": TableResource(
-            path="gs://gnomad-public-requester-pays/resources/context/grch37_context_vep_annotated.ht",
+            path="/resources/context/grch37_context_vep_annotated.ht",
+            gnomad_bucket="gnomad-public-requester-pays",
         )
     },
 )
@@ -75,7 +76,7 @@ dbsnp = VersionedTableResource(
     default_version="20180423",
     versions={
         "20180423": TableResource(
-            path="gs://gnomad-public/resources/grch37/dbsnp/All_20180423.ht",
+            path="/resources/grch37/dbsnp/All_20180423.ht",
             import_func=import_sites_vcf,
             import_args={
                 "path": "gs://gnomad-public/resources/grch37/dbsnp/All_20180423.vcf.bgz",
@@ -92,7 +93,7 @@ clinvar = VersionedTableResource(
     default_version="20181028",
     versions={
         "20181028": TableResource(
-            path="gs://gnomad-public/resources/grch37/clinvar/clinvar_20181028.vep.ht",
+            path="/resources/grch37/clinvar/clinvar_20181028.vep.ht",
             import_func=import_sites_vcf,
             import_args={
                 "path": "gs://gnomad-public/resources/grch37/clinvar/clinvar_20181028.vcf.bgz",
@@ -109,7 +110,7 @@ kgp_phase_3 = VersionedMatrixTableResource(
     default_version="phase_3_split",
     versions={
         "phase_3_split": MatrixTableResource(
-            path="gs://gnomad-public/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.split.mt",
+            path="/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.split.mt",
             import_func=hl.import_vcf,
             import_args={
                 "path": "gs://genomics-public-data/1000-genomes-phase-3/vcf-20150220/ALL.chr*.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf",
@@ -120,7 +121,7 @@ kgp_phase_3 = VersionedMatrixTableResource(
             },
         ),
         "phase_3": MatrixTableResource(
-            path="gs://gnomad-public/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.mt",
+            path="/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.mt",
             import_func=hl.import_vcf,
             import_args={
                 "path": "gs://genomics-public-data/1000-genomes-phase-3/vcf-20150220/ALL.chr*.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf",
@@ -137,7 +138,7 @@ kgp = VersionedTableResource(
     default_version="phase_1_hc",
     versions={
         "phase_1_hc": TableResource(
-            path="gs://gnomad-public/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.ht",
+            path="/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.ht",
             import_func=import_sites_vcf,
             import_args={
                 "path": "gs://gnomad-public/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.vcf.bgz",
@@ -150,14 +151,14 @@ kgp = VersionedTableResource(
     },
 )
 
-cpg_sites = TableResource(path="gs://gnomad-public/resources/grch37/cpg_sites/cpg.ht")
+cpg_sites = TableResource(path="/resources/grch37/cpg_sites/cpg.ht")
 
 methylation_sites = TableResource(
-    path="gs://gnomad-public/resources/grch37/methylation_sites/methylation.ht"
+    path="/resources/grch37/methylation_sites/methylation.ht"
 )
 
 lcr_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list.ht",
+    path="/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list",
@@ -166,7 +167,7 @@ lcr_intervals = TableResource(
 )
 
 decoy_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.ht",
+    path="/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.ht",
     import_func=hl.import_bed,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.bed",
@@ -175,7 +176,7 @@ decoy_intervals = TableResource(
 )
 
 purcell_5k_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/purcell_5k_intervals/purcell5k.ht",
+    path="/resources/grch37/purcell_5k_intervals/purcell5k.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/purcell_5k_intervals/purcell5k.interval_list",
@@ -184,7 +185,7 @@ purcell_5k_intervals = TableResource(
 )
 
 seg_dup_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.ht",
+    path="/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.ht",
     import_func=hl.import_bed,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.bed",
@@ -193,7 +194,7 @@ seg_dup_intervals = TableResource(
 )
 
 exome_hc_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list.ht",
+    path="/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list",
@@ -202,7 +203,7 @@ exome_hc_intervals = TableResource(
 )
 
 high_coverage_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/high_coverage.auto.interval_list.ht",
+    path="/resources/grch37/broad_intervals/high_coverage.auto.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/broad_intervals/high_coverage.auto.interval_list",
@@ -211,7 +212,7 @@ high_coverage_intervals = TableResource(
 )
 
 exome_calling_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list.ht",
+    path="/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list",
@@ -220,7 +221,7 @@ exome_calling_intervals = TableResource(
 )
 
 exome_evaluation_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list.ht",
+    path="/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list",
@@ -229,7 +230,7 @@ exome_evaluation_intervals = TableResource(
 )
 
 genome_evaluation_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list.ht",
+    path="/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list",
@@ -238,7 +239,7 @@ genome_evaluation_intervals = TableResource(
 )
 
 na12878_hc_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_intervals.ht",
+    path="/resources/grch37/na12878/NA12878_GIAB_highconf_intervals.ht",
     import_func=hl.import_bed,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.bed",
@@ -247,7 +248,7 @@ na12878_hc_intervals = TableResource(
 )
 
 syndip_hc_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch37/syndip/syndip_highconf_genome_intervals.ht",
+    path="/resources/grch37/syndip/syndip_highconf_genome_intervals.ht",
     import_func=hl.import_bed,
     import_args={
         "path": "gs://gnomad-public/resources/grch37/syndip/hybrid.m37m.bed",

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -205,7 +205,10 @@ def public_release(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_release_ht_path(data_type, release))
+            release: TableResource(
+                path=_public_release_ht_path(data_type, release),
+                gnomad_bucket="gnomad-public-requester-pays",
+            )
             for release in releases
         },
     )
@@ -233,7 +236,10 @@ def coverage(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_coverage_ht_path(data_type, release))
+            release: TableResource(
+                path=_public_coverage_ht_path(data_type, release),
+                gnomad_bucket="gnomad-public-requester-pays",
+            )
             for release in releases
         },
     )

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -144,18 +144,14 @@ DOWNSAMPLINGS = [
 gnomad_syndip = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
-        "3.0": MatrixTableResource(
-            path="gs://gnomad-public/truth-sets/hail-0.2/gnomad_v3_syndip.b38.mt"
-        )
+        "3.0": MatrixTableResource(path="/truth-sets/hail-0.2/gnomad_v3_syndip.b38.mt")
     },
 )
 
 na12878 = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
-        "3.0": MatrixTableResource(
-            path="gs://gnomad-public/truth-sets/hail-0.2/gnomad_v3_na12878.mt"
-        )
+        "3.0": MatrixTableResource(path="/truth-sets/hail-0.2/gnomad_v3_na12878.mt")
     },
 )
 
@@ -168,7 +164,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh38
     :return: Path to release Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
+    return f"/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
 
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
@@ -179,7 +175,7 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh38
     :return: path to coverage Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
+    return f"/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -4,6 +4,7 @@ from gnomad.resources.resource_utils import (
     MatrixTableResource,
     VersionedTableResource,
     DataException,
+    get_resource_url,
 )
 from typing import Optional
 
@@ -268,7 +269,8 @@ def coverage_tsv_path(data_type: str, version: Optional[str] = None) -> str:
                 f"Version {version} of gnomAD genomes for GRCh38 does not exist"
             )
 
-    return f"gs://gnomad-public/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.summary.tsv.bgz"
+    path = f"/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.summary.tsv.bgz"
+    return get_resource_url(path, gnomad_bucket="gnomad-public")
 
 
 def release_vcf_path(data_type: str, version: str, contig: str) -> str:
@@ -282,4 +284,5 @@ def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     :return: Path to VCF
     """
     contig = f".{contig}" if contig else ""
-    return f"gs://gnomad-public/release/{version}/vcf/{data_type}/gnomad.{data_type}.r{version}.sites{contig}.vcf.bgz"
+    path = f"/release/{version}/vcf/{data_type}/gnomad.{data_type}.r{version}.sites{contig}.vcf.bgz"
+    return get_resource_url(path, gnomad_bucket="gnomad-public")

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -45,7 +45,7 @@ def _import_clinvar(**kwargs) -> hl.Table:
 
 # Resources with no versioning needed
 purcell_5k_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch38/purcell_5k_intervals/purcell5k.ht",
+    path="/resources/grch38/purcell_5k_intervals/purcell5k.ht",
     import_func=_import_purcell_5k,
     import_args={
         "path": "gs://gnomad-public/resources/grch38/purcell_5k_intervals/purcell5k.interval_list",
@@ -53,7 +53,7 @@ purcell_5k_intervals = TableResource(
 )
 
 na12878_giab = MatrixTableResource(
-    path="gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.mt",
+    path="/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.mt",
     import_func=hl.import_vcf,
     import_args={
         "path": "gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz",
@@ -64,7 +64,7 @@ na12878_giab = MatrixTableResource(
 )
 
 na12878_giab_hc_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7_hc_regions.ht",
+    path="/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7_hc_regions.ht",
     import_func=hl.import_bed,
     import_args={
         "path": "gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7.bed",
@@ -78,7 +78,8 @@ vep_context = VersionedTableResource(
     default_version="95",
     versions={
         "95": TableResource(
-            path="gs://gnomad-public-requester-pays/resources/context/grch38_context_vep_annotated.ht",
+            path="/resources/context/grch38_context_vep_annotated.ht",
+            gnomad_bucket="gnomad-public-requester-pays",
         )
     },
 )
@@ -87,7 +88,7 @@ syndip = VersionedMatrixTableResource(
     default_version="20180222",
     versions={
         "20180222": MatrixTableResource(
-            path="gs://gnomad-public/resources/grch38/syndip/syndip.b38_20180222.mt",
+            path="/resources/grch38/syndip/syndip.b38_20180222.mt",
             import_func=hl.import_vcf,
             import_args={
                 "path": "gs://gnomad-public/resources/grch38/syndip/full.38.20180222.vcf.gz",
@@ -103,7 +104,7 @@ syndip_hc_intervals = VersionedTableResource(
     default_version="20180222",
     versions={
         "20180222": TableResource(
-            path="gs://gnomad-public/resources/grch38/syndip/syndip_b38_20180222_hc_regions.ht",
+            path="/resources/grch38/syndip/syndip_b38_20180222_hc_regions.ht",
             import_func=hl.import_bed,
             import_args={
                 "path": "gs://gnomad-public/resources/grch38/syndip/syndip.b38_20180222.bed",
@@ -119,7 +120,7 @@ clinvar = VersionedTableResource(
     default_version="20190923",
     versions={
         "20190923": TableResource(
-            path="gs://gnomad-public/resources/grch38/clinvar/clinvar_20190923.ht",
+            path="/resources/grch38/clinvar/clinvar_20190923.ht",
             import_func=_import_clinvar,
             import_args={
                 "path": "gs://gnomad-public/resources/grch38/clinvar/clinvar_20190923.vcf.gz",
@@ -137,7 +138,7 @@ dbsnp = VersionedTableResource(
     default_version="b154",
     versions={
         "b154": TableResource(
-            path="gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_20200514.ht",
+            path="/resources/grch38/dbsnp/dbsnp_b154_grch38_all_20200514.ht",
             import_func=import_sites_vcf,
             import_args={
                 "path": "gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_GCF_000001405.38_20200514.vcf.bgz",
@@ -150,7 +151,7 @@ dbsnp = VersionedTableResource(
             },
         ),
         "b151": TableResource(
-            path="gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.ht",
+            path="/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.ht",
             import_func=import_sites_vcf,
             import_args={
                 "path": "gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.vcf.bgz",
@@ -166,7 +167,7 @@ dbsnp = VersionedTableResource(
 )
 
 hapmap = TableResource(
-    path="gs://gnomad-public/resources/grch38/hapmap/hapmap_3.3.hg38.ht",
+    path="/resources/grch38/hapmap/hapmap_3.3.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://genomics-public-data/resources/broad/hg38/v0/hapmap_3.3.hg38.vcf.gz",
@@ -176,7 +177,7 @@ hapmap = TableResource(
 )
 
 kgp_omni = TableResource(
-    path="gs://gnomad-public/resources/grch38/kgp/1000G_omni2.5.hg38.ht",
+    path="/resources/grch38/kgp/1000G_omni2.5.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://genomics-public-data/resources/broad/hg38/v0/1000G_omni2.5.hg38.vcf.gz",
@@ -189,7 +190,7 @@ kgp = VersionedTableResource(
     default_version="phase_1_hc",
     versions={
         "phase_1_hc": TableResource(
-            path="gs://gnomad-public/resources/grch38/kgp/1000G_phase1.snps.high_confidence.hg38.ht",
+            path="/resources/grch38/kgp/1000G_phase1.snps.high_confidence.hg38.ht",
             import_func=import_sites_vcf,
             import_args={
                 "path": "gs://genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz",
@@ -201,7 +202,7 @@ kgp = VersionedTableResource(
 )
 
 mills = TableResource(
-    path="gs://gnomad-public/resources/grch38/mills/Mills_and_1000G_gold_standard.indels.hg38.ht",
+    path="/resources/grch38/mills/Mills_and_1000G_gold_standard.indels.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
@@ -211,7 +212,7 @@ mills = TableResource(
 )
 
 lcr_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch38/lcr_intervals/LCRFromHengHg38.ht",
+    path="/resources/grch38/lcr_intervals/LCRFromHengHg38.ht",
     import_func=hl.import_locus_intervals,
     import_args={
         "path": "gs://gnomad-public/resources/grch38/lcr_intervals/LCRFromHengHg38.txt",
@@ -221,7 +222,7 @@ lcr_intervals = TableResource(
 )
 
 seg_dup_intervals = TableResource(
-    path="gs://gnomad-public/resources/grch38/seg_dup_intervals/GRCh38_segdups.ht",
+    path="/resources/grch38/seg_dup_intervals/GRCh38_segdups.ht",
     import_func=hl.import_bed,
     import_args={
         "path": "gs://gnomad-public/resources/grch38/seg_dup_intervals/GRCh38_segdups.bed",
@@ -230,7 +231,7 @@ seg_dup_intervals = TableResource(
 )
 
 telomeres_and_centromeres = TableResource(
-    path="gs://gnomad-public/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht",
+    path="/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht",
     import_func=hl.import_bed,
     import_args={
         "path": "gs://gnomad-public/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.bed",

--- a/gnomad/resources/import_resources.py
+++ b/gnomad/resources/import_resources.py
@@ -81,7 +81,9 @@ def main(args):
     for resource_arg in args.resources:
         resource_name, resource = all_resources[resource_arg]
         print(f"Importing {resource_name}...")
-        resource.import_resource(args.overwrite)
+        resource.import_resource(
+            overwrite=args.overwrite, resources_root="gs://gnomad-public"
+        )
 
 
 if __name__ == "__main__":

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -26,6 +26,9 @@ def get_resource_url(
 
     resource_provider = gnomad_resource_configuration.default_resource_provider
 
+    if resource_provider == GnomadResourceProvider.GOOGLE_CLOUD_PUBLIC_DATASETS:
+        return f"gs://gcp-public-data--gnomad{path}"
+
     if resource_provider == GnomadResourceProvider.GNOMAD:
         return f"gs://{gnomad_bucket}{path}"
 

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -17,6 +17,7 @@ class BaseResource(ABC):
     :param import_args: Any sources that are required for the import and need to be kept track of (e.g. .vcf path for an imported VCF)
     :param import_func: A function used to import the resource. `import_func` will be passed the `import_args` dictionary as kwargs.
     :param expected_file_extensions: A list of all expected file extensions. If path doesn't end with one of these, a warning if emitted.
+    :param gnomad_bucket: Which of the gnomAD project's GCS buckets the resource is stored in.
     """
 
     @abstractmethod
@@ -26,6 +27,7 @@ class BaseResource(ABC):
         import_args: Optional[Dict[str, Any]] = None,
         import_func: Optional[Callable] = None,
         expected_file_extensions: Optional[List[str]] = None,
+        gnomad_bucket: str = "gnomad-public",
     ):
         if path is None and import_func is None:
             raise ValueError(
@@ -35,6 +37,7 @@ class BaseResource(ABC):
         self.path = path
         self.import_args = import_args
         self.import_func = import_func
+        self.gnomad_bucket = gnomad_bucket
 
         if (
             path is not None
@@ -71,6 +74,7 @@ class TableResource(BaseResource):
     :param path: The Table path (typically ending in .ht)
     :param import_args: Any sources that are required for the import and need to be kept track of and/or passed to the import_func (e.g. .vcf path for an imported VCF)
     :param import_func: A function used to import the Table. `import_func` will be passed the `import_args` dictionary as kwargs.
+    :param gnomad_bucket: Which of the gnomAD project's GCS buckets the resource is stored in.
     """
 
     def __init__(
@@ -78,12 +82,14 @@ class TableResource(BaseResource):
         path: Optional[str] = None,
         import_args: Optional[Dict[str, Any]] = None,
         import_func: Optional[Callable[..., hl.Table]] = None,
+        gnomad_bucket: str = "gnomad-public",
     ):
         super().__init__(
             path=path,
             import_args=import_args,
             import_func=import_func,
             expected_file_extensions=[".ht"],
+            gnomad_bucket=gnomad_bucket,
         )
 
     def ht(self, force_import: bool = False) -> hl.Table:
@@ -117,6 +123,7 @@ class MatrixTableResource(BaseResource):
     :param path: The MatrixTable path (typically ending in .mt)
     :param import_args: Any sources that are required for the import and need to be kept track of and/or passed to the import_func (e.g. .vcf path for an imported VCF)
     :param import_func: A function used to import the MatrixTable. `import_func` will be passed the `import_args` dictionary as kwargs.
+    :param gnomad_bucket: Which of the gnomAD project's GCS buckets the resource is stored in.
     """
 
     def __init__(
@@ -124,12 +131,14 @@ class MatrixTableResource(BaseResource):
         path: Optional[str] = None,
         import_args: Optional[Dict[str, Any]] = None,
         import_func: Optional[Callable[..., hl.MatrixTable]] = None,
+        gnomad_bucket: str = "gnomad-public",
     ):
         super().__init__(
             path=path,
             import_args=import_args,
             import_func=import_func,
             expected_file_extensions=[".mt"],
+            gnomad_bucket=gnomad_bucket,
         )
 
     def mt(self, force_import: bool = False) -> hl.MatrixTable:
@@ -166,6 +175,7 @@ class PedigreeResource(BaseResource):
     :param quant_pheno: If ``True``, phenotype is interpreted as quantitative.
     :param delimiter: Field delimiter regex.
     :param missing: The string used to denote missing values. For case-control, 0, -9, and non-numeric are also treated as missing.
+    :param gnomad_bucket: Which of the gnomAD project's GCS buckets the resource is stored in.
     """
 
     def __init__(
@@ -176,12 +186,14 @@ class PedigreeResource(BaseResource):
         quant_pheno: bool = False,
         delimiter: str = r"\\s+",
         missing: str = "NA",
+        gnomad_bucket: str = "gnomad-public",
     ):
         super().__init__(
             path=path,
             import_args=import_args,
             import_func=import_func,
             expected_file_extensions=[".fam", ".ped"],
+            gnomad_bucket=gnomad_bucket,
         )
 
         self.quant_pheno = quant_pheno
@@ -231,6 +243,7 @@ class BlockMatrixResource(BaseResource):
     :param path: The BlockMatrix path (typically ending in .bm)
     :param import_args: Any sources that are required for the import and need to be kept track of and/or passed to the import_func.
     :param import_func: A function used to import the BlockMatrix. `import_func` will be passed the `import_args` dictionary as kwargs.
+    :param gnomad_bucket: Which of the gnomAD project's GCS buckets the resource is stored in.
     """
 
     def __init__(
@@ -238,12 +251,14 @@ class BlockMatrixResource(BaseResource):
         path: Optional[str] = None,
         import_args: Optional[Dict[str, Any]] = None,
         import_func: Optional[Callable[..., BlockMatrix]] = None,
+        gnomad_bucket: str = "gnomad-public",
     ):
         super().__init__(
             path=path,
             import_args=import_args,
             import_func=import_func,
             expected_file_extensions=[".bm"],
+            gnomad_bucket=gnomad_bucket,
         )
 
     def bm(self) -> BlockMatrix:
@@ -298,6 +313,7 @@ class BaseVersionedResource(BaseResource, ABC):
             path=versions[default_version].path,
             import_args=versions[default_version].import_args,
             import_func=versions[default_version].import_func,
+            gnomad_bucket=versions[default_version].gnomad_bucket,
         )
 
     def __repr__(self):

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -5,6 +5,9 @@ from typing import Any, Callable, Dict, List, Optional
 import hail as hl
 from hail.linalg import BlockMatrix
 
+from .config import GnomadResourceProvider, gnomad_resource_configuration
+
+
 logger = logging.getLogger("gnomad.resources")
 
 
@@ -19,9 +22,14 @@ def get_resource_url(
     :param gnomad_bucket: Which of the gnomAD project's GCS buckets the resource is stored in.
     """
     if resources_root:
-        return f"{resources_root}{path}"
+        return f"{resources_root.rstrip('/')}{path}"
 
-    return f"gs://{gnomad_bucket}{path}"
+    resource_provider = gnomad_resource_configuration.default_resource_provider
+
+    if resource_provider == GnomadResourceProvider.GNOMAD:
+        return f"gs://{gnomad_bucket}{path}"
+
+    raise RuntimeError("Unknown resource provider")
 
 
 # Resource classes

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("gnomad.resources")
 
 
 def get_resource_url(
-    path, resources_root: Optional[str] = None, gnomad_bucket: str = "gnomad-public"
+    path, *, resources_root: Optional[str] = None, gnomad_bucket: str = "gnomad-public"
 ) -> str:
     """
     Get URL for a source.
@@ -134,7 +134,11 @@ class TableResource(BaseResource):
         if self.path is None or force_import:
             return self.import_func(**self.import_args)
         else:
-            url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+            url = get_resource_url(
+                self.path,
+                resources_root=resources_root,
+                gnomad_bucket=self.gnomad_bucket,
+            )
             return hl.read_table(url)
 
     def import_resource(
@@ -148,7 +152,9 @@ class TableResource(BaseResource):
         :param kwargs: Any other parameters to be passed to hl.Table.write
         :return: Nothing
         """
-        url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+        url = get_resource_url(
+            self.path, resources_root=resources_root, gnomad_bucket=self.gnomad_bucket
+        )
         self.import_func(**self.import_args).write(
             url, overwrite=overwrite, **kwargs,
         )
@@ -191,7 +197,11 @@ class MatrixTableResource(BaseResource):
         if self.path is None or force_import:
             return self.import_func(**self.import_args)
         else:
-            url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+            url = get_resource_url(
+                self.path,
+                resources_root=resources_root,
+                gnomad_bucket=self.gnomad_bucket,
+            )
             return hl.read_matrix_table(url)
 
     def import_resource(
@@ -205,7 +215,9 @@ class MatrixTableResource(BaseResource):
         :param kwargs: Any other parameters to be passed to hl.MatrixTable.write
         :return: Nothing
         """
-        url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+        url = get_resource_url(
+            self.path, resources_root=resources_root, gnomad_bucket=self.gnomad_bucket
+        )
         self.import_func(**self.import_args).write(
             url, overwrite=overwrite, **kwargs,
         )
@@ -253,7 +265,9 @@ class PedigreeResource(BaseResource):
         :param resources_root: URL for the root of the resources tree.
         :return: Family table
         """
-        url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+        url = get_resource_url(
+            self.path, resources_root=resources_root, gnomad_bucket=self.gnomad_bucket
+        )
         return hl.import_fam(
             url,
             quant_pheno=self.quant_pheno,
@@ -268,7 +282,9 @@ class PedigreeResource(BaseResource):
         :param resources_root: URL for the root of the resources tree.
         :return: pedigree
         """
-        url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+        url = get_resource_url(
+            self.path, resources_root=resources_root, gnomad_bucket=self.gnomad_bucket
+        )
         return hl.Pedigree.read(url, delimiter=self.delimiter)
 
     def import_resource(
@@ -285,7 +301,9 @@ class PedigreeResource(BaseResource):
         if not overwrite:
             raise NotImplementedError
 
-        url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+        url = get_resource_url(
+            self.path, resources_root=resources_root, gnomad_bucket=self.gnomad_bucket
+        )
         self.import_func(**self.import_args).write(url)
 
 
@@ -321,7 +339,9 @@ class BlockMatrixResource(BaseResource):
         :param resources_root: URL for the root of the resources tree.
         :return: Hail MatrixTable resource
         """
-        url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+        url = get_resource_url(
+            self.path, resources_root=resources_root, gnomad_bucket=self.gnomad_bucket
+        )
         return BlockMatrix.read(url)
 
     def import_resource(
@@ -335,7 +355,9 @@ class BlockMatrixResource(BaseResource):
         :param kwargs: Any additional parameters to be passed to BlockMatrix.write
         :return: Nothing
         """
-        url = get_resource_url(self.path, resources_root, self.gnomad_bucket)
+        url = get_resource_url(
+            self.path, resources_root=resources_root, gnomad_bucket=self.gnomad_bucket
+        )
         self.import_func(**self.import_args).write(
             url, overwrite=False, **kwargs,
         )

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -85,7 +85,7 @@ class BaseResource(ABC):
 
     @abstractmethod
     def import_resource(
-        self, overwrite: bool = True, resources_root: Optional[str] = None, **kwargs
+        self, overwrite: bool = True, *, resources_root: Optional[str] = None, **kwargs
     ) -> None:
         """
         Abstract method to import the resource using its import_func and writes it in its path.
@@ -123,7 +123,7 @@ class TableResource(BaseResource):
         )
 
     def ht(
-        self, force_import: bool = False, resources_root: Optional[str] = None
+        self, force_import: bool = False, *, resources_root: Optional[str] = None
     ) -> hl.Table:
         """
         Read and return the Hail Table resource
@@ -142,7 +142,7 @@ class TableResource(BaseResource):
             return hl.read_table(url)
 
     def import_resource(
-        self, overwrite: bool = True, resources_root: Optional[str] = None, **kwargs
+        self, overwrite: bool = True, *, resources_root: Optional[str] = None, **kwargs
     ) -> None:
         """
         Imports the TableResource using its import_func and writes it in its path.
@@ -186,7 +186,7 @@ class MatrixTableResource(BaseResource):
         )
 
     def mt(
-        self, force_import: bool = False, resources_root: Optional[str] = None
+        self, force_import: bool = False, *, resources_root: Optional[str] = None
     ) -> hl.MatrixTable:
         """
         Read and return the Hail MatrixTable resource
@@ -205,7 +205,7 @@ class MatrixTableResource(BaseResource):
             return hl.read_matrix_table(url)
 
     def import_resource(
-        self, overwrite: bool = True, resources_root: Optional[str] = None, **kwargs
+        self, overwrite: bool = True, *, resources_root: Optional[str] = None, **kwargs
     ) -> None:
         """
         Imports the MatrixTable resource using its import_func and writes it in its path.
@@ -258,7 +258,7 @@ class PedigreeResource(BaseResource):
         self.delimiter = delimiter
         self.missing = missing
 
-    def ht(self, resources_root: Optional[str] = None) -> hl.Table:
+    def ht(self, *, resources_root: Optional[str] = None) -> hl.Table:
         """
         Reads the pedigree into a family HT using hl.import_fam().
 
@@ -275,7 +275,7 @@ class PedigreeResource(BaseResource):
             missing=self.missing,
         )
 
-    def pedigree(self, resources_root: Optional[str] = None) -> hl.Pedigree:
+    def pedigree(self, *, resources_root: Optional[str] = None) -> hl.Pedigree:
         """
         Reads the pedigree into an hl.Pedigree using hl.Pedigree.read().
 
@@ -288,7 +288,7 @@ class PedigreeResource(BaseResource):
         return hl.Pedigree.read(url, delimiter=self.delimiter)
 
     def import_resource(
-        self, overwrite: bool = True, resources_root: Optional[str] = None, **kwargs
+        self, overwrite: bool = True, *, resources_root: Optional[str] = None, **kwargs
     ) -> None:
         """
         Imports the Pedigree resource using its import_func and writes it in its path.
@@ -332,7 +332,7 @@ class BlockMatrixResource(BaseResource):
             gnomad_bucket=gnomad_bucket,
         )
 
-    def bm(self, resources_root: Optional[str] = None) -> BlockMatrix:
+    def bm(self, *, resources_root: Optional[str] = None) -> BlockMatrix:
         """
         Read and return the Hail MatrixTable resource
 
@@ -345,7 +345,7 @@ class BlockMatrixResource(BaseResource):
         return BlockMatrix.read(url)
 
     def import_resource(
-        self, overwrite: bool = True, resources_root: Optional[str] = None, **kwargs
+        self, overwrite: bool = True, *, resources_root: Optional[str] = None, **kwargs
     ) -> None:
         """
         Imports the BlockMatrixResource using its import_func and writes it in its path.


### PR DESCRIPTION
This adds support for multiple resource buckets in order to provide access to resources hosted on different cloud providers through our resources framework (#255, #263, #264). This also sets the default resource bucket to the Google Cloud Public Datasets bucket: `gs://gcp-public-data--gnomad` (resolves #264).

Some design goals:
1. Do not change interfaces. Everyone has more pressing things to do right now than update pipelines with changes to resources.
2. The resource "directory" structure is the same in each bucket. Because of this, we can define resource paths in one place and parameterize the URL schema (`gs://`, `s3://`, etc.) and the bucket name instead of having different resource modules for each cloud provider.
3. Easily select a resource bucket to use for all resources in a pipeline.

Because our resource modules export objects, my [initial idea](https://github.com/broadinstitute/gnomad_methods/issues/263#issuecomment-698397151) of adding a cloud provider parameter to Resource classes was unworkable since it would require changing the library's interface (against goal 1) or adding separate modules for each provider (against goals 2 and 3).

To meet goal 2, this changes the `path` attribute of `Resource` objects from an absolute URL to a relative (within a bucket) path and adds a `resources_root` parameter to `Resource` methods that read the resource (`TableResource.ht`, `PedigreeResource.pedigree`, etc.) and `import_resource`. This provides flexibility: users can mix and match resource buckets within a pipeline (for example, if a file in `gnomad-public` hasn't yet been copied to `gcp-public-data--gnomad`) or use resource buckets unknown to us (for example, if someone sets up a copy of `gnomad-public` in Australia). `resources_root` is optional (goal 1) and the expectation is that most users will leave it unspecified.

Setting a default behavior is not as simple as setting `"gs://gnomad-public"` as the default value for `resources_root`. This partly because our resource files are split between two buckets: `gnomad-public` and `gnomad-public-requester-pays` and partly because of goal 3: a pipeline using resources from AWS shouldn't have to pass `resources_root` every time a resource is read.

Thus, `Resource` methods call `get_resource_url` with the `Resource`'s `path` attribute, the given `resources_root`, and a new `Resource` attribute: `gnomad_bucket`. The `gnomad_bucket` attribute is necessary to distinguish resources stored in `gnomad-public` vs `gnomad-public-requester-pays`.

In turn, `get_resource_url` looks at a new setting: the "default resource provider". This controls how resource URLs are constructed when no `resources_root` is provided (which is expected to usually be the case). With this, the resource bucket to use for all resources in a pipeline can be set by changing the `default_resource_provider` attribute on `gnomad.resources.config.gnomad_resource_configuration`. And support for other cloud providers can be added by adding to the `GnomadResourceProvider` enum and updating `get_resource_url` to accordingly.

### Import paths

The `gnomad/resources/import_resources.py` script is used to convert VCF, TSV, etc. files into Hail formats. The `import_args` attribute on `Resource` is not aware of `resources_root` and thus URLs there for files in `gnomad-public` or `gnomad-public-requester-pays` are not changed. This is not likely to be a problem, since we will have limited access to the various cloud providers' buckets and thus the workflow will probably be to import resources in our own buckets and then copy from there to other buckets. Likewise, in `import_resources.py`, the `resources_root` is hard coded to `gs://gnomad-public`.

### Usage

To load resources from the Google Cloud Public Datasets bucket:

```python
from gnomad.resources.grch37 import gnomad

ds = gnomad.public_release("exomes").ht()
```

To load resources from gnomAD buckets:

```python
from gnomad.resources.grch37 import gnomad
from gnomad.resources import GnomadResourceProvider, gnomad_resource_configuration

gnomad_resource_configuration.default_resource_provider = GnomadResourceProvider.GNOMAD

ds = gnomad.public_release("exomes").ht()
```

or

```python
from gnomad.resources.grch37 import gnomad

ds = gnomad.public_release("exomes").ht(resources_root="gs://gnomad-public-requester-pays")
```