### PR TITLE
Add vep versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Added fix for MQ calculation in `_get_info_agg_expr`, switched `RAW_MQ` and `MQ_DP` in calculation [(#262)](https://github.com/broadinstitute/gnomad_methods/pull/262)
 * Fix for error in `default_lift_data` caused by missing `results` field in `new_locus` [(#270)](https://github.com/broadinstitute/gnomad_methods/pull/270)
 * Update to `compute_last_ref_block_end`, removing assumption that sparse MatrixTables are keyed only by `locus` by default [(#279)] (https://github.com/broadinstitute/gnomad_methods/pull/279)
+* Added VEPed context HT to resource files and included support for versioning [(#282)](https://github.com/broadinstitute/gnomad_methods/pull/282)
+* Modified `vep_or_lookup_vep` to support the use of different VEP versions [(#282)](https://github.com/broadinstitute/gnomad_methods/pull/282)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -62,6 +62,15 @@ syndip = MatrixTableResource(
 )
 
 # Versioned resources: versions should be listed from most recent to oldest
+vep_context = VersionedTableResource(
+    default_version="95",
+    versions={
+        "95": TableResource(
+            path="gs://gnomad-public-requester-pays/resources/context/grch37_context_vep_annotated.ht",
+        )
+    },
+)
+
 dbsnp = VersionedTableResource(
     default_version="20180423",
     versions={

--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -63,9 +63,9 @@ syndip = MatrixTableResource(
 
 # Versioned resources: versions should be listed from most recent to oldest
 vep_context = VersionedTableResource(
-    default_version="95",
+    default_version="85",
     versions={
-        "95": TableResource(
+        "85": TableResource(
             path="gs://gnomad-public-requester-pays/resources/context/grch37_context_vep_annotated.ht",
         )
     },

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -74,6 +74,15 @@ na12878_giab_hc_intervals = TableResource(
 )
 
 # Versioned resources: versions should be listed from most recent to oldest
+vep_context = VersionedTableResource(
+    default_version="95",
+    versions={
+        "95": TableResource(
+            path="gs://gnomad-public-requester-pays/resources/context/grch38_context_vep_annotated.ht",
+        )
+    },
+)
+
 syndip = VersionedMatrixTableResource(
     default_version="20180222",
     versions={

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -152,13 +152,14 @@ def vep_or_lookup_vep(
     :param vep_version: Version of VEPed context Table to use (if None, the default `vep_context` resource will be used)
     :return: VEPed Table
     """
-    vep_help = get_vep_help(vep_config_path)
 
     if reference is None:
         reference = hl.default_reference().name
 
     if vep_config_path is None:
         vep_config_path = VEP_CONFIG_PATH
+
+    vep_help = get_vep_help(vep_config_path)
 
     with hl.hadoop_open(vep_config_path) as vep_config_file:
         vep_config = vep_config_file.read()

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -1,7 +1,13 @@
+import logging
 from typing import Union
 
 import hail as hl
-from gnomad.resources.resource_utils import DataException
+
+from gnomad.resources.resource_utils import VersionedTableResource
+
+logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # Note that this is the current as of v81 with some included for backwards compatibility (VEP <= 75)
 CSQ_CODING_HIGH_IMPACT = [
@@ -62,17 +68,10 @@ CSQ_ORDER = (
     + CSQ_NON_CODING
 )
 
-VEP_REFERENCE_DATA = {
-    "GRCh37": {
-        "vep_config": "file:///vep_data/vep-gcloud.json",
-        "all_possible": "gs://gnomad-public-requester-pays/resources/context/grch37_context_vep_annotated.ht",
-    },
-    "GRCh38": {
-        "vep_config": "file:///vep_data/vep-gcloud.json",
-        "all_possible": "gs://gnomad-public-requester-pays/resources/context/grch38_context_vep_annotated.ht",
-    },
-}
-
+VEP_CONFIG_PATH = "file:///vep_data/vep-gcloud.json"
+"""
+Constant that contains the local path to the VEP config file
+"""
 
 VEP_CSQ_FIELDS = "Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|ALLELE_NUM|DISTANCE|STRAND|VARIANT_CLASS|MINIMISED|SYMBOL_SOURCE|HGNC_ID|CANONICAL|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|GENE_PHENO|SIFT|PolyPhen|DOMAINS|HGVS_OFFSET|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|LoF|LoF_filter|LoF_flags|LoF_info"
 """
@@ -85,23 +84,23 @@ Constant that contains description for VEP used in VCF export.
 """
 
 
-def vep_context_ht_path(ref: str = "GRCh37"):
-    if ref not in VEP_REFERENCE_DATA.keys():
-        raise DataException(
-            "Select reference as one of: {}".format(",".join(VEP_REFERENCE_DATA.keys()))
-        )
-    return VEP_REFERENCE_DATA[ref]["all_possible"]
+def vep_context_resource(ref: str = "GRCh37") -> VersionedTableResource:
+    """
+    Get VEP context resource for the genome build `ref`
+
+    :param ref: Genome build
+    :return: VEPed context resource
+    """
+    import gnomad.resources.grch37.reference_data as grch37
+    import gnomad.resources.grch38.reference_data as grch38
+
+    vep_context_res = grch37.vep_context if ref == "GRCh37" else grch38.vep_context
+    return vep_context_res
 
 
-def vep_config_path(ref: str = "GRCh37"):
-    if ref not in VEP_REFERENCE_DATA.keys():
-        raise DataException(
-            "Select reference as one of: {}".format(",".join(VEP_REFERENCE_DATA.keys()))
-        )
-    return VEP_REFERENCE_DATA[ref]["vep_config"]
-
-
-def vep_or_lookup_vep(ht, reference_vep_ht=None, reference=None, vep_config=None):
+def vep_or_lookup_vep(
+    ht, reference_vep_ht=None, reference=None, vep_config=None, vep_version=None
+):
     """
     VEP a table, or lookup variants in a reference database
 
@@ -109,10 +108,15 @@ def vep_or_lookup_vep(ht, reference_vep_ht=None, reference=None, vep_config=None
     :param reference_vep_ht: A reference database with VEP annotations (must be in top-level `vep`)
     :param reference: If reference_vep_ht is not specified, find a suitable one in reference (if None, grabs from hl.default_reference)
     :param vep_config: vep_config to pass to hl.vep (if None, a suitable one for `reference` is chosen)
+    :param vep_version: Version of VEPed context Table to use, if none is supplied the default `vep_context` resource will be used
     :return: VEPped Table
     """
     if reference is None:
         reference = hl.default_reference().name
+
+    if vep_config is None:
+        vep_config = VEP_CONFIG_PATH
+
     if reference_vep_ht is None:
 
         possible_refs = ("GRCh37", "GRCh38")
@@ -121,16 +125,25 @@ def vep_or_lookup_vep(ht, reference_vep_ht=None, reference=None, vep_config=None
                 f'vep_or_lookup_vep got {reference}. Expected one of {", ".join(possible_refs)}'
             )
 
-        reference_vep_ht = hl.read_table(vep_context_ht_path(reference))
+        reference_vep_res = vep_context_resource(reference)
+        if vep_version is None:
+            vep_version = reference_vep_res.default_version
+
+        if vep_version not in reference_vep_res.versions:
+            logger.warning(
+                f"No VEPed context Table available for genome build {reference} and VEP version {vep_version}, all variants will be VEPed"
+            )
+            return hl.vep(ht, vep_config)
+
+        logger.info(
+            f"Using VEPed context Table from genome build {reference} and VEP version {vep_version}"
+        )
+        reference_vep_ht = reference_vep_res.versions[vep_version].ht()
 
     ht = ht.annotate(vep=reference_vep_ht[ht.key].vep)
 
     vep_ht = ht.filter(hl.is_defined(ht.vep))
     revep_ht = ht.filter(hl.is_missing(ht.vep))
-
-    if vep_config is None:
-        vep_config = vep_config_path(reference)
-
     revep_ht = hl.vep(revep_ht, vep_config)
 
     return vep_ht.union(revep_ht)

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -141,6 +141,10 @@ def vep_or_lookup_vep(
     """
     VEP a table, or lookup variants in a reference database
 
+    .. warning::
+        If `reference_vep_ht` is supplied, no check is performed to confirm `reference_vep_ht` was
+        generated with the same version of VEP / VEP configuration as the VEP referenced in `vep_config_path`.
+
     :param ht: Input Table
     :param reference_vep_ht: A reference database with VEP annotations (must be in top-level `vep`)
     :param reference: If reference_vep_ht is not specified, find a suitable one in reference (if None, grabs from hl.default_reference)

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -84,7 +84,7 @@ Constant that contains description for VEP used in VCF export.
 """
 
 
-def vep_context_resource(ref: str = "GRCh37") -> VersionedTableResource:
+def get_vep_context(ref: str = "GRCh37") -> VersionedTableResource:
     """
     Get VEP context resource for the genome build `ref`
 
@@ -94,8 +94,8 @@ def vep_context_resource(ref: str = "GRCh37") -> VersionedTableResource:
     import gnomad.resources.grch37.reference_data as grch37
     import gnomad.resources.grch38.reference_data as grch38
 
-    vep_context_res = grch37.vep_context if ref == "GRCh37" else grch38.vep_context
-    return vep_context_res
+    vep_context = grch37.vep_context if ref == "GRCh37" else grch38.vep_context
+    return vep_context
 
 
 def vep_or_lookup_vep(
@@ -108,8 +108,8 @@ def vep_or_lookup_vep(
     :param reference_vep_ht: A reference database with VEP annotations (must be in top-level `vep`)
     :param reference: If reference_vep_ht is not specified, find a suitable one in reference (if None, grabs from hl.default_reference)
     :param vep_config: vep_config to pass to hl.vep (if None, a suitable one for `reference` is chosen)
-    :param vep_version: Version of VEPed context Table to use, if none is supplied the default `vep_context` resource will be used
-    :return: VEPped Table
+    :param vep_version: Version of VEPed context Table to use (if None, the default `vep_context` resource will be used)
+    :return: VEPed Table
     """
     if reference is None:
         reference = hl.default_reference().name
@@ -125,7 +125,7 @@ def vep_or_lookup_vep(
                 f'vep_or_lookup_vep got {reference}. Expected one of {", ".join(possible_refs)}'
             )
 
-        reference_vep_res = vep_context_resource(reference)
+        reference_vep_res = get_vep_context(reference)
         if vep_version is None:
             vep_version = reference_vep_res.default_version
 


### PR DESCRIPTION
Moved the VEPed context paths out of vep utils and into resources, also turning it into a versioned resource. If we add a VEPed context HT for v101 when fixed then we will need to have versioning. Also changed `vep_or_lookup_vep` to handle the versioning and if a version is not present it will warn the user that it is going to VEP everything from scratch.