### PR TITLE
densify_sites update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add reference genome to call of `has_liftover` in `get_liftover_genome` [(#259)](https://github.com/broadinstitute/gnomad_methods/pull/259)
 * Added fix for MQ calculation in `_get_info_agg_expr`, switched `RAW_MQ` and `MQ_DP` in calculation [(#262)](https://github.com/broadinstitute/gnomad_methods/pull/262)
 * Fix for error in `default_lift_data` caused by missing `results` field in `new_locus` [(#270)](https://github.com/broadinstitute/gnomad_methods/pull/270)
+* Update to `densify_sites`, removing assumption that last END table is keyed only by `locus` [(#279)] (https://github.com/broadinstitute/gnomad_methods/pull/279)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Add reference genome to call of `has_liftover` in `get_liftover_genome` [(#259)](https://github.com/broadinstitute/gnomad_methods/pull/259)
 * Added fix for MQ calculation in `_get_info_agg_expr`, switched `RAW_MQ` and `MQ_DP` in calculation [(#262)](https://github.com/broadinstitute/gnomad_methods/pull/262)
 * Fix for error in `default_lift_data` caused by missing `results` field in `new_locus` [(#270)](https://github.com/broadinstitute/gnomad_methods/pull/270)
-* Update to `densify_sites`, removing assumption that last END table is keyed only by `locus` [(#279)] (https://github.com/broadinstitute/gnomad_methods/pull/279)
+* Update to `compute_last_ref_block_end`, removing assumption that sparse MatrixTables are keyed only by `locus` by default [(#279)] (https://github.com/broadinstitute/gnomad_methods/pull/279)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -84,7 +84,7 @@ def densify_sites(
     """
     Creates a dense version of the input sparse MT at the sites in `sites_ht` reading the minimal amount of data required.
 
-    Note that only rows that appear both in `mt` and `sites_ht` are returned. 
+    Note that only rows that appear both in `mt` and `sites_ht` are returned.
 
     :param mt: Input sparse MT
     :param sites_ht: Desired sites to densify
@@ -92,8 +92,8 @@ def densify_sites(
     :param semi_join_rows: Whether to filter the MT rows based on semi-join (default, better if sites_ht is large) or based on filter_intervals (better if sites_ht only contains a few sites)
     :return: Dense MT filtered to the sites in `sites_ht`
     """
-    sites_ht = sites_ht.key_by("locus")
     logger.info("Computing intervals to densify from sites Table.")
+    sites_ht = sites_ht.key_by("locus")
     sites_ht = sites_ht.annotate(
         interval=hl.locus_interval(
             sites_ht.locus.contig,

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -72,7 +72,7 @@ def compute_last_ref_block_end(mt: hl.MatrixTable) -> hl.Table:
             ht.locus.position,
         )
     )
-    return ht.select_globals()
+    return ht.select_globals().key_by("locus")
 
 
 def densify_sites(
@@ -80,24 +80,19 @@ def densify_sites(
     sites_ht: hl.Table,
     last_END_positions_ht: hl.Table,
     semi_join_rows: bool = True,
-    key_by_locus: bool = False,
 ) -> hl.MatrixTable:
     """
     Creates a dense version of the input sparse MT at the sites in `sites_ht` reading the minimal amount of data required.
 
     Note that only rows that appear both in `mt` and `sites_ht` are returned. 
 
-    Assumes that `sites_ht` and `last_END_positions_ht` have the same key type.
-
     :param mt: Input sparse MT
     :param sites_ht: Desired sites to densify
     :param last_END_positions_ht: Table storing positions of the furthest ref block (END tag)
     :param semi_join_rows: Whether to filter the MT rows based on semi-join (default, better if sites_ht is large) or based on filter_intervals (better if sites_ht only contains a few sites)
-    :param key_by_locus: Whether to re-key the sites HT by locus. This assumes that the last END HT is keyed by locus. Default is False.
     :return: Dense MT filtered to the sites in `sites_ht`
     """
-    if key_by_locus:
-        sites_ht = sites_ht.key_by("locus")
+    sites_ht = sites_ht.key_by("locus")
     logger.info("Computing intervals to densify from sites Table.")
     sites_ht = sites_ht.annotate(
         interval=hl.locus_interval(

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -84,7 +84,9 @@ def densify_sites(
     """
     Creates a dense version of the input sparse MT at the sites in `sites_ht` reading the minimal amount of data required.
 
-    Note that only rows that appear both in `mt` and `sites_ht` are returned.
+    Note that only rows that appear both in `mt` and `sites_ht` are returned. 
+
+    Assumes that `sites_ht` and `last_END_positions_ht` have the same key type.
 
     :param mt: Input sparse MT
     :param sites_ht: Desired sites to densify
@@ -93,7 +95,6 @@ def densify_sites(
     :return: Dense MT filtered to the sites in `sites_ht`
     """
     logger.info("Computing intervals to densify from sites Table.")
-    sites_ht = sites_ht.key_by("locus")
     sites_ht = sites_ht.annotate(
         interval=hl.locus_interval(
             sites_ht.locus.contig,

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -80,6 +80,7 @@ def densify_sites(
     sites_ht: hl.Table,
     last_END_positions_ht: hl.Table,
     semi_join_rows: bool = True,
+    key_by_locus: bool = False,
 ) -> hl.MatrixTable:
     """
     Creates a dense version of the input sparse MT at the sites in `sites_ht` reading the minimal amount of data required.
@@ -92,8 +93,11 @@ def densify_sites(
     :param sites_ht: Desired sites to densify
     :param last_END_positions_ht: Table storing positions of the furthest ref block (END tag)
     :param semi_join_rows: Whether to filter the MT rows based on semi-join (default, better if sites_ht is large) or based on filter_intervals (better if sites_ht only contains a few sites)
+    :param key_by_locus: Whether to re-key the sites HT by locus. This assumes that the last END HT is keyed by locus. Default is False.
     :return: Dense MT filtered to the sites in `sites_ht`
     """
+    if key_by_locus:
+        sites_ht = sites_ht.key_by("locus")
     logger.info("Computing intervals to densify from sites Table.")
     sites_ht = sites_ht.annotate(
         interval=hl.locus_interval(


### PR DESCRIPTION
Sparse MTs were previously only keyed by locus by default. They are now keyed by locus and alleles by default