### PR TITLE
Resolve Pylint errors

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -56,6 +56,8 @@ def pop_max_expr(
     :return: Popmax struct
     """
     _pops_to_exclude = hl.literal(pops_to_exclude)
+
+    # pylint: disable=invalid-unary-operand-type
     popmax_freq_indices = hl.range(0, hl.len(freq_meta)).filter(
         lambda i: (hl.set(freq_meta[i].keys()) == {"group", "pop"})
         & (freq_meta[i]["group"] == "adj")
@@ -166,6 +168,8 @@ def faf_expr(
     _pops_to_exclude = (
         hl.literal(pops_to_exclude) if pops_to_exclude is not None else {}
     )
+
+    # pylint: disable=invalid-unary-operand-type
     faf_freq_indices = hl.range(0, hl.len(freq_meta)).filter(
         lambda i: (freq_meta[i].get("group") == "adj")
         & (

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -215,11 +215,14 @@ def plot_multi_hail_hist(
 
         hist_source = ColumnDataSource(data)
 
+        # fmt: off
+        hide_zeros_filter = BooleanFilter(
+            [top > 0 for top in hist_source.data["top"]]  # pylint: disable=unsubscriptable-object
+        )
+        # fmt: on
+
         view = (
-            CDSView(
-                source=hist_source,
-                filters=[BooleanFilter([top > 0 for top in hist_source.data["top"]])],
-            )
+            CDSView(source=hist_source, filters=[hide_zeros_filter])
             if hide_zeros
             else CDSView(source=hist_source)
         )

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -215,11 +215,8 @@ def plot_multi_hail_hist(
 
         hist_source = ColumnDataSource(data)
 
-        # fmt: off
-        hide_zeros_filter = BooleanFilter(
-            [top > 0 for top in hist_source.data["top"]]  # pylint: disable=unsubscriptable-object
-        )
-        # fmt: on
+        # pylint: disable=unsubscriptable-object
+        hide_zeros_filter = BooleanFilter([top > 0 for top in hist_source.data["top"]])
 
         view = (
             CDSView(source=hist_source, filters=[hide_zeros_filter])


### PR DESCRIPTION
On #265, Pylint threw some errors that appear to be false positives (on code that was not changed in the PR).

https://github.com/broadinstitute/gnomad_methods/pull/265/checks?check_run_id=1954044098


The `invalid-unary-operand-type` error has come up before: https://the-tgg.slack.com/archives/C0295AMDW/p1608218693011800