### PR TITLE
Fix available releases for v2 coverage and liftover

### DIFF
--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -141,11 +141,10 @@ def coverage(data_type: str) -> VersionedTableResource:
 
     if data_type == "exomes":
         current_release = "2.1"
-        releases = EXOME_RELEASES
-        releases.remove("2.1.1")
+        releases = [r for r in EXOME_RELEASES if r != "2.1.1"]
     else:
         current_release = CURRENT_GENOME_RELEASE
-        releases = GENOME_RELEASES
+        releases = [r for r in GENOME_RELEASES if r != "2.1.1"]
 
     return VersionedTableResource(
         current_release,
@@ -168,11 +167,10 @@ def liftover(data_type: str) -> VersionedTableResource:
 
     if data_type == "exomes":
         current_release = CURRENT_EXOME_RELEASE
-        releases = EXOME_RELEASES
-        releases.remove("2.1")
+        releases = [r for r in EXOME_RELEASES if r != "2.1"]
     else:
         current_release = CURRENT_GENOME_RELEASE
-        releases = GENOME_RELEASES
+        releases = [r for r in GENOME_RELEASES if r != "2.1"]
 
     return VersionedTableResource(
         current_release,


### PR DESCRIPTION
A few issues fixed here:
1. Coverage was not recalculated for v2.1.1. That was accounted for in exome resources, but not genome.
2. Similar to 1, there was no liftover dataset created for v2.1. That was accounted for in exome resources, but not genome.
3. Using `remove` to exclude those versions from coverage/liftover resources modified the constant `EXOME_RELEASES`. Thus, after accessing exome coverage resources, v2.1.1 was not available for any other resource that used that constant. For example:

   ```
   from gnomad.resources.grch37 import gnomad
   gnomad.coverage("exomes").ht()
   gnomad.public_release("exomes").ht()
   ```
   currently throws `KeyError: 'default_version 2.1.1 not found in versions dictionary passed to VersionedTableResource.'`
   
   This changes the `coverage` and `liftover` functions to create new lists of versions instead of modifying constants.
