### PR TITLE
fix default_lift_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix for error in `compute_stratified_sample_qc` where `gt_expr` caused error [(#259)](https://github.com/broadinstitute/gnomad_methods/pull/259)
 * Add reference genome to call of `has_liftover` in `get_liftover_genome` [(#259)](https://github.com/broadinstitute/gnomad_methods/pull/259)
 * Added fix for MQ calculation in `_get_info_agg_expr`, switched `RAW_MQ` and `MQ_DP` in calculation [(#262)](https://github.com/broadinstitute/gnomad_methods/pull/262)
+* Fix for error in `default_lift_data` caused by missing `results` field in `new_locus` [(#270)](https://github.com/broadinstitute/gnomad_methods/pull/270)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/utils/liftover.py
+++ b/gnomad/utils/liftover.py
@@ -134,7 +134,7 @@ def default_lift_data(
         keep_expr = ~t.locus_fail_liftover
         t = t.filter(keep_expr) if isinstance(t, hl.Table) else t.filter_rows(keep_expr)
 
-    row_key_expr = {"locus": t.new_locus.result, "alleles": t.new_alleles}
+    row_key_expr = {"locus": t.new_locus, "alleles": t.new_alleles}
     return (
         t.key_by(**row_key_expr)
         if isinstance(t, hl.Table)


### PR DESCRIPTION
The current `default_lift_data` doesn't work since `new_locus` is set as `new_locus=lifted_over_locus.result` in `liftover_expr` as below. This PR fixes this error.

https://github.com/broadinstitute/gnomad_methods/blob/ef0fbf3b78ee675b5a94c0673fc28bf6a0960e9c/gnomad/utils/liftover.py#L95-L103
