### PR TITLE
Fix paths to resources for v3.1+ releases

### DIFF
--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -282,4 +282,5 @@ def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     :return: Path to VCF
     """
     contig = f".{contig}" if contig else ""
-    return f"gs://gnomad-public/release/{version}/vcf/{data_type}/gnomad.{data_type}.r{version}.sites{contig}.vcf.bgz"
+    version_prefix = "r" if version.startswith("3.0") else "v"
+    return f"gs://gnomad-public/release/{version}/vcf/{data_type}/gnomad.{data_type}.{version_prefix}{version}.sites{contig}.vcf.bgz"

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -168,7 +168,8 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh38
     :return: Path to release Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
+    version_prefix = "r" if version.startswith("3.0") else "v"
+    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.{version_prefix}{version}.sites.ht"
 
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
@@ -179,7 +180,8 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh38
     :return: path to coverage Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
+    version_prefix = "r" if version.startswith("3.0") else "v"
+    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.{version_prefix}{version}.coverage.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:


### PR DESCRIPTION
Starting with gnomAD v3.1, we moved from naming release Hail tables `gnomad.{exomes|genomes}.r{version}.sites.ht` to `gnomad.{exomes|genomes}.v{version}.sites.ht`. However, the public release and coverage resources still assume the old convention.

Resolves #350