### PR TITLE
Use overwrite argument for importing a BlockMatrixResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Removed `prefix` parameter from  to `make_combo_header_text`, as this was only used to check if samples were from gnomAD [(#348)](https://github.com/broadinstitute/gnomad_methods/pull/348)
 * Fixed available versions for gnomAD v2 `coverage` and `liftover` resources [(#352)](https://github.com/broadinstitute/gnomad_methods/pull/352)
 * Removed side effect of accessing gnomAD v2 `coverage` and `liftover` exome resources that would edit available versions for other resources [(#352)](https://github.com/broadinstitute/gnomad_methods/pull/352)
+* Use `overwrite` argument for importing a BlockMatrixResource [(#342)](https://github.com/broadinstitute/gnomad_methods/pull/342)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -262,7 +262,9 @@ class BlockMatrixResource(BaseResource):
         :param kwargs: Any additional parameters to be passed to BlockMatrix.write
         :return: Nothing
         """
-        self.import_func(**self.import_args).write(self.path, overwrite=False, **kwargs)
+        self.import_func(**self.import_args).write(
+            self.path, overwrite=overwrite, **kwargs
+        )
 
 
 class BaseVersionedResource(BaseResource, ABC):


### PR DESCRIPTION
Currently, importing a BlockMatrixResource ignores the `overwrite` argument. This passes it through to BlockMatrix.write.

Resolves #266