### PR TITLE
Changed or to and in set_female_metrics_to_na

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Added function `default_generate_gene_lof_summary` to summarize gene matrix results [(#292)](https://github.com/broadinstitute/gnomad_methods/pull/292)
 * Modified `create_truth_sample_ht` to add adj annotation information in the returned Table if present in the supplied MatrixTables [(#300)](https://github.com/broadinstitute/gnomad_methods/pull/300)
 * Fix to dbSNP b154 resource (resources.grch38.reference_data) import to allow for multiple rsIDs per variant [(#345)](https://github.com/broadinstitute/gnomad_methods/pull/345)
+* Fix to `set_female_metrics_to_na` to correctly update chrY metrics to be missing [(#347)](https://github.com/broadinstitute/gnomad_methods/pull/347)
 
 ## Version 0.4.0 - July 9th, 2020
 

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -776,7 +776,7 @@ def set_female_y_metrics_to_na(
         female_metrics_dict.update(
             {
                 f"{metric}": hl.or_missing(
-                    (~t.locus.in_y_nonpar() | ~t.locus.in_y_par()), t.info[f"{metric}"],
+                    (~t.locus.in_y_nonpar() & ~t.locus.in_y_par()), t.info[f"{metric}"],
                 )
             }
         )


### PR DESCRIPTION
Function previously was not correctly setting metrics to missing on chrY (XX samples only). For example:
```
+----------+---------+
| locus         | alleles     | ac_xx_adj | y_par | y_nonpar | y_conds |
+---------------+-------------+-----------+-------+----------+---------+
| locus<GRCh38> | array<str>  |     int32 |  bool |     bool |    bool |
+---------------+-------------+-----------+-------+----------+---------+
| chrY:2786709  | ["G","T"]   |        NA | false |     true |    true |
| chrY:2786719  | ["C","A"]   |         0 | false |     true |    true |
```

- `y_par` is an annotation showing whether the locus is in a pseudoautosomal region of chromosome Y
- `y_nonpar` is an annotation showing whether the locus is in a non-pseudoautosomal region of chromosome Y
- `y_conds` is an annotation with the following condition: `(~locus.in_y_nonpar() | ~locus.in_y_par())`

`ac_xx_adj` should be NA on both lines, but you can see that on both lines, `y_conds` evaluates to True, which means [line 779](https://github.com/broadinstitute/gnomad_methods/blob/master/gnomad/utils/vcf.py#L779) will return the original value of this metric (and not missing).