### PR TITLE
Add pre-commit hook to run Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        language_version: python3
+        files: gnomad

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,24 @@
 # Contributing
 
+## Setting up a development environment
+
+- Install development dependencies.
+
+  ```
+  python3 -m pip install -r requirements-dev.txt
+  ```
+
+- Install [pre-commit](https://pre-commit.com/) hooks.
+
+  ```
+  python3 -m pre_commit install
+  ```
+
 ## Running Pylint
 
 Use [Pylint](https://www.pylint.org/) to check for some types of errors.
 
 ```
-python -m pip install -r requirements-dev.txt
 ./lint
 ```
 
@@ -20,7 +33,6 @@ To disable warnings, use:
 Use [Black](https://black.readthedocs.io/) to format code.
 
 ```
-python -m pip install -r requirements-dev.txt
 black gnomad
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 black==19.10b0
+pre-commit==2.10.1
 pylint


### PR DESCRIPTION
There are [a lot of commits that are just running Black](https://github.com/broadinstitute/gnomad_methods/search?q=black&type=commits).

To save time, this adds a [pre-commit](https://pre-commit.com/) hook that runs Black. After setting it up (`pip install -r requirements-dev.txt`, `pre-commit install`), `git commit` will automatically run Black and the commit will be cancelled if Black made any changes.