### PR TITLE
Fix ref_allele_mismatch in liftover_expr for indel variants 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add reference genome to call of `has_liftover` in `get_liftover_genome` [(#259)](https://github.com/broadinstitute/gnomad_methods/pull/259)
 * Added fix for MQ calculation in `_get_info_agg_expr`, switched `RAW_MQ` and `MQ_DP` in calculation [(#262)](https://github.com/broadinstitute/gnomad_methods/pull/262)
 * Fix for error in `default_lift_data` caused by missing `results` field in `new_locus` [(#270)](https://github.com/broadinstitute/gnomad_methods/pull/270)
+* Fix for incorrect `ref_allele_mismatch` error in `liftover_expr` when the original reference allele has more than one bp [(#273)](https://github.com/broadinstitute/gnomad_methods/pull/273)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/utils/liftover.py
+++ b/gnomad/utils/liftover.py
@@ -98,7 +98,9 @@ def liftover_expr(
         original_locus=locus,
         original_alleles=alleles,
         locus_fail_liftover=hl.is_missing(lifted_over_locus),
-        ref_allele_mismatch=lifted_over_locus.result.sequence_context()
+        ref_allele_mismatch=lifted_over_locus.result.sequence_context(
+            after=hl.len(alleles[0]) - 1
+        )
         != lifted_over_alleles[0],
     )
 


### PR DESCRIPTION
Hi, it seems the current `ref_allele_mismatch` doesn't work when the original reference allele has more than one bp. This PR fixes the issue.

Additionally, I found there are `ref_allele_mismatch` cases where ref/alt flips between the builds. For example, [`chr3:195513874:T:C`](https://gnomad.broadinstitute.org/variant/3-195513874-T-C?dataset=gnomad_r3) (GRCh38) corresponds to [`3:195240670:C:T`](https://gnomad.broadinstitute.org/variant/rs823499?dataset=gnomad_r2_1) (GRCh37).

It is particularly confusing since it looks like `new_alleles == original_alleles` but `ref_allele_mismatch` is true. Does it make sense to add a field e.g. `ref_alt_flip`? If so, I'd be happy to make a separate PR.

```
+---------------+------------+---------------+-------------+----------------+------------------+---------------------+---------------------+
| locus         | alleles    | new_locus     | new_alleles | original_locus | original_alleles | locus_fail_liftover | ref_allele_mismatch |
+---------------+------------+---------------+-------------+----------------+------------------+---------------------+---------------------+
| locus<GRCh37> | array<str> | locus<GRCh37> | array<str>  | locus<GRCh38>  | array<str>       |                bool |                bool |
+---------------+------------+---------------+-------------+----------------+------------------+---------------------+---------------------+
| 3:195236460   | ["T","C"]  | 3:195236460   | ["T","C"]   | chr3:195509651 | ["T","C"]        |               false |                true |
| 3:195236756   | ["G","C"]  | 3:195236756   | ["G","C"]   | chr3:195509947 | ["G","C"]        |               false |                true |
| 3:195237817   | ["C","A"]  | 3:195237817   | ["C","A"]   | chr3:195511010 | ["C","A"]        |               false |                true |
| 3:195240670   | ["T","C"]  | 3:195240670   | ["T","C"]   | chr3:195513874 | ["T","C"]        |               false |                true |
| 3:195242526   | ["T","C"]  | 3:195242526   | ["T","C"]   | chr3:195515729 | ["T","C"]        |               false |                true |
| 3:195244526   | ["T","C"]  | 3:195244526   | ["T","C"]   | chr3:195517728 | ["T","C"]        |               false |                true |
| 3:195245027   | ["G","A"]  | 3:195245027   | ["G","A"]   | chr3:195518229 | ["G","A"]        |               false |                true |
| 3:195245225   | ["G","A"]  | 3:195245225   | ["G","A"]   | chr3:195518427 | ["G","A"]        |               false |                true |
| 3:195246299   | ["G","A"]  | 3:195246299   | ["G","A"]   | chr3:195519502 | ["G","A"]        |               false |                true |
| 3:195251227   | ["G","C"]  | 3:195251227   | ["G","C"]   | chr3:195524429 | ["G","C"]        |               false |                true |
+---------------+------------+---------------+-------------+----------------+------------------+---------------------+---------------------+
```
