### PR TITLE
Simplify workflow for updating docs site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
         run: ./docs/build.sh
       - name: Publish to GitHub Pages
         if: github.event_name == 'push'
-        env:
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         run: |
           # Create empty gh-pages branch
           git checkout --orphan gh-pages
@@ -80,17 +78,7 @@ jobs:
           git add .
           git commit --allow-empty -m "Update docs"
 
-          mkdir -p $HOME/.ssh
-          echo "${DEPLOY_KEY}" > $HOME/.ssh/id_rsa
-          chmod 600 $HOME/.ssh/id_rsa
-          ssh-keyscan github.com >> $HOME/.ssh/known_hosts
-
-          git remote rm origin
-          git remote add origin git@github.com:${GITHUB_REPOSITORY}.git
-
           git push --force origin gh-pages
-
-          rm $HOME/.ssh/id_rsa
 
           # Restore the original working tree by checking out the
           # commit that triggered the workflow.


### PR DESCRIPTION
When a commit is made to the default branch, a [GitHub Actions](https://docs.github.com/en/actions) workflow builds the docs site and pushes the site content to the `gh-pages` branch, where it is then picked up by [GitHub Pages](https://docs.github.com/en/pages).

Currently, we use an SSH key stored in repository [secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) together with a [deploy key](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys) to authenticate the workflow's push to that branch. However, workflows include an [access token](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) for the current repository and the [checkout action](https://github.com/actions/checkout) configures git to use that token for authentication. Thus, there's no need for our workflow to reconfigure authentication.