### PR TITLE
Select `alleles` in default_compute_info

### DIFF
--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -485,7 +485,7 @@ def default_compute_info(
         AC=grp_ac_expr.map(lambda i: hl.int32(i.get(True, 0))),
     )
 
-    info_ht = mt.select_rows(info=info_expr).rows()
+    info_ht = mt.select_rows(mt.alleles, info=info_expr).rows()
 
     # Add AS lowqual flag
     info_ht = info_ht.annotate(


### PR DESCRIPTION
Add `alleles` explicitly in case if the matrix table is only indexed by locus (otherwise the `info_ht` doesn't get `alleles` and lines below fail).