### PR TITLE
Make versioned resources work with subclasses of resource types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added function `set_female_y_metrics_to_na_expr` to set Y-variant frequency callstats for female-specific metrics to missing [(#349)](https://github.com/broadinstitute/gnomad_methods/pull/349/files)
 * Added function `make_faf_index_dict` to create a look-up Dictionary for entries contained in the filter allele frequency annotation array [(#349)](https://github.com/broadinstitute/gnomad_methods/pull/349/files)
 * Added function `make_freq_index_dict` to create a look-up Dictionary for entries contained in the frequency annotation array [(#349)](https://github.com/broadinstitute/gnomad_methods/pull/349/files)
+* VersionedResource objects are no longer subclasses of BaseResource [(#359)](https://github.com/broadinstitute/gnomad_methods/pull/359)
 
 ## Version 0.5.0 - April 22nd, 2021
 

--- a/gnomad/resources/import_resources.py
+++ b/gnomad/resources/import_resources.py
@@ -34,16 +34,18 @@ def get_module_importable_resources(
     """
     _prefix = f"{prefix}." if prefix else ""
     resources = {}
-    for resource_name, resource in getmembers(
-        module, lambda x: isinstance(x, BaseResource)
-    ):
-        if resource.path and resource.import_func:
-            arg_name = f"{_prefix}{resource_name}"
-            if isinstance(resource, BaseVersionedResource):
-                for version in resource.versions:
-                    arg_name += f".{version}"
-                    resource_name = f"{resource_name} version {version}"
-            resources[arg_name] = (resource_name, resource)
+    for name, obj in getmembers(module):
+        if isinstance(obj, BaseResource) and obj.path and obj.import_func:
+            resources[f"{_prefix}{name}"] = (name, obj)
+
+        if isinstance(obj, BaseVersionedResource):
+            for version_name, version_resource in obj.versions.items():
+                if version_resource.path and version_resource.import_func:
+                    resources[f"{_prefix}{name}.{version_name}"] = (
+                        f"{name}.{version_name}",
+                        version_resource,
+                    )
+
     return resources
 
 

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -236,46 +236,54 @@ class BlockMatrixResource(BaseResource):
         )
 
 
-class BaseVersionedResource(BaseResource, ABC):
+class BaseVersionedResource:
     """
-    Abstract class for a versioned resource.
+    Class for a versioned resource.
 
-    The `path`/`import_args` attributes of the versioned resource are those of the default version of the resource.
+    The attributes and methods of the versioned resource are those of the default version of the resource.
     In addition, all versions of the resource are stored in the `versions` attribute.
 
-    :param default_version: The default version of this resource (must to be in the `versions` dict)
+    :param default_version: The default version of this resource (must be in the `versions` dict)
     :param versions: A dict of version name -> resource.
     """
 
+    resource_class = BaseResource
+
+    __slots__ = ["default_version", "versions"]
+
     def __init__(self, default_version: str, versions: Dict[str, BaseResource]):
-        if type(self) is BaseVersionedResource:
-            raise TypeError("Can't instantiate abstract class BaseVersionedResource")
+        default_resource = versions[default_version]
 
-        if default_version not in versions:
-            raise KeyError(
-                f"default_version {default_version} not found in versions dictionary passed to {self.__class__.__name__}."
-            )
-
-        for version_name, version_resource in versions.items():
-            if version_resource.__class__ not in self.__class__.__bases__:
+        for version_resource in versions.values():
+            if not isinstance(version_resource, self.resource_class):
                 raise TypeError(
-                    f"Cannot create a {self.__class__.__name__} resource with version {version_name} of type {version_resource.__class__.__name__}"
+                    f"{self.__class.__name__} requires all versions to be of type {self.resource_class.__name__}"
+                )
+
+            if version_resource.__class__ is not default_resource.__class__:
+                raise TypeError(
+                    f"{self.__class.__name__} requires all versions to be of the same type"
                 )
 
         self.default_version = default_version
         self.versions = versions
 
-        super().__init__(
-            path=versions[default_version].path,
-            import_args=versions[default_version].import_args,
-            import_func=versions[default_version].import_func,
+    def __repr__(self):
+        return "{cls}(default_version={default_version}, versions={{{versions}}})".format(
+            cls=self.__class.__name__,
+            default_version=self.default_version,
+            versions=", ".join(f'"{k}": {repr(v)}' for k, v in self.versions.items()),
         )
 
-    def __repr__(self):
-        return f"{self.__class__.__name__}(default_version={self.default_version}, default_resource={self.versions[self.default_version]}, versions={list(self.versions.keys())})"
+    def __getattr__(self, name):
+        # If __getattr__ is called for 'default_version', 'version', etc. then something has gone wrong.
+        if name in self.__slots__:
+            raise ValueError("VersionedResource has not been initialized")
+
+        return getattr(self.versions[self.default_version], name)
 
 
-class VersionedTableResource(BaseVersionedResource, TableResource):
+class VersionedTableResource(BaseVersionedResource):
     """
     Versioned Table resource.
 
@@ -286,11 +294,13 @@ class VersionedTableResource(BaseVersionedResource, TableResource):
     :param versions: A dict of version name -> TableResource.
     """
 
+    resource_class = TableResource
+
     def __init__(self, default_version: str, versions: Dict[str, TableResource]):
         super().__init__(default_version, versions)
 
 
-class VersionedMatrixTableResource(BaseVersionedResource, MatrixTableResource):
+class VersionedMatrixTableResource(BaseVersionedResource):
     """
     Versioned MatrixTable resource.
 
@@ -300,6 +310,8 @@ class VersionedMatrixTableResource(BaseVersionedResource, MatrixTableResource):
     :param default_version: The default version of this MatrixTable resource (must to be in the `versions` dict)
     :param versions: A dict of version name -> MatrixTableResource.
     """
+
+    resource_class = MatrixTableResource
 
     def __init__(self, default_version: str, versions: Dict[str, MatrixTableResource]):
         super().__init__(default_version, versions)
@@ -316,11 +328,10 @@ class VersionedPedigreeResource(BaseVersionedResource, PedigreeResource):
     :param versions: A dict of version name -> PedigreeResource.
     """
 
+    resource_class = PedigreeResource
+
     def __init__(self, default_version: str, versions: Dict[str, PedigreeResource]):
         super().__init__(default_version, versions)
-        self.delimiter = versions[default_version].delimiter
-        self.missing = versions[default_version].missing
-        self.quant_pheno = versions[default_version].quant_pheno
 
 
 class VersionedBlockMatrixResource(BaseVersionedResource, BlockMatrixResource):
@@ -333,6 +344,8 @@ class VersionedBlockMatrixResource(BaseVersionedResource, BlockMatrixResource):
     :param default_version: The default version of this BlockMatrix resource (must to be in the `versions` dict)
     :param versions: A dict of version name -> BlockMatrixResource.
     """
+
+    resource_class = BlockMatrixResource
 
     def __init__(self, default_version: str, versions: Dict[str, BlockMatrixResource]):
         super().__init__(default_version, versions)

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -249,7 +249,7 @@ class BaseVersionedResource:
 
     resource_class = BaseResource
 
-    __slots__ = ["default_version", "versions"]
+    __slots__ = {"default_version", "versions"}
 
     def __init__(self, default_version: str, versions: Dict[str, BaseResource]):
         default_resource = versions[default_version]

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -257,12 +257,12 @@ class BaseVersionedResource:
         for version_resource in versions.values():
             if not isinstance(version_resource, self.resource_class):
                 raise TypeError(
-                    f"{self.__class.__name__} requires all versions to be of type {self.resource_class.__name__}"
+                    f"{self.__class__.__name__} requires all versions to be of type {self.resource_class.__name__}"
                 )
 
             if version_resource.__class__ is not default_resource.__class__:
                 raise TypeError(
-                    f"{self.__class.__name__} requires all versions to be of the same type"
+                    f"{self.__class__.__name__} requires all versions to be of the same type"
                 )
 
         self.default_version = default_version
@@ -270,7 +270,7 @@ class BaseVersionedResource:
 
     def __repr__(self):
         return "{cls}(default_version={default_version}, versions={{{versions}}})".format(
-            cls=self.__class.__name__,
+            cls=self.__class__.__name__,
             default_version=self.default_version,
             versions=", ".join(f'"{k}": {repr(v)}' for k, v in self.versions.items()),
         )


### PR DESCRIPTION
The motivation here is to be able to do this:

```
class MyTableResource(TableResource):
    def ht(self):
        ...

resource = VersionedTableResource(
    "latest",
    {
        "latest": MyTableResource(...),
        ...
    }
)
```

Currently, versioned resources require that the class of every version matches one of the base classes of the versioned resource.
https://github.com/broadinstitute/gnomad_methods/blob/763aae935e0de8046a4025f70033b8a1a4e091ed/gnomad/resources/resource_utils.py#L291

Also, accessing an attribute or calling a method on a versioned resource object is effectively the same as accessing the same attribute or calling the same method on the resource object for the default version. Currently, the way this is done is the versioned resource object copies/references all attributes from the resource object for the default version and implements methods itself (by subclassing a resource type).

https://github.com/broadinstitute/gnomad_methods/blob/763aae935e0de8046a4025f70033b8a1a4e091ed/gnomad/resources/resource_utils.py#L299-L303

This means that, currently, using a subclass of one of the resource classes also requires a matching subclass of `BaseVersionedResource`:
```
class MyTableResource(TableResource):
    def ht(self):
        ...

class VersionedMyTableResource(BaseVersionedResource, MyTableResource):
    pass

resource = VersionedMyTableResource(
    "latest",
    {
        "latest": MyTableResource(...),
        ...
    }
)
```

With this change, versioned resource objects instead use `__getattr__` to proxy attribute access to the resource object for the default version. So calling `ht` on `versioned_table_resource` calls `ht` on `versioned_table_resource.versions[versioned_table_resource.default_version]`. This removes the requirement that the type of each version's resource object has to match the base type of the versioned resource object.

This could potentially break some code. Since versioned resource objects no longer subclass the resource types, `isinstance(versioned_table_resource, TableResource)` will now return False where it previously returned True. So far as I know, the only place that relied on this in either this repository or gnomad_qc was the `import_resources.py` script.

---

This also fixes a bug in `import_resources.py`. Currently, it adds versioned resource objects to the list of importable resources and does not add the resource objects for every version. This makes it so that only the default version can be imported and the argument to import that version is correct.

This can be seen by running `python import_resources.py --help`. Currently, it shows:
```
grch38.dbsnp.b154.b151:
    import gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_GCF_000001405.38_20200514.vcf.bgz
    to gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_20200514.ht
``` 
vs with this change:
```
grch38.dbsnp.b154:
    import gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_GCF_000001405.38_20200514.vcf.bgz
    to gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_20200514.ht

grch38.dbsnp.b151:
    import gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.vcf.bgz
    to gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.ht
```