### PR TITLE
Fix default version for GRCh37 genome coverage resource

### DIFF
--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -143,7 +143,7 @@ def coverage(data_type: str) -> VersionedTableResource:
         current_release = "2.1"
         releases = [r for r in EXOME_RELEASES if r != "2.1.1"]
     else:
-        current_release = CURRENT_GENOME_RELEASE
+        current_release = "2.1"
         releases = [r for r in GENOME_RELEASES if r != "2.1.1"]
 
     return VersionedTableResource(


### PR DESCRIPTION
The default version for gnomAD genome coverage on GRCh37 is set to the current gnomAD release (v2.1.1). However, there is no coverage for v2.1.1 and currently attempting to get that resource throws an error:

```python
from gnomad.resources.grch37 import gnomad
r = gnomad.coverage("genomes")
# KeyError: 'default_version 2.1.1 not found in versions dictionary passed to VersionedTableResource.'
```

This changes the default version for that resource to v2.1.