### PR TITLE
Added readviz utils

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -975,18 +975,3 @@ def hemi_expr(
         # mt.GT[0] is alternate allele
         gt.is_haploid() & (sex_expr == male_str) & (gt[0] == 1),
     )
-
-
-def readviz_struct_expr(
-    s: hl.expr.StringExpression, gq: hl.expr.Int32Expression
-) -> hl.expr.StructExpression:
-    """
-    Extract sample ID and genotype quality from input MatrixTable.
-
-    Part of pipeline creating readviz input.
-
-    :param s: Input StringExpression containing sample ID.
-    :param gq: Input Int32Expression containing sample genotype quality.
-    :return: StructExpression of sample ID (s) and genotype quality (GQ).
-    """
-    return hl.struct(s=s, GQ=gq)

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -950,3 +950,43 @@ def unphase_call_expr(call_expr: hl.expr.CallExpression) -> hl.expr.CallExpressi
         .when(call_expr.is_haploid(), hl.call(call_expr[0], phased=False))
         .default(hl.null(hl.tcall))
     )
+
+
+def hemi_expr(
+    locus: hl.expr.LocusExpression,
+    sex_expr: hl.expr.StringExpression,
+    gt: hl.expr.CallExpression,
+    male_str: str = "XY",
+) -> hl.expr.BooleanExpression:
+    """
+    Return whether genotypes are hemizygous.
+
+    Return missing expression if locus is not in chrX/chrY non-PAR regions.
+
+    :param locus: Input locus.
+    :param sex_expr: Input StringExpression indicating whether sample is XX or XY.
+    :param gt: Input genotype.
+    :param xy_str: String indicating whether sample is XY. Default is "XY".
+    :return: BooleanExpression indicating whether genotypes are hemizygous.
+    """
+    return hl.or_missing(
+        locus.in_x_nonpar() | locus.in_y_nonpar(),
+        # Haploid genotypes have a single integer, so checking if
+        # mt.GT[0] is alternate allele
+        gt.is_haploid() & (sex_expr == male_str) & (gt[0] == 1),
+    )
+
+
+def readviz_struct_expr(
+    s: hl.expr.StringExpression, gq: hl.expr.Int32Expression
+) -> hl.expr.StructExpression:
+    """
+    Extract sample ID and genotype quality from input MatrixTable.
+
+    Part of pipeline creating readviz input.
+
+    :param s: Input StringExpression containing sample ID.
+    :param gq: Input Int32Expression containing sample genotype quality.
+    :return: StructExpression of sample ID (s) and genotype quality (GQ).
+    """
+    return hl.struct(s=s, GQ=gq)


### PR DESCRIPTION
Added two functions from https://github.com/broadinstitute/gnomad-readviz/blob/master/step1__select_samples.py:
`het_hom_hemi_take_expr` (renamed `readviz_struct_expr`) and `hemi_expr`