### PR TITLE
Format and fix docs build

### DIFF
--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -378,24 +378,26 @@ def make_label_combos(
     return combos
 
 
-def index_globals(globals_array, label_groups):
-    '''
+def index_globals(
+    globals_array: List[str], label_groups: Dict[str, List[str]]
+) -> Dict[str, int]:
+    """
     Create a dictionary keyed by the specified label groupings with values describing the corresponding index of each grouping entry
     in the meta_array annotation
-    :param list of str globals_aray: Ordered list containing string entries describing all the grouping combinations contained in the
+
+    :param globals_aray: Ordered list containing string entries describing all the grouping combinations contained in the
         globals_array annotation
-    :param dict label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
+    :param label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
         e.g. "sex" or "pop", and value is a list of all possible values for that grouping (e.g. ["male", "female"] or ["afr", "nfe", "amr"])
     :return: Dictionary keyed by specified label grouping combinations, with values describing the corresponding index
         of each grouping entry in the globals
-    :rtype: Dict of str: int
-    '''
+    """
     combos = make_label_combos(label_groups)
     index_dict = {}
 
     for combo in combos:
         combo_fields = combo.split("-")
-        for i,v in enumerate(globals_array):
+        for i, v in enumerate(globals_array):
             if set(v.values()) == set(combo_fields):
                 index_dict.update({f"{combo}": i})
     return index_dict

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -379,14 +379,14 @@ def make_label_combos(
 
 
 def index_globals(
-    globals_array: List[str], label_groups: Dict[str, List[str]]
+    globals_array: List[Dict[str, str]], label_groups: Dict[str, List[str]]
 ) -> Dict[str, int]:
     """
     Create a dictionary keyed by the specified label groupings with values describing the corresponding index of each grouping entry
     in the meta_array annotation
 
-    :param globals_aray: Ordered list containing string entries describing all the grouping combinations contained in the
-        globals_array annotation
+    :param globals_array: Ordered list containing dictionary entries describing all the grouping combinations contained in the globals_array annotation.
+       Keys are the grouping type (e.g., 'group', 'pop', 'sex') and values are the grouping attribute (e.g., 'adj', 'eas', 'XY').
     :param label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
         e.g. "sex" or "pop", and value is a list of all possible values for that grouping (e.g. ["male", "female"] or ["afr", "nfe", "amr"])
     :return: Dictionary keyed by specified label grouping combinations, with values describing the corresponding index


### PR DESCRIPTION
Changes in 0b6125c3c48e3f44fa433649667abe10059e7c6c broke the docs build. See https://github.com/broadinstitute/gnomad_methods/actions/runs/329380698.

This change:
* Formats with Black
* Fixes the docs build (by adding an empty line between function description and parameters)
* Replaces parameter/return types in docstring with type annotations