### PR TITLE
Continue with docs build if unable to download Hail's objects.inv

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import requests
 import sphinx_autodoc_typehints
 from sphinx.ext import autosummary
 
@@ -73,10 +74,12 @@ autosummary.extract_summary = extract_summary
 
 # Configuration for sphinx.ext.intersphinx
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
-#intersphinx_mapping = {
-#    "hail": ("https://hail.is/docs/0.2", None),
-#}
+intersphinx_mapping = {}
 
+if requests.head("https://hail.is/docs/0.2/objects.inv").status_code == 200:
+    intersphinx_mapping["hail"] = ("https://hail.is/docs/0.2", None)
+else:
+    print("Unable to link to Hail docs (cannot access objects.inv)", file=sys.stderr)
 
 # sphinx_autodoc_typehints generates references with qualified names.
 # Since Hail re-exports many objects from higher level packages/modules,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 recommonmark==0.6.0
+requests
 Sphinx==2.3.1
 sphinx-autodoc-typehints==1.10.3
 sphinx-rtd-theme==0.4.3


### PR DESCRIPTION
Currently, we use [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) to link to Hail docs from references to Hail classes, functions, etc. in our docs. However, while that's a nice to have feature, it's not essential. If we can't download `objects.inv` from Hail's website for whatever reason (like if the website is temporarily down) that shouldn't block PR checks or prevent updates to our docs.

Currently, if `https://hail.is/docs/0.2/objects.inv` is unavailable, the docs build will fail. This changes the docs build to check if that file is available before configuring the intersphinx mapping for Hail. If it's not, the docs will build anyway, just without links to Hail docs.