### PR TITLE
Fixes to docstring formatting

### DIFF
--- a/docs/copy_changelog.py
+++ b/docs/copy_changelog.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-"""
-Copy CHANGELOG.md from repository root and remove "Unreleased" section.
-"""
+"""Copy CHANGELOG.md from repository root and remove "Unreleased" section."""
 
 import os
 

--- a/docs/directives.py
+++ b/docs/directives.py
@@ -1,6 +1,4 @@
-"""
-Sphinx helpers for documentation.
-"""
+"""Sphinx helpers for documentation."""
 
 import importlib
 import symtable

--- a/docs/generate_api_reference.py
+++ b/docs/generate_api_reference.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-"""
-Generate API reference documentation for a package.
-"""
+"""Generate API reference documentation for a package."""
 
 import importlib
 import os
@@ -25,9 +23,7 @@ EXCLUDE_PACKAGES = ["tests"]
 
 
 def module_doc_path(module):
-    """
-    Get the path for a module's documentation file.
-    """
+    """Get the path for a module's documentation file."""
     return os.path.join(
         DOCS_DIRECTORY,
         "api_reference",
@@ -36,9 +32,7 @@ def module_doc_path(module):
 
 
 def package_doc_path(package):
-    """
-    Get the path for a package's documentation file.
-    """
+    """Get the path for a package's documentation file."""
     return os.path.join(
         DOCS_DIRECTORY,
         "api_reference",
@@ -48,9 +42,7 @@ def package_doc_path(package):
 
 
 def write_file(path, contents):
-    """
-    Write a file after ensuring that the target directory exists.
-    """
+    """Write a file after ensuring that the target directory exists."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as out:
         out.write(contents)
@@ -77,9 +69,7 @@ MODULE_DOC_TEMPLATE = """{title}
 
 
 def write_module_doc(module_name):
-    """
-    Write API reference documentation file for a module.
-    """
+    """Write API reference documentation file for a module."""
     module = importlib.import_module(module_name)
 
     doc = MODULE_DOC_TEMPLATE.format(
@@ -104,9 +94,7 @@ PACKAGE_DOC_TEMPLATE = """{title}
 
 
 def write_package_doc(package_name):
-    """
-    Write API reference documentation file for a package.
-    """
+    """Write API reference documentation file for a package."""
     package = importlib.import_module(package_name)
 
     module_links = []

--- a/gnomad/assessment/sanity_checks.py
+++ b/gnomad/assessment/sanity_checks.py
@@ -110,8 +110,9 @@ def sample_sum_check(
     sort_order: List[str] = SORT_ORDER,
 ) -> None:
     """
-    Compute afresh the sum of annotations for a specified group of annotations, and compare to the annotated version;
-    display results from checking the sum of the specified annotations in the terminal.
+    Compute the sum of annotations for a specified group of annotations, and compare to the annotated version.
+
+    Results from from checking the sum of the specified annotations are printed in the terminal.
 
     :param ht: Table containing annotations to be summed.
     :param prefix: String indicating sample subset.

--- a/gnomad/assessment/sanity_checks.py
+++ b/gnomad/assessment/sanity_checks.py
@@ -112,7 +112,7 @@ def sample_sum_check(
     """
     Compute the sum of annotations for a specified group of annotations, and compare to the annotated version.
 
-    Results from from checking the sum of the specified annotations are printed in the terminal.
+    Results from checking the sum of the specified annotations are printed in the terminal.
 
     :param ht: Table containing annotations to be summed.
     :param prefix: String indicating sample subset.

--- a/gnomad/assessment/summary_stats.py
+++ b/gnomad/assessment/summary_stats.py
@@ -22,16 +22,17 @@ def freq_bin_expr(
     freq_expr: hl.expr.ArrayExpression, index: int = 0
 ) -> hl.expr.StringExpression:
     """
-	Returns frequency string annotations based on input AC or AF.
+    Return frequency string annotations based on input AC or AF.
 
     .. note::
+
         - Default index is 0 because function assumes freq_expr was calculated with `annotate_freq`.
         - Frequency index 0 from `annotate_freq` is frequency for all pops calculated on adj genotypes only.
 
-	:param freq_expr: Array of structs containing frequency information.
-	:param index: Which index of freq_expr to use for annotation. Default is 0. 
-	:return: StringExpression containing bin name based on input AC or AF.
-	"""
+    :param freq_expr: Array of structs containing frequency information.
+    :param index: Which index of freq_expr to use for annotation. Default is 0.
+    :return: StringExpression containing bin name based on input AC or AF.
+    """
     return (
         hl.case(missing_false=True)
         .when(freq_expr[index].AC == 0, "Not found")
@@ -56,7 +57,7 @@ def get_summary_counts_dict(
     prefix_str: str = "",
 ) -> Dict[str, hl.expr.Int64Expression]:
     """
-    Returns dictionary containing containing counts of multiple variant categories.
+    Return dictionary containing containing counts of multiple variant categories.
 
     Categories are:
         - Number of variants
@@ -71,8 +72,8 @@ def get_summary_counts_dict(
         - Number of synonymous variants
         - Number of autosomal variants
         - Number of allosomal variants
-        
-    .. warning:: 
+
+    .. warning::
         Assumes `allele_expr` contains only two variants (multi-allelics have been split).
 
     :param locus_expr: LocusExpression.
@@ -121,7 +122,7 @@ def get_summary_ac_dict(
     most_severe_csq_expr: hl.expr.StringExpression,
 ) -> Dict[str, hl.expr.Int64Expression]:
     """
-    Returns dictionary containing containing total allele counts for variant categories.
+    Return dictionary containing containing total allele counts for variant categories.
 
     Categories are:
         - All variants
@@ -133,7 +134,7 @@ def get_summary_ac_dict(
         - Missense variants
         - Synonymous variants
 
-    .. warning:: 
+    .. warning::
         Assumes `allele_expr` contains only two variants (multi-allelics have been split).
 
     :param allele_expr: ArrayExpression containing alleles.
@@ -168,7 +169,7 @@ def get_summary_counts(
     index: int = 0,
 ) -> hl.Table:
     """
-	Generates a struct with summary counts across variant categories.
+    Generate a struct with summary counts across variant categories.
 
     Summary counts:
         - Number of variants
@@ -185,7 +186,7 @@ def get_summary_counts(
     Before calculating summary counts, function:
         - Filters out low confidence regions
         - Filters to canonical transcripts
-        - Uses the most severe consequence 
+        - Uses the most severe consequence
 
     Assumes that:
         - Input HT is annotated with VEP.
@@ -197,9 +198,9 @@ def get_summary_counts(
     :param freq_field: Name of field in HT containing frequency annotation (array of structs). Default is "freq".
     :param filter_field: Name of field in HT containing variant filter information. Default is "filters".
     :param filter_decoy: Whether to filter decoy regions. Default is False.
-    :param index: Which index of freq_expr to use for annotation. Default is 0. 
-    :return: Table grouped by frequency bin and aggregated across summary count categories. 
-	"""
+    :param index: Which index of freq_expr to use for annotation. Default is 0.
+    :return: Table grouped by frequency bin and aggregated across summary count categories.
+    """
     logger.info("Checking if multi-allelic variants have been split...")
     max_alleles = ht.aggregate(hl.agg.max(hl.len(ht.alleles)))
     if max_alleles > 2:
@@ -263,7 +264,7 @@ def get_an_criteria(
     an_proportion_cutoff: float = 0.8,
 ) -> hl.expr.BooleanExpression:
     """
-    Generates criteria to filter samples based on allele number (AN).
+    Generate criteria to filter samples based on allele number (AN).
 
     Uses allele number as proxy for call rate.
 
@@ -310,7 +311,7 @@ def get_tx_expression_expr(
     tx_struct: str = "tx_annotation",
 ) -> hl.expr.Float64Expression:
     """
-    Pulls appropriate transcript expression annotation struct given a specific locus and alleles (provided in `key_expr`).
+    Pull appropriate transcript expression annotation struct given a specific locus and alleles (provided in `key_expr`).
 
     Assumes that `key_expr` contains a locus and alleles.
     Assumes that multi-allelic variants have been split in both `tx_ht` and `key_expr`.
@@ -347,7 +348,7 @@ def default_generate_gene_lof_matrix(
     remove_ultra_common: bool = False,
 ) -> hl.MatrixTable:
     """
-    Generates loss-of-function gene matrix.
+    Generate loss-of-function gene matrix.
 
     Used to generate summary metrics on LoF variants.
 
@@ -472,7 +473,7 @@ def get_het_hom_summary_dict(
     pop_expr: hl.expr.StringExpression,
 ) -> Dict[str, hl.expr.Int64Expression]:
     """
-    Generates dictionary containing summary counts. 
+    Generate dictionary containing summary counts.
 
     Summary counts are:
         - Number of sites with defined genotype calls
@@ -534,9 +535,9 @@ def default_generate_gene_lof_summary(
     filter_loftee: bool = False,
 ) -> hl.Table:
     """
-    Generates summary counts for loss-of-function (LoF), missense, and synonymous variants.
+    Generate summary counts for loss-of-function (LoF), missense, and synonymous variants.
 
-    Also calculates p, proportion of of haplotypes carrying a putative LoF (pLoF) variant, 
+    Also calculates p, proportion of of haplotypes carrying a putative LoF (pLoF) variant,
     and observed/expected (OE) ratio of samples with homozygous pLoF variant calls.
 
     Summary counts are (all per gene):
@@ -559,7 +560,7 @@ def default_generate_gene_lof_summary(
     :param lof_csq_set: Set containing LoF transcript consequence strings. Default is LOF_CSQ_SET.
     :param meta_root: String indicating top level name for sample metadata. Default is 'meta'.
     :param pop_field: String indiciating field with sample population assignment information. Default is 'pop'.
-    :param filter_loftee: Filters to LOFTEE pass variants (and no LoF flags) only. Default is False. 
+    :param filter_loftee: Filters to LOFTEE pass variants (and no LoF flags) only. Default is False.
     :return: Table with het/hom summary counts.
     """
     if collapse_indels:

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -60,7 +60,7 @@ POP_NAMES = {
 
 def _public_release_ht_path(data_type: str, version: str) -> str:
     """
-    Get public release table path
+    Get public release table path.
 
     :param data_type: One of "exomes" or "genomes"
     :param version: One of the release versions of gnomAD on GRCh37
@@ -71,7 +71,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
     """
-    Get public coverage hail table
+    Get public coverage hail table.
 
     :param data_type: One of "exomes" or "genomes"
     :param version: One of the release versions of gnomAD on GRCh37
@@ -82,7 +82,7 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
 
 def _public_pca_ht_path(subpop: str) -> str:
     """
-    Get public pca loadings path
+    Get public pca loadings path.
 
     :param subpop: Can be empty ("") -> global, "eas" or "nfe"
     :return: Path to release Table
@@ -93,7 +93,7 @@ def _public_pca_ht_path(subpop: str) -> str:
 
 def _liftover_data_path(data_type: str, version: str) -> str:
     """
-    Paths to liftover gnomAD Table
+    Paths to liftover gnomAD Table.
 
     :param data_type: One of `exomes` or `genomes`
     :param version: One of the release versions of gnomAD on GRCh37
@@ -104,12 +104,11 @@ def _liftover_data_path(data_type: str, version: str) -> str:
 
 def public_release(data_type: str) -> VersionedTableResource:
     """
-    Retrieves publicly released versioned table resource
+    Retrieve publicly released versioned table resource.
 
     :param data_type: One of "exomes" or "genomes"
     :return: Release Table
     """
-
     if data_type not in DATA_TYPES:
         raise DataException(f"{data_type} not in {DATA_TYPES}")
 
@@ -131,7 +130,7 @@ def public_release(data_type: str) -> VersionedTableResource:
 
 def coverage(data_type: str) -> VersionedTableResource:
     """
-    Retrieves gnomAD's coverage table by data_type
+    Retrieve gnomAD's coverage table by data_type.
 
     :param data_type: One of "exomes" or "genomes"
     :return: Coverage Table
@@ -157,7 +156,7 @@ def coverage(data_type: str) -> VersionedTableResource:
 
 def liftover(data_type: str) -> VersionedTableResource:
     """
-    Get the 38 liftover of gnomad v2.1.1
+    Get the 38 liftover of gnomad v2.1.1.
 
     :param data_type: One of "exomes" or "genomes"
     :return: Release Table
@@ -183,7 +182,7 @@ def liftover(data_type: str) -> VersionedTableResource:
 
 def public_pca_loadings(subpop: str = "") -> TableResource:
     """
-    Returns the TableResource containing sites and loadings from population PCA
+    Return the TableResource containing sites and loadings from population PCA.
 
     :param subpop: Can be empty ("") -> global, "eas" or "nfe"
     :return: gnomAD public PCA loadings TableResource
@@ -198,8 +197,7 @@ def public_pca_loadings(subpop: str = "") -> TableResource:
 
 def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     """
-    Publically released VCF. Provide specific contig, i.e. "20", to retrieve contig
-    specific VCF
+    Publically released VCF. Provide specific contig, i.e. "20", to retrieve contig specific VCF.
 
     :param data_type: One of "exomes" or "genomes"
     :param version: One of the release versions of gnomAD on GRCh37

--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -258,15 +258,16 @@ syndip_hc_intervals = TableResource(
 
 def get_truth_ht() -> hl.Table:
     """
-    Returns a table with the following annotations from the latest version of the corresponding truth data:
-    - hapmap
-    - kgp_omni (1000 Genomes intersection Onni 2.5M array)
-    - kgp_phase_1_hc (high confidence sites in 1000 genonmes)
-    - mills (Mills & Devine indels)
+    Return a table with annotations from the latest version of the corresponding truth data.
+
+    The following annotations are included:
+        - hapmap
+        - kgp_omni (1000 Genomes intersection Onni 2.5M array)
+        - kgp_phase_1_hc (high confidence sites in 1000 genonmes)
+        - mills (Mills & Devine indels)
 
     :return: A table with the latest version of popular truth data annotations
     """
-
     return (
         hapmap.ht()
         .select(hapmap=True)

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -162,7 +162,7 @@ na12878 = VersionedMatrixTableResource(
 
 def _public_release_ht_path(data_type: str, version: str) -> str:
     """
-    Get public release table path
+    Get public release table path.
 
     :param data_type: One of "exomes" or "genomes"
     :param version: One of the release versions of gnomAD on GRCh38
@@ -174,7 +174,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
     """
-    Get public coverage hail table
+    Get public coverage hail table.
 
     :param data_type: One of "exomes" or "genomes"
     :param version: One of the release versions of gnomAD on GRCh38
@@ -186,12 +186,11 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
 
 def public_release(data_type: str) -> VersionedTableResource:
     """
-    Retrieves publicly released versioned table resource
+    Retrieve publicly released versioned table resource.
 
     :param data_type: One of "exomes" or "genomes"
     :return: Release Table
     """
-
     if data_type not in DATA_TYPES:
         raise DataException(
             f"{data_type} not in {DATA_TYPES}, please select a data type from {DATA_TYPES}"
@@ -215,7 +214,7 @@ def public_release(data_type: str) -> VersionedTableResource:
 
 def coverage(data_type: str) -> VersionedTableResource:
     """
-    Retrieves gnomAD's coverage table by data_type
+    Retrieve gnomAD's coverage table by data_type.
 
     :param data_type: One of "exomes" or "genomes"
     :return: Coverage Table
@@ -243,7 +242,7 @@ def coverage(data_type: str) -> VersionedTableResource:
 
 def coverage_tsv_path(data_type: str, version: Optional[str] = None) -> str:
     """
-    Retrieves gnomAD's coverage table by data_type
+    Retrieve gnomAD's coverage table by data_type.
 
     :param data_type: One of "exomes" or "genomes"
     :return: Coverage Table
@@ -273,8 +272,7 @@ def coverage_tsv_path(data_type: str, version: Optional[str] = None) -> str:
 
 def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     """
-    Publically released VCF. Provide specific contig, i.e. "chr20", to retrieve contig
-    specific VCF
+    Publically released VCF. Provide specific contig, i.e. "chr20", to retrieve contig specific VCF.
 
     :param data_type: One of "exomes" or "genomes"
     :param version: One of the release versions of gnomAD on GRCh37

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -253,15 +253,16 @@ telomeres_and_centromeres = TableResource(
 
 def get_truth_ht() -> Table:
     """
-    Returns a table with the following annotations from the latest version of the corresponding truth data:
-    - hapmap
-    - kgp_omni (1000 Genomes intersection Onni 2.5M array)
-    - kgp_phase_1_hc (high confidence sites in 1000 genonmes)
-    - mills (Mills & Devine indels)
+    Return a table with annotations from the latest version of the corresponding truth data.
+
+    The following annotations are included:
+        - hapmap
+        - kgp_omni (1000 Genomes intersection Onni 2.5M array)
+        - kgp_phase_1_hc (high confidence sites in 1000 genonmes)
+        - mills (Mills & Devine indels)
 
     :return: A table with the latest version of popular truth data annotations
     """
-
     return (
         hapmap.ht()
         .select(hapmap=True)

--- a/gnomad/resources/import_resources.py
+++ b/gnomad/resources/import_resources.py
@@ -13,21 +13,22 @@ def get_module_importable_resources(
     module, prefix: Optional[str] = None
 ) -> Dict[str, Tuple[str, BaseResource]]:
     """
-    This takes a module that was imported and generates a list of all resources in this module that can be imported (i.e. with a path and import_func).
-    The dict produced is as follows:
-    keys: {prefix}.{resource_name}.{version} (with prefix only present if `prefix` is set, and `version` only present for versioned resources)
-    values: ({resource_name}[ version {version}], resource) with resource_name set to the variable name in the module and the version present for versioned resources.
+    Take a module that was imported and generates a list of all resources in this module that can be imported (i.e. with a path and import_func).
 
-     The following example will generate a dict with all the resources in gnomad.resources.grch37 that can be imported:
+    The dict produced is as follows:
+        - keys: {prefix}.{resource_name}.{version} (with prefix only present if `prefix` is set, and `version` only present for versioned resources)
+        - values: ({resource_name}[ version {version}], resource) with resource_name set to the variable name in the module and the version present for versioned resources.
+
+    The following example will generate a dict with all the resources in gnomad.resources.grch37 that can be imported:
 
     .. code-block:: python
 
         import gnomad.resources.grch37 as grch37
         grch37_resources = get_module_importable_resources(grch37, prefix='grch37')
-    
+
     :param module: Input module
-    :param prefix: 
-    :return: 
+    :param prefix:
+    :return:
     """
     _prefix = f"{prefix}." if prefix else ""
     resources = {}
@@ -48,8 +49,7 @@ def get_resources_descriptions(
     resources: Dict[str, Tuple[str, BaseResource]], width: Optional[int] = 100
 ) -> str:
     """
-    Returns a string listing all resources in the input dict along with the path from which they
-    are imported and the path at which they are stored.
+    Return a string listing all resources in the input dict along with the path from which they are imported and the path at which they are stored.
 
     :param resources: A dict returned from get_module_importable_resources
     :param width: Maximum width of lines in the returned string

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -66,7 +66,7 @@ class BaseResource(ABC):
 
 class TableResource(BaseResource):
     """
-    A Hail Table resource
+    A Hail Table resource.
 
     :param path: The Table path (typically ending in .ht)
     :param import_args: Any sources that are required for the import and need to be kept track of and/or passed to the import_func (e.g. .vcf path for an imported VCF)
@@ -88,7 +88,7 @@ class TableResource(BaseResource):
 
     def ht(self, force_import: bool = False) -> hl.Table:
         """
-        Read and return the Hail Table resource
+        Read and return the Hail Table resource.
 
         :return: Hail Table resource
         """
@@ -99,7 +99,7 @@ class TableResource(BaseResource):
 
     def import_resource(self, overwrite: bool = True, **kwargs) -> None:
         """
-        Imports the TableResource using its import_func and writes it in its path.
+        Import the TableResource using its import_func and writes it in its path.
 
         :param overwrite: If ``True``, overwrite an existing file at the destination.
         :param kwargs: Any other parameters to be passed to hl.Table.write
@@ -112,7 +112,7 @@ class TableResource(BaseResource):
 
 class MatrixTableResource(BaseResource):
     """
-    A Hail MatrixTable resource
+    A Hail MatrixTable resource.
 
     :param path: The MatrixTable path (typically ending in .mt)
     :param import_args: Any sources that are required for the import and need to be kept track of and/or passed to the import_func (e.g. .vcf path for an imported VCF)
@@ -134,7 +134,7 @@ class MatrixTableResource(BaseResource):
 
     def mt(self, force_import: bool = False) -> hl.MatrixTable:
         """
-        Read and return the Hail MatrixTable resource
+        Read and return the Hail MatrixTable resource.
 
         :return: Hail MatrixTable resource
         """
@@ -145,7 +145,7 @@ class MatrixTableResource(BaseResource):
 
     def import_resource(self, overwrite: bool = True, **kwargs) -> None:
         """
-        Imports the MatrixTable resource using its import_func and writes it in its path.
+        Import the MatrixTable resource using its import_func and writes it in its path.
 
         :param overwrite: If set, existing file(s) will be overwritten
         :param kwargs: Any other parameters to be passed to hl.MatrixTable.write
@@ -158,7 +158,7 @@ class MatrixTableResource(BaseResource):
 
 class PedigreeResource(BaseResource):
     """
-    A pedigree resource
+    A pedigree resource.
 
     :param path: The Pedigree path (typically ending in .fam or .ped)
     :param import_args: Any sources that are required for the import and need to be kept track of and/or passed to the import_func (e.g. .vcf path for an imported VCF)
@@ -190,7 +190,7 @@ class PedigreeResource(BaseResource):
 
     def ht(self) -> hl.Table:
         """
-        Reads the pedigree into a family HT using hl.import_fam().
+        Read the pedigree into a family HT using hl.import_fam().
 
         :return: Family table
         """
@@ -203,7 +203,7 @@ class PedigreeResource(BaseResource):
 
     def pedigree(self) -> hl.Pedigree:
         """
-        Reads the pedigree into an hl.Pedigree using hl.Pedigree.read().
+        Read the pedigree into an hl.Pedigree using hl.Pedigree.read().
 
         :param delimiter: Delimiter used in the ped file
         :return: pedigree
@@ -212,7 +212,7 @@ class PedigreeResource(BaseResource):
 
     def import_resource(self, overwrite: bool = True, **kwargs) -> None:
         """
-        Imports the Pedigree resource using its import_func and writes it in its path.
+        Import the Pedigree resource using its import_func and writes it in its path.
 
         :param overwrite: If set, existing file(s) will be overwritten. IMPORTANT: Currently there is no implementation of this method when `overwrite` is set the `False`
         :param kwargs: Any other parameters to be passed to hl.Pedigree.write
@@ -226,7 +226,7 @@ class PedigreeResource(BaseResource):
 
 class BlockMatrixResource(BaseResource):
     """
-    A Hail BlockMatrix resource
+    A Hail BlockMatrix resource.
 
     :param path: The BlockMatrix path (typically ending in .bm)
     :param import_args: Any sources that are required for the import and need to be kept track of and/or passed to the import_func.
@@ -248,7 +248,7 @@ class BlockMatrixResource(BaseResource):
 
     def bm(self) -> BlockMatrix:
         """
-        Read and return the Hail MatrixTable resource
+        Read and return the Hail MatrixTable resource.
 
         :return: Hail MatrixTable resource
         """
@@ -256,7 +256,7 @@ class BlockMatrixResource(BaseResource):
 
     def import_resource(self, overwrite: bool = True, **kwargs) -> None:
         """
-        Imports the BlockMatrixResource using its import_func and writes it in its path.
+        Import the BlockMatrixResource using its import_func and writes it in its path.
 
         :param overwrite: If ``True``, overwrite an existing file at the destination.
         :param kwargs: Any additional parameters to be passed to BlockMatrix.write
@@ -269,7 +269,7 @@ class BlockMatrixResource(BaseResource):
 
 class BaseVersionedResource(BaseResource, ABC):
     """
-    Abstract class for a versioned resource
+    Abstract class for a versioned resource.
 
     The `path`/`import_args` attributes of the versioned resource are those of the default version of the resource.
     In addition, all versions of the resource are stored in the `versions` attribute.
@@ -308,7 +308,7 @@ class BaseVersionedResource(BaseResource, ABC):
 
 class VersionedTableResource(BaseVersionedResource, TableResource):
     """
-    Versioned Table resource
+    Versioned Table resource.
 
     The attributes (path, import_args and import_func) of the versioned resource are those of the default version of the resource.
     In addition, all versions of the resource are stored in the `versions` attribute.
@@ -323,7 +323,7 @@ class VersionedTableResource(BaseVersionedResource, TableResource):
 
 class VersionedMatrixTableResource(BaseVersionedResource, MatrixTableResource):
     """
-    Versioned MatrixTable resource
+    Versioned MatrixTable resource.
 
     The attributes (path, import_args and import_func) of the versioned resource are those of the default version of the resource.
     In addition, all versions of the resource are stored in the `versions` attribute.
@@ -338,7 +338,7 @@ class VersionedMatrixTableResource(BaseVersionedResource, MatrixTableResource):
 
 class VersionedPedigreeResource(BaseVersionedResource, PedigreeResource):
     """
-    Versioned Pedigree resource
+    Versioned Pedigree resource.
 
     The attributes (path, import_args and import_func) of the versioned resource are those of the default version of the resource.
     In addition, all versions of the resource are stored in the `versions` attribute.
@@ -356,7 +356,7 @@ class VersionedPedigreeResource(BaseVersionedResource, PedigreeResource):
 
 class VersionedBlockMatrixResource(BaseVersionedResource, BlockMatrixResource):
     """
-    Versioned BlockMatrix resource
+    Versioned BlockMatrix resource.
 
     The attributes (path, import_args and import_func) of the versioned resource are those of the default version of the resource.
     In addition, all versions of the resource are stored in the `versions` attribute.

--- a/gnomad/sample_qc/ancestry.py
+++ b/gnomad/sample_qc/ancestry.py
@@ -81,7 +81,7 @@ def pc_project(
     af_location: str = "pca_af",
 ) -> hl.Table:
     """
-    Projects samples in `mt` on pre-computed PCs.
+    Project samples in `mt` on pre-computed PCs.
 
     :param mt: MT containing the samples to project
     :param loadings_ht: HT containing the PCA loadings and allele frequencies used for the PCA
@@ -89,7 +89,6 @@ def pc_project(
     :param af_location: Location of expression for allele frequency in `loadings_ht`
     :return: Table with scores calculated from loadings in column `scores`
     """
-
     n_variants = loadings_ht.count()
 
     mt = mt.annotate_rows(
@@ -128,17 +127,17 @@ def assign_population_pcs(
     Union[hl.Table, pd.DataFrame], Any
 ]:  # 2nd element of the tuple should be RandomForestClassifier but we do not want to import sklearn.RandomForestClassifier outside
     """
-    This function uses a random forest model to assign population labels based on the results of PCA.
+    Use a random forest model to assign population labels based on the results of PCA.
+
     Default values for model and assignment parameters are those used in gnomAD.
 
     As input, this function can either take:
-
-    - A Hail Table (typically the output of `hwe_normalized_pca`). In this case,
-        - `pc_cols` should be an ArrayExpression of Floats where each element is one of the PCs to use.
-        - A Hail Table will be returned as output
-    - A Pandas DataFrame. In this case:
-        - Each PC should be in a separate column and `pc_cols` is the list of all the columns containing the PCs to use.
-        - A pandas DataFrame is returned as output
+         - A Hail Table (typically the output of `hwe_normalized_pca`). In this case,
+            - `pc_cols` should be an ArrayExpression of Floats where each element is one of the PCs to use.
+            - A Hail Table will be returned as output
+        - A Pandas DataFrame. In this case:
+            - Each PC should be in a separate column and `pc_cols` is the list of all the columns containing the PCs to use.
+            - A pandas DataFrame is returned as output
 
     .. note::
 
@@ -242,8 +241,7 @@ def run_pca_with_relateds(
     autosomes_only: bool = True,
 ) -> Tuple[List[float], hl.Table, hl.Table]:
     """
-    First runs PCA excluding the given related samples,
-    then projects these samples in the PC space to return scores for all samples.
+    Run PCA excluding the given related samples, and project those samples in the PC space to return scores for all samples.
 
     The `related_samples_to_drop` Table has to be keyed by the sample ID and all samples present in this
     table will be excluded from the PCA.
@@ -257,7 +255,6 @@ def run_pca_with_relateds(
     :param autosomes_only: Whether to run the analysis on autosomes only
     :return: eigenvalues, scores and loadings
     """
-
     unrelated_mt = qc_mt.persist()
 
     if autosomes_only:

--- a/gnomad/sample_qc/ancestry.py
+++ b/gnomad/sample_qc/ancestry.py
@@ -132,7 +132,7 @@ def assign_population_pcs(
     Default values for model and assignment parameters are those used in gnomAD.
 
     As input, this function can either take:
-         - A Hail Table (typically the output of `hwe_normalized_pca`). In this case,
+        - A Hail Table (typically the output of `hwe_normalized_pca`). In this case,
             - `pc_cols` should be an ArrayExpression of Floats where each element is one of the PCs to use.
             - A Hail Table will be returned as output
         - A Pandas DataFrame. In this case:
@@ -141,8 +141,8 @@ def assign_population_pcs(
 
     .. note::
 
-        If you have a Pandas Dataframe and have all PCs as an array in a single column, the
-        `expand_pd_array_col` can be used to expand this column into multiple `PC` columns.
+        If you have a Pandas Dataframe and have all PCs as an array in a single column, the `expand_pd_array_col`
+        can be used to expand this column into multiple `PC` columns.
 
     :param pop_pc_pd: Input Hail Table or Pandas Dataframe
     :param pc_cols: Columns storing the PCs to use

--- a/gnomad/sample_qc/filtering.py
+++ b/gnomad/sample_qc/filtering.py
@@ -19,7 +19,7 @@ def compute_qc_metrics_residuals(
     regression_sample_inclusion_expr: hl.expr.BooleanExpression = hl.bool(True),
 ) -> hl.Table:
     """
-    Computes QC metrics residuals after regressing out PCs (and optionally PC^2)
+    Compute QC metrics residuals after regressing out PCs (and optionally PC^2).
 
     .. note::
 
@@ -34,7 +34,6 @@ def compute_qc_metrics_residuals(
     :param regression_sample_inclusion_expr: An optional expression to select samples to include in the regression calculation.
     :return: Table with QC metrics residuals
     """
-
     # Annotate QC HT with fields necessary for computation
     _sample_qc_ht = ht.select(
         **qc_metrics, scores=pc_scores, _keep=regression_sample_inclusion_expr
@@ -111,7 +110,7 @@ def compute_stratified_metrics_filter(
     filter_name: str = "qc_metrics_filters",
 ) -> hl.Table:
     """
-    Compute median, MAD, and upper and lower thresholds for each metric used in outlier filtering
+    Compute median, MAD, and upper and lower thresholds for each metric used in outlier filtering.
 
     :param ht: HT containing relevant sample QC metric annotations
     :param qc_metrics: list of metrics (name and expr) for which to compute the critical values for filtering outliers
@@ -122,7 +121,6 @@ def compute_stratified_metrics_filter(
     :param filter_name: Name of resulting filters annotation
     :return: Table grouped by strata, with upper and lower threshold values computed for each sample QC metric
     """
-
     _metric_threshold = {
         metric: (lower_threshold, upper_threshold) for metric in qc_metrics
     }
@@ -188,8 +186,11 @@ def compute_stratified_sample_qc(
     gt_col: Optional[str] = None,
 ) -> hl.Table:
     """
-    Runs hl.sample_qc on different strata and then also merge the results into a single expression.
-    Note that strata should be non-overlapping, e.g. SNV vs indels or bi-allelic vs multi-allelic
+    Run hl.sample_qc on different strata and then also merge the results into a single expression.
+
+    .. note::
+
+        Strata should be non-overlapping, e.g. SNV vs indels or bi-allelic vs multi-allelic
 
     :param mt: Input MT
     :param strata: Strata names and filtering expressions
@@ -234,7 +235,7 @@ def merge_sample_qc_expr(
     sample_qc_exprs: List[hl.expr.StructExpression],
 ) -> hl.expr.StructExpression:
     """
-    Creates an expression that merges results from non-overlapping strata of hail.sample_qc
+    Create an expression that merges results from non-overlapping strata of hail.sample_qc.
 
     E.g.:
 
@@ -253,7 +254,6 @@ def merge_sample_qc_expr(
     :param sample_qc_exprs: List of sample QC struct expressions for each stratification
     :return: Combined sample QC results
     """
-
     # List of metrics that can be aggregated by summing
     additive_metrics = [
         "n_called",

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -27,8 +27,10 @@ def filter_rows_for_qc(
     snv_only: bool = True,
 ) -> hl.MatrixTable:
     """
-    Annotates rows with `sites_callrate`, `site_inbreeding_coeff` and `af`, then applies thresholds.
-    AF and callrate thresholds are taken from gnomAD QC; inbreeding coeff, MQ, FS and QD filters are taken from GATK best practices
+    Annotate rows with `sites_callrate`, `site_inbreeding_coeff` and `af`, then applies thresholds.
+
+    AF and callrate thresholds are taken from gnomAD QC; inbreeding coeff, MQ, FS and QD filters are taken from
+    GATK best practices.
 
     .. note::
 
@@ -119,13 +121,14 @@ def get_qc_mt(
     high_conf_regions: Optional[List[str]] = None,
 ) -> hl.MatrixTable:
     """
-    Creates a QC-ready MT by keeping:
+    Create a QC-ready MT.
 
-    - Variants outside known problematic regions
-    - Bi-allelic SNVs only
-    - Variants passing hard thresholds
-    - Variants passing the set call rate and MAF thresholds
-    - Genotypes passing on gnomAD ADJ criteria (GQ>=20, DP>=10, AB>0.2 for hets)
+    Keeps the following:
+        - Variants outside known problematic regions
+        - Bi-allelic SNVs only
+        - Variants passing hard thresholds
+        - Variants passing the set call rate and MAF thresholds
+        - Genotypes passing on gnomAD ADJ criteria (GQ>=20, DP>=10, AB>0.2 for hets)
 
     In addition, the MT will be LD-pruned if `ld_r2` is set.
 
@@ -216,9 +219,9 @@ def annotate_sex(
     aaf_threshold: float = 0.001,
 ) -> hl.Table:
     """
-    Imputes sample sex based on X-chromosome heterozygosity and sex chromosome ploidy.
- 
-    Returns Table with the following fields:
+    Impute sample sex based on X-chromosome heterozygosity and sex chromosome ploidy.
+
+    Return Table with the following fields:
         - s (str): Sample
         - chr20_mean_dp (float32): Sample's mean coverage over chromosome 20.
         - chrX_mean_dp (float32): Sample's mean coverage over chromosome X.

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -27,7 +27,7 @@ def filter_rows_for_qc(
     snv_only: bool = True,
 ) -> hl.MatrixTable:
     """
-    Annotate rows with `sites_callrate`, `site_inbreeding_coeff` and `af`, then applies thresholds.
+    Annotate rows with `sites_callrate`, `site_inbreeding_coeff` and `af`, then apply thresholds.
 
     AF and callrate thresholds are taken from gnomAD QC; inbreeding coeff, MQ, FS and QD filters are taken from
     GATK best practices.

--- a/gnomad/sample_qc/platform.py
+++ b/gnomad/sample_qc/platform.py
@@ -19,7 +19,8 @@ def compute_callrate_mt(
     match: bool = True,
 ) -> hl.MatrixTable:
     """
-    Computes a sample/interval MT with each entry containing the call rate for that sample/interval.
+    Compute a sample/interval MT with each entry containing the call rate for that sample/interval.
+
     This can be used as input for imputing exome sequencing platforms.
 
     .. note::
@@ -80,7 +81,8 @@ def run_platform_pca(
     callrate_mt: hl.MatrixTable, binarization_threshold: Optional[float] = 0.25
 ) -> Tuple[List[float], hl.Table, hl.Table]:
     """
-    Runs a PCA on a sample/interval MT with each entry containing the call rate.
+    Run PCA on a sample/interval MT with each entry containing the call rate.
+
     When `binzarization_threshold` is set, the callrate is transformed to a 0/1 value based on the threshold.
     E.g. with the default threshold of 0.25, all entries with a callrate < 0.25 are considered as 0s, others as 1s.
 
@@ -116,7 +118,7 @@ def assign_platform_from_pcs(
     hdbscan_min_samples: int = None,
 ) -> hl.Table:
     """
-    Assigns platforms using HBDSCAN on the results of call rate PCA.
+    Assign platforms using HBDSCAN on the results of call rate PCA.
 
     :param platform_pca_scores_ht: Input table with the PCA score for each sample
     :param pc_scores_ann: Field containing the scores

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -51,7 +51,7 @@ def get_duplicated_samples(
     rel_col: str = "relationship",
 ) -> List[Set[str]]:
     """
-    Extract the list of duplicate sample using a Table ouput from pc_relate.
+    Extract the list of duplicate samples using a Table ouput from pc_relate.
 
     :param relationship_ht: Table with relationships between pairs of samples
     :param i_col: Column containing the 1st sample
@@ -270,8 +270,8 @@ def infer_families(
     """
     Generate a pedigree containing trios inferred from the `relationship_ht`.
 
-    This function takes a hail Table with a row for each pair of individuals i,j in the data that are
-    related (it's OK to have unrelated samples too).
+    This function takes a hail Table with a row for each pair of related individuals i, j in the data (it's OK to have
+    unrelated samples too).
 
     The `relationship_col` should be a column specifying the relationship between each two samples as defined in this
      module's constants.
@@ -297,8 +297,6 @@ def infer_families(
     ) -> List[List[Tuple[str, str]]]:
         """
         Group parent-child pairs into a list of families.
-
-        Takes all parent-children pairs and groups them by family.
 
         A family here is defined as a list of sample-pairs which all share at least one sample with at least one other
         sample-pair in the list.
@@ -409,7 +407,7 @@ def infer_families(
 
         def check_sibs(children: List[str]) -> bool:
             """
-            Confirm that all children a parent pair are siblings with each other.
+            Confirm that all children of a parent pair are siblings with each other.
 
             If there are multiple children for a given parent pair, all children should be siblings with each other.
 
@@ -571,7 +569,7 @@ def create_fake_pedigree(
     """
     Generate a pedigree made of trios created by sampling 3 random samples in the sample list.
 
-    - If `real_pedigree` is given, then children the resulting fake trios will not include any trio with proband - parents
+    - If `real_pedigree` is given, then children in the resulting fake trios will not include any trio with proband - parents
       that are in the real ones.
     - Each sample can be used only once as a proband in the resulting trios.
     - Sex of probands in fake trios is random.

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -51,7 +51,8 @@ def get_duplicated_samples(
     rel_col: str = "relationship",
 ) -> List[Set[str]]:
     """
-    Given a pc_relate output Table, extract the list of duplicate samples. Returns a list of set of samples that are duplicates.
+    Extract the list of duplicate sample using a Table ouput from pc_relate.
+
     :param relationship_ht: Table with relationships between pairs of samples
     :param i_col: Column containing the 1st sample
     :param j_col: Column containing the 2nd sample
@@ -63,8 +64,9 @@ def get_duplicated_samples(
         s: str, dups: Set[str], samples_duplicates: Dict[str, Set[str]]
     ) -> Tuple[Set[str], Dict[str, Set[str]]]:
         """
-        Creates the set of all duplicated samples corresponding to `s` that are found in `sample_duplicates`.
-        Also returns the remaining sample duplicates after removing all duplicated samples corresponding to `s`.
+        Create the set of all duplicated samples corresponding to `s` that are found in `sample_duplicates`.
+
+        Also return the remaining sample duplicates after removing all duplicated samples corresponding to `s`.
 
         Works by recursively adding duplicated samples to the set.
 
@@ -112,7 +114,8 @@ def get_duplicated_samples_ht(
     rank_ann: str = "rank",
 ):
     """
-    Creates a HT with duplicated samples sets.
+    Create a HT with duplicated samples sets.
+
     Each row is indexed by the sample that is kept and also contains the set of duplicate samples that should be filtered.
 
     `samples_rankings_ht` is a HT containing a global rank for each of the samples (smaller is better).
@@ -150,7 +153,8 @@ def get_duplicated_samples_ht(
 
 def explode_duplicate_samples_ht(dups_ht: hl.Table) -> hl.Table:
     """
-    Explodes the result of `get_duplicated_samples_ht`, so that each line contains a single sample.
+    Explode the result of `get_duplicated_samples_ht`, so that each line contains a single sample.
+
     An additional annotation is added: `dup_filtered` indicating which of the duplicated samples was kept.
     Requires a field `filtered` which type should be the same as the input duplicated samples Table key.
 
@@ -200,9 +204,11 @@ def get_relationship_expr(  # TODO: The threshold detection could be easily auto
     ibd2_100_thresholds: Tuple[float, float] = (0.75, 1.25),
 ) -> hl.expr.StringExpression:
     """
-    Returns an expression that gives the relationship between a pair of samples given their kin coefficient and IBDO, IBD1, IBD2 values.
-    The kinship coefficient values in the defaults are in line with those output from `hail.methods.pc_relate <https://hail.is/docs/0.2/methods/genetics.html?highlight=pc_relate#hail.methods.pc_relate>`.
-    
+    Return an expression indicating the relationship between a pair of samples given their kin coefficient and IBDO, IBD1, IBD2 values.
+
+    The kinship coefficient values in the defaults are in line with those output from
+    `hail.methods.pc_relate <https://hail.is/docs/0.2/methods/genetics.html?highlight=pc_relate#hail.methods.pc_relate>`.
+
     :param kin_expr: Kin coefficient expression
     :param ibd0_expr: IBDO expression
     :param ibd1_expr: IBD1 expression
@@ -262,8 +268,13 @@ def infer_families(
     relationship_col: str = "relationship",
 ) -> hl.Pedigree:
     """
-    This function takes a hail Table with a row for each pair of individuals i,j in the data that are related (it's OK to have unrelated samples too).
-    The `relationship_col` should be a column specifying the relationship between each two samples as defined in this module's constants.
+    Generate a pedigree containing trios inferred from the `relationship_ht`.
+
+    This function takes a hail Table with a row for each pair of individuals i,j in the data that are
+    related (it's OK to have unrelated samples too).
+
+    The `relationship_col` should be a column specifying the relationship between each two samples as defined in this
+     module's constants.
 
     This function returns a pedigree containing trios inferred from the data. Family ID can be the same for multiple
     trios if one or more members of the trios are related (e.g. sibs, multi-generational family). Trios are ordered by family ID.
@@ -285,8 +296,12 @@ def infer_families(
         parent_child_pairs: Iterable[Tuple[str, str]]
     ) -> List[List[Tuple[str, str]]]:
         """
+        Group parent-child pairs into a list of families.
+
         Takes all parent-children pairs and groups them by family.
-        A family here is defined as a list of sample-pairs which all share at least one sample with at least one other sample-pair in the list.
+
+        A family here is defined as a list of sample-pairs which all share at least one sample with at least one other
+        sample-pair in the list.
 
         :param parent_child_pairs: All the parent-children pairs
         :return: A list of families, where each element of the list is a list of the parent-children pairs
@@ -328,8 +343,9 @@ def infer_families(
         related_pairs: Dict[Tuple[str, str], str],
     ) -> List[hl.Trio]:
         """
-        Generates trios based from the list of parent-child pairs in the family and
-        all related pairs in the data. Only complete parent/offspring trios are included in the results.
+        Generate trios based on the list of parent-child pairs in the family and all related pairs in the data.
+
+        Only complete parent/offspring trios are included in the results.
 
         The trios are assembled as follows:
         1. All pairs of unrelated samples with different sexes within the family are extracted as possible parent pairs
@@ -345,7 +361,7 @@ def infer_families(
 
         def get_possible_parents(samples: List[str]) -> List[Tuple[str, str]]:
             """
-            1. All pairs of unrelated samples with different sexes within the family are extracted as possible parent pairs
+            Return all pairs of unrelated samples with different sexes within the family are extracted as possible parent pairs.
 
             :param samples: All samples in the family
             :return: Possible parent pairs
@@ -367,7 +383,9 @@ def infer_families(
 
         def get_children(possible_parents: Tuple[str, str]) -> List[str]:
             """
-            2. For a given possible parent pair, a list of all children is constructed (each child in the list has a parent-offspring pair with each parent)
+            Construct a list of all children for a given possible parent pair.
+
+            Each child in the list has a parent-offspring pair with each parent.
 
             :param possible_parents: A pair of possible parents
             :return: The list of all children (if any) corresponding to the possible parents
@@ -391,7 +409,9 @@ def infer_families(
 
         def check_sibs(children: List[str]) -> bool:
             """
-            3. If there are multiple children for a given parent pair, all children should be siblings with each other
+            Confirm that all children a parent pair are siblings with each other.
+
+            If there are multiple children for a given parent pair, all children should be siblings with each other.
 
             :param children: List of all children for a given parent pair
             :return: Whether all children in the list are siblings
@@ -407,7 +427,9 @@ def infer_families(
 
         def discard_multi_parents_children(trios: List[hl.Trio]):
             """
-            4. Check that each child was only assigned a single pair of parents. If a child is found to have multiple parent pairs, they are ALL discarded.
+            Check that each child was only assigned a single pair of parents.
+
+            If a child is found to have multiple parent pairs, they are ALL discarded.
 
             :param trios: All trios formed for this family
             :return: The list of trios for which each child has a single parents pair.
@@ -547,10 +569,12 @@ def create_fake_pedigree(
     real_pedigree: Optional[hl.Pedigree] = None,
 ) -> hl.Pedigree:
     """
-    Generates a pedigree made of trios created by sampling 3 random samples in the sample list.
-    If `real_pedigree` is given, then children the resulting fake trios will not include any trio with proband - parents that are in the real ones.
-    Each sample can be used only once as a proband in the resulting trios.
-    Sex of probands in fake trios is random.
+    Generate a pedigree made of trios created by sampling 3 random samples in the sample list.
+
+    - If `real_pedigree` is given, then children the resulting fake trios will not include any trio with proband - parents
+      that are in the real ones.
+    - Each sample can be used only once as a proband in the resulting trios.
+    - Sex of probands in fake trios is random.
 
     :param n: Number of fake trios desired in the pedigree
     :param sample_list: List of samples
@@ -609,7 +633,7 @@ def compute_related_samples_to_drop(
     min_related_hard_filter: Optional[int] = None,
 ) -> hl.Table:
     """
-    Computes a Table with the list of samples to drop (and their global rank) to get the maximal independent set of unrelated samples.
+    Compute a Table with the list of samples to drop (and their global rank) to get the maximal independent set of unrelated samples.
 
     .. note::
 
@@ -623,7 +647,6 @@ def compute_related_samples_to_drop(
     :param min_related_hard_filter: If provided, any sample that is related to more samples than this parameter will be filtered prior to computing the maximal independent set and appear in the results.
     :return: A Table with the list of the samples to drop along with their rank.
     """
-
     # Make sure that the key types are valid
     assert len(list(relatedness_ht.key)) == 2
     assert relatedness_ht.key[0].dtype == relatedness_ht.key[1].dtype
@@ -707,7 +730,7 @@ def compute_related_samples_to_drop(
 
 def filter_mt_to_trios(mt: hl.MatrixTable, fam_ht: hl.Table) -> hl.MatrixTable:
     """
-    Filters a MatrixTable to a set of trios in `fam_ht` and annotates with adj.
+    Filter a MatrixTable to a set of trios in `fam_ht` and annotates with adj.
 
     :param mt: A Matrix Table to filter to only trios
     :param fam_ht: A Table of trios to filter to, loaded using `hl.import_fam`
@@ -733,8 +756,9 @@ def generate_trio_stats_expr(
     proband_is_female_expr: Optional[hl.expr.BooleanExpression] = None,
 ) -> hl.expr.StructExpression:
     """
-    Generates a row-wise expression containing the following counts:
+    Generate a row-wise expression containing trio transmission stats.
 
+    The expression will generate the following counts:
         - Number of alleles in het parents transmitted to the proband
         - Number of alleles in het parents not transmitted to the proband
         - Number of de novo mutations
@@ -757,7 +781,6 @@ def generate_trio_stats_expr(
     :param proband_is_female_expr: An optional expression giving the sex the proband. If not given, DNMs are only computed for autosomes.
     :return: An expression with the counts
     """
-
     # Create map for transmitted, untransmitted and DNM
     hom_ref = 0
     het = 1
@@ -789,10 +812,7 @@ def generate_trio_stats_expr(
     trans_count_map = hl.literal(trans_config_counts)
 
     def _get_copy_state(locus: hl.expr.LocusExpression) -> hl.expr.Int32Expression:
-        """
-        Helper method to go from LocusExpression to a copy-state int for indexing into the
-        trans_count_map.
-        """
+        """Get copy-state int from LocusExpression for indexing into the trans_count_map."""
         return (
             hl.case()
             .when(locus.in_autosome_or_par(), auto_or_par)
@@ -808,9 +828,7 @@ def generate_trio_stats_expr(
         locus: hl.expr.LocusExpression,
         proband_is_female: Optional[hl.expr.BooleanExpression],
     ) -> hl.expr.BooleanExpression:
-        """
-        Helper method to get whether a given genotype combination is a DNM at a given locus with a given proband sex.
-        """
+        """Determine whether a given genotype combination is a DNM at a given locus with a given proband sex."""
         if proband_is_female is None:
             logger.warning(
                 "Since no proband sex expression was given to generate_trio_stats_expr, only DNMs in autosomes will be counted."
@@ -832,9 +850,7 @@ def generate_trio_stats_expr(
         father_gt: hl.expr.CallExpression,
         mother_gt: hl.expr.CallExpression,
     ) -> Dict[str, hl.expr.Int64Expression]:
-        """
-        Helper method to get AC and AN for parents and children
-        """
+        """Get AC and AN for parents and children."""
         ac_parent_expr = hl.agg.sum(
             father_gt.n_alt_alleles() + mother_gt.n_alt_alleles()
         )
@@ -923,7 +939,7 @@ def generate_sib_stats_expr(
     is_female: Optional[hl.expr.BooleanExpression] = None,
 ) -> hl.expr.StructExpression:
     """
-    Generates a row-wise expression containing the number of alternate alleles in common between sibling pairs.
+    Generate a row-wise expression containing the number of alternate alleles in common between sibling pairs.
 
     The sibling sharing counts can be stratified using additional filters using `stata`.
 
@@ -942,9 +958,7 @@ def generate_sib_stats_expr(
     """
 
     def _get_alt_count(locus, gt, is_female):
-        """
-        Helper method to calculate alt allele count with sex info if present
-        """
+        """Calculate alt allele count with sex info if present."""
         if is_female is None:
             return hl.or_missing(locus.in_autosome(), gt.n_alt_alleles())
         return (

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -18,7 +18,7 @@ def adjusted_sex_ploidy_expr(
     xx_karyotype_str: str = "XX",
 ) -> hl.expr.CallExpression:
     """
-    Creates an entry expression to convert males to haploid on non-PAR X/Y and females to missing on Y
+    Create an entry expression to convert males to haploid on non-PAR X/Y and females to missing on Y.
 
     :param locus_expr: Locus
     :param gt_expr: Genotype
@@ -48,7 +48,7 @@ def adjust_sex_ploidy(
     female_str: str = "female",
 ) -> hl.MatrixTable:
     """
-    Converts males to haploid on non-PAR X/Y, sets females to missing on Y
+    Convert males to haploid on non-PAR X/Y, sets females to missing on Y.
 
     :param mt: Input MatrixTable
     :param sex_expr: Expression pointing to sex in MT (if not male_str or female_str, no change)
@@ -68,8 +68,13 @@ def get_ploidy_cutoffs(
     aneuploidy_cutoff: int = 6,
 ) -> Tuple[Tuple[float, Tuple[float, float], float], Tuple[Tuple[float, float], float]]:
     """
-    Gets chromosome X and Y ploidy cutoffs for XY and XX samples. Note this assumes the input hail Table has the fields f_stat, chrX_ploidy, and chrY_ploidy.
-    Returns a tuple of sex chromosome ploidy cutoffs: ((x_ploidy_cutoffs), (y_ploidy_cutoffs)).
+    Get chromosome X and Y ploidy cutoffs for XY and XX samples.
+
+    .. note::
+
+        This assumes the input hail Table has the fields f_stat, chrX_ploidy, and chrY_ploidy.
+
+    Return a tuple of sex chromosome ploidy cutoffs: ((x_ploidy_cutoffs), (y_ploidy_cutoffs)).
     x_ploidy_cutoffs: (upper cutoff for single X, (lower cutoff for double X, upper cutoff for double X), lower cutoff for triple X)
     y_ploidy_cutoffs: ((lower cutoff for single Y, upper cutoff for single Y), lower cutoff for double Y)
 
@@ -128,10 +133,7 @@ def get_sex_expr(
     y_ploidy_cutoffs: Tuple[Tuple[float, float], float],
 ) -> hl.expr.StructExpression:
     """
-    Creates a struct with the following annotation:
-    - X_karyotype (str)
-    - Y_karyotype (str)
-    - sex_karyotype (str)
+    Create a struct with X_karyotype, Y_karyotype, and sex_karyotype.
 
     Note that X0 is currently returned as 'X'.
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -36,10 +36,9 @@ def pop_max_expr(
     pops_to_exclude: Optional[Set[str]] = None,
 ) -> hl.expr.StructExpression:
     """
-    Creates an expression containing popmax: the frequency information about the population
-    that has the highest AF from the populations provided in `freq_meta`,
-    excluding those specified in `pops_to_exclude`.
-    Only frequencies from adj populations are considered.
+    Create an expression containing the frequency information about the population that has the highest AF in `freq_meta`.
+
+    Populations specified in `pops_to_exclude` are excluded and only frequencies from adj populations are considered.
 
     This resulting struct contains the following fields:
 
@@ -78,8 +77,9 @@ def project_max_expr(
     n_projects: int = 5,
 ) -> hl.expr.ArrayExpression:
     """
-    Creates an expression that computes allele frequency information by project for the `n_projects` with the largest AF at this row.
-    This return an array with one element per non-reference allele.
+    Create an expression that computes allele frequency information by project for the `n_projects` with the largest AF at this row.
+
+    Will return an array with one element per non-reference allele.
 
     Each of these elements is itself an array of structs with the following fields:
 
@@ -100,7 +100,6 @@ def project_max_expr(
     :param n_projects: Maximum number of projects to return for each row
     :return: projectmax expression
     """
-
     n_alleles = hl.len(alleles_expr)
 
     # compute call stats by  project
@@ -142,7 +141,8 @@ def faf_expr(
     faf_thresholds: List[float] = [0.95, 0.99],
 ) -> Tuple[hl.expr.ArrayExpression, List[Dict[str, str]]]:
     """
-    Calculates the filtering allele frequency (FAF) for each threshold specified in `faf_thresholds`.
+    Calculate the filtering allele frequency (FAF) for each threshold specified in `faf_thresholds`.
+
     See http://cardiodb.org/allelefrequencyapp/ for more information.
 
     The FAF is computed for each of the following population stratification if found in `freq_meta`:
@@ -231,7 +231,7 @@ def qual_hist_expr(
     adj_expr: Optional[hl.expr.BooleanExpression] = None,
 ) -> hl.expr.StructExpression:
     """
-    Returns a struct expression with genotype quality histograms based on the arguments given (dp, gq, ad).
+    Return a struct expression with genotype quality histograms based on the arguments given (dp, gq, ad).
 
     .. note::
 
@@ -296,7 +296,7 @@ def age_hists_expr(
     n_bins: int = 10,
 ) -> hl.expr.StructExpression:
     """
-    Returns a StructExpression with the age histograms for hets and homs.
+    Return a StructExpression with the age histograms for hets and homs.
 
     :param adj_expr: Entry expression containing whether a genotype is high quality (adj) or not
     :param gt_expr: Entry expression containing the genotype
@@ -327,8 +327,12 @@ def annotate_freq(
     downsamplings: Optional[List[int]] = None,
 ) -> hl.MatrixTable:
     """
-    Adds a row annotation `freq` to the input `mt` with stratified allele frequencies, a global annotation `freq_meta`
-    with metadata, and a global annotation `freq_sample_count` with sample count information.
+    Annotate `mt` with stratified allele frequencies.
+
+    The output Matrix table will include:
+        - row annotation `freq` containing the stratified allele frequencies
+        - global annotation `freq_meta` with metadata
+        - global annotation `freq_sample_count` with sample count information
 
     .. note::
 
@@ -377,7 +381,6 @@ def annotate_freq(
     :param downsamplings: When specified, frequencies are computed by downsampling the data to the number of samples given in the list. Note that if `pop_expr` is specified, downsamplings by population is also computed.
     :return: MatrixTable with `freq` annotation
     """
-
     if subpop_expr is not None and pop_expr is None:
         raise NotImplementedError(
             "annotate_freq requires pop_expr when using subpop_expr"
@@ -555,7 +558,7 @@ def get_lowqual_expr(
     indel_phred_het_prior: int = 39,  # 1/8,000
 ) -> Union[hl.expr.BooleanExpression, hl.expr.ArrayExpression]:
     """
-    Computes lowqual threshold expression for either split or unsplit alleles based on QUALapprox or AS_QUALapprox
+    Compute lowqual threshold expression for either split or unsplit alleles based on QUALapprox or AS_QUALapprox.
 
     .. note::
 
@@ -571,7 +574,6 @@ def get_lowqual_expr(
     :param indel_phred_het_prior: Phred-scaled indel heterozygosity prior (30 = 1/1000 bases, GATK default)
     :return: lowqual expression (BooleanExpression if `qual_approx_expr`is Numeric, Array[BooleanExpression] if `qual_approx_expr` is ArrayNumeric)
     """
-
     min_snv_qual = snv_phred_threshold + snv_phred_het_prior
     min_indel_qual = indel_phred_threshold + indel_phred_het_prior
     min_mixed_qual = max(min_snv_qual, min_indel_qual)
@@ -609,7 +611,8 @@ def get_annotations_hists(
     log10_annotations: List[str] = ["DP"],
 ) -> Dict[str, hl.expr.StructExpression]:
     """
-    Creates histograms for variant metrics in ht.info.
+    Create histograms for variant metrics in ht.info.
+
     Used when creating site quality distribution json files.
 
     :param ht: Table with variant metrics
@@ -635,7 +638,7 @@ def create_frequency_bins_expr(
     AC: hl.expr.NumericExpression, AF: hl.expr.NumericExpression
 ) -> hl.expr.StringExpression:
     """
-    Creates bins for frequencies in preparation for aggregating QUAL by frequency bin.
+    Create bins for frequencies in preparation for aggregating QUAL by frequency bin.
 
     Bins:
         - singleton
@@ -697,7 +700,8 @@ def get_adj_expr(
     haploid_adj_dp: int = 5,
 ) -> hl.expr.BooleanExpression:
     """
-    Gets adj genotype annotation.
+    Get adj genotype annotation.
+
     Defaults correspond to gnomAD values.
     """
     return (
@@ -723,7 +727,8 @@ def annotate_adj(
     haploid_adj_dp: int = 5,
 ) -> hl.MatrixTable:
     """
-    Annotate genotypes with adj criteria (assumes diploid)
+    Annotate genotypes with adj criteria (assumes diploid).
+
     Defaults correspond to gnomAD values.
     """
     return mt.annotate_entries(
@@ -734,9 +739,7 @@ def annotate_adj(
 
 
 def add_variant_type(alt_alleles: hl.expr.ArrayExpression) -> hl.expr.StructExpression:
-    """
-    Get Struct of variant_type and n_alt_alleles from ArrayExpression of Strings (all alleles)
-    """
+    """Get Struct of variant_type and n_alt_alleles from ArrayExpression of Strings (all alleles)."""
     ref = alt_alleles[0]
     alts = alt_alleles[1:]
     non_star_alleles = hl.filter(lambda a: a != "*", alts)
@@ -772,7 +775,10 @@ def annotation_type_is_numeric(t: Any) -> bool:
 def annotation_type_in_vcf_info(t: Any) -> bool:
     """
     Given an annotation type, returns whether that type can be natively exported to a VCF INFO field.
-    Note types that aren't natively exportable to VCF will be converted to String on export.
+
+    .. note::
+
+        Types that aren't natively exportable to VCF will be converted to String on export.
 
     :param t: Type to test
     :return: If the input type can be exported to VCF
@@ -822,7 +828,8 @@ def fs_from_sb(
     min_p_value: float = 1e-320,
 ) -> hl.expr.Int64Expression:
     """
-    Computes `FS` (Fisher strand balance) annotation from  the `SB` (strand balance table) field.
+    Compute `FS` (Fisher strand balance) annotation from  the `SB` (strand balance table) field.
+
     `FS` is the phred-scaled value of the double-sided Fisher exact test on strand balance.
 
     Using default values will have the same behavior as the GATK implementation, that is:
@@ -893,7 +900,7 @@ def sor_from_sb(
     sb: Union[hl.expr.ArrayNumericExpression, hl.expr.ArrayExpression]
 ) -> hl.expr.Float64Expression:
     """
-    Computes `SOR` (Symmetric Odds Ratio test) annotation from  the `SB` (strand balance table) field.
+    Compute `SOR` (Symmetric Odds Ratio test) annotation from  the `SB` (strand balance table) field.
 
     .. note::
 
@@ -906,7 +913,6 @@ def sor_from_sb(
     :param sb: Count of ref/alt reads on each strand
     :return: SOR value
     """
-
     if not isinstance(sb, hl.expr.ArrayNumericExpression):
         sb = hl.bind(lambda x: hl.flatten(x), sb)
 
@@ -928,8 +934,7 @@ def sor_from_sb(
 
 def bi_allelic_expr(t: Union[hl.Table, hl.MatrixTable]) -> hl.expr.BooleanExpression:
     """
-    Returns a boolean expression selecting bi-allelic sites only,
-    accounting for whether the input MT/HT was split.
+    Return a boolean expression selecting bi-allelic sites only, accounting for whether the input MT/HT was split.
 
     :param t: Input HT/MT
     :return: Boolean expression selecting only bi-allelic sites
@@ -939,7 +944,7 @@ def bi_allelic_expr(t: Union[hl.Table, hl.MatrixTable]) -> hl.expr.BooleanExpres
 
 def unphase_call_expr(call_expr: hl.expr.CallExpression) -> hl.expr.CallExpression:
     """
-    Generate unphased version of a call expression (which can be phased or not)
+    Generate unphased version of a call expression (which can be phased or not).
 
     :param call_expr: Input call expression
     :return: unphased call expression

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -16,6 +16,7 @@ logger.setLevel(logging.INFO)
 def file_exists(fname: str) -> bool:
     """
     Check whether a file exists.
+
     Supports either local or Google cloud (gs://) paths.
     If the file is a Hail file (.ht, .mt extensions), it checks that _SUCCESS is present.
 
@@ -51,6 +52,7 @@ def write_temp_gcs(
 def select_primitives_from_ht(ht: hl.Table) -> hl.Table:
     """
     Select only primitive types (string, int, float, bool) from a Table.
+
     Particularly useful for exporting a Table.
 
     :param ht: Input Table
@@ -68,7 +70,8 @@ def select_primitives_from_ht(ht: hl.Table) -> hl.Table:
 
 def get_file_stats(url: str) -> Tuple[int, str, str]:
     """
-    Gets size (as both int and str) and md5 for file at specified URL.
+    Get size (as both int and str) and md5 for file at specified URL.
+
     Typically used to get stats on VCFs.
 
     :param url: Path to file of interest.
@@ -101,7 +104,8 @@ def get_file_stats(url: str) -> Tuple[int, str, str]:
 
 def read_list_data(input_file_path: str) -> List[str]:
     """
-    Reads a file input into a python list (each line will be an element).
+    Read a file input into a python list (each line will be an element).
+
     Supports Google storage paths and .gz compression.
 
     :param input_file_path: File path

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -14,9 +14,7 @@ logger.setLevel(logging.INFO)
 
 
 def filter_to_adj(mt: hl.MatrixTable) -> hl.MatrixTable:
-    """
-    Filter genotypes to adj criteria
-    """
+    """Filter genotypes to adj criteria."""
     if "adj" not in list(mt.entry):
         mt = annotate_adj(mt)
     mt = mt.filter_entries(mt.adj)
@@ -35,8 +33,9 @@ def filter_by_frequency(
     adj: bool = True,
 ) -> Union[hl.MatrixTable, hl.Table]:
     """
-    Filter MatrixTable or Table with gnomAD-format frequency data (assumed bi-allelic/split)
-    (i.e. Array[Struct(Array[AC], Array[AF], AN, homozygote_count, meta)])
+    Filter MatrixTable or Table with gnomAD-format frequency data (assumed bi-allelic/split).
+
+    gnomAD frequency data format expectation is: Array[Struct(Array[AC], Array[AF], AN, homozygote_count, meta)].
 
     At least one of frequency or allele_count is required.
 
@@ -118,7 +117,7 @@ def filter_low_conf_regions(
     high_conf_regions: Optional[List[str]] = None,
 ) -> Union[hl.MatrixTable, hl.Table]:
     """
-    Filters low-confidence regions
+    Filter low-confidence regions.
 
     :param mt: MatrixTable or Table to filter
     :param filter_lcr: Whether to filter LCR regions
@@ -180,7 +179,8 @@ def filter_to_autosomes(
     t: Union[hl.MatrixTable, hl.Table]
 ) -> Union[hl.MatrixTable, hl.Table]:
     """
-    Filters the Table or MatrixTable to autosomes only.
+    Filter the Table or MatrixTable to autosomes only.
+
     This assumes that the input contains a field named `locus` of type Locus
 
     :param t: Input MT/HT
@@ -198,7 +198,8 @@ def add_filters_expr(
     current_filters: hl.expr.SetExpression = None,
 ) -> hl.expr.SetExpression:
     """
-    Creates an expression to create or add filters.
+    Create an expression to create or add filters.
+
     For each entry in the `filters` dictionary, if the value evaluates to `True`,
     then the key is added as a filter name.
 
@@ -230,7 +231,7 @@ def subset_samples_and_variants(
     gt_expr: str = "GT",
 ) -> hl.MatrixTable:
     """
-    Subsets the MatrixTable to the provided list of samples and their variants
+    Subset the MatrixTable to the provided list of samples and their variants.
 
     :param mt: Input MatrixTable
     :param sample_path: Path to a file with list of samples
@@ -278,7 +279,7 @@ def filter_to_clinvar_pathogenic(
     remove_conflicting: bool = True,
 ) -> Union[hl.MatrixTable, hl.Table]:
     """
-    Returns a MatrixTable or Table that filters the clinvar data to pathogenic and likely pathogenic variants.
+    Return a MatrixTable or Table that filters the clinvar data to pathogenic and likely pathogenic variants.
 
     Example use:
 

--- a/gnomad/utils/gen_stats.py
+++ b/gnomad/utils/gen_stats.py
@@ -9,7 +9,7 @@ logger.setLevel(logging.INFO)
 
 def to_phred(linear_expr: hl.expr.NumericExpression) -> hl.expr.Float64Expression:
     """
-    Computes the phred-scaled value of the linear-scale input
+    Compute the phred-scaled value of the linear-scale input.
 
     :param linear_expr: input
     :return: Phred-scaled value
@@ -21,7 +21,7 @@ def from_phred(
     phred_score_expr: hl.expr.NumericExpression,
 ) -> hl.expr.Float64Expression:
     """
-    Computes the linear-scale value of the phred-scaled input.
+    Compute the linear-scale value of the phred-scaled input.
 
     :param phred_score_expr: phred-scaled value
     :return: linear-scale value of the phred-scaled input.
@@ -33,8 +33,11 @@ def get_median_and_mad_expr(
     metric_expr: hl.expr.ArrayNumericExpression, k: float = 1.4826
 ) -> hl.expr.StructExpression:
     """
-    Computes the median and median absolute deviation (MAD) for the given expression.
-    Note that the default value of k assumes normally distributed data.
+    Compute the median and median absolute deviation (MAD) for the given expression.
+
+    ..note::
+
+        The default value of k assumes normally distributed data.
 
     :param metric_expr: Expression to compute median and MAD for
     :param k: The scaling factor for MAD calculation. Default assumes normally distributed data.
@@ -50,10 +53,9 @@ def merge_stats_counters_expr(
     stats: hl.expr.ArrayExpression,
 ) -> hl.expr.StructExpression:
     """
-    Merges multiple stats counters, assuming that they were computed on non-overlapping data.
+    Merge multiple stats counters, assuming that they were computed on non-overlapping data.
 
     Examples:
-
     - Merge stats computed on indel and snv separately
     - Merge stats computed on bi-allelic and multi-allelic variants separately
     - Merge stats computed on autosomes and sex chromosomes separately
@@ -66,7 +68,9 @@ def merge_stats_counters_expr(
         i: hl.expr.StructExpression, j: hl.expr.StructExpression
     ) -> hl.expr.StructExpression:
         """
-        This merges two stast counters together. It assumes that all stats counter fields are present in the struct.
+        Merge two stast counters together.
+
+        Assumes that all stats counter fields are present in the struct.
 
         :param i: accumulator: struct with mean, n and variance
         :param j: new element: stats_struct -- needs to contain mean, n and variance

--- a/gnomad/utils/gen_stats.py
+++ b/gnomad/utils/gen_stats.py
@@ -68,7 +68,7 @@ def merge_stats_counters_expr(
         i: hl.expr.StructExpression, j: hl.expr.StructExpression
     ) -> hl.expr.StructExpression:
         """
-        Merge two stast counters together.
+        Merge two stats counters together.
 
         Assumes that all stats counter fields are present in the struct.
 

--- a/gnomad/utils/intervals.py
+++ b/gnomad/utils/intervals.py
@@ -5,8 +5,7 @@ import hail as hl
 
 def sort_intervals(intervals: List[hl.Interval]):
     """
-    Sorts an array of intervals by:
-    start contig, then start position, then end contig, then end position
+    Sort an array of intervals by start contig, then start position, then end contig, then end position.
 
     :param intervals: Intervals to sort
     :return: Sorted interval list
@@ -24,7 +23,7 @@ def sort_intervals(intervals: List[hl.Interval]):
 
 def union_intervals(intervals: List[hl.Interval], is_sorted: bool = False):
     """
-    Generates a list with the union of all intervals in the input list by merging overlapping intervals.
+    Generate a list with the union of all intervals in the input list by merging overlapping intervals.
 
     :param intervals: Intervals to merge
     :param is_sorted: If set, assumes intervals are already sorted, otherwise will sort.
@@ -49,7 +48,7 @@ def union_intervals(intervals: List[hl.Interval], is_sorted: bool = False):
 
 def interval_length(interval: hl.Interval) -> int:
     """
-    Returns the total number of bases in an Interval
+    Return the total number of bases in an Interval.
 
     :param interval: Input interval
     :return: Total length of the interval

--- a/gnomad/utils/liftover.py
+++ b/gnomad/utils/liftover.py
@@ -28,7 +28,7 @@ def get_liftover_genome(
     t: Union[hl.MatrixTable, hl.Table]
 ) -> Tuple[hl.genetics.ReferenceGenome, hl.genetics.ReferenceGenome]:
     """
-    Infer reference genome build of input data and assumes destination reference genome build.
+    Infer reference genome build of input data and assume destination reference genome build.
 
     Adds liftover chain to source reference genome and sequence to destination reference genome.
     Returns tuple containing both reference genomes in preparation for liftover.

--- a/gnomad/utils/liftover.py
+++ b/gnomad/utils/liftover.py
@@ -28,16 +28,15 @@ def get_liftover_genome(
     t: Union[hl.MatrixTable, hl.Table]
 ) -> Tuple[hl.genetics.ReferenceGenome, hl.genetics.ReferenceGenome]:
     """
-    Infers reference genome build of input data and assumes destination reference genome build. 
+    Infer reference genome build of input data and assumes destination reference genome build.
 
     Adds liftover chain to source reference genome and sequence to destination reference genome.
     Returns tuple containing both reference genomes in preparation for liftover.
 
     :param t: Input Table or MatrixTable.
-    :return: Tuple of source reference genome (with liftover chain added) 
+    :return: Tuple of source reference genome (with liftover chain added)
         and destination reference genome (with sequence loaded)
     """
-
     logger.info("Inferring reference genome of input...")
     input_build = get_reference_genome(t.locus).name
     source = hl.get_reference(input_build)
@@ -69,7 +68,7 @@ def liftover_expr(
     destination_reference: hl.ReferenceGenome,
 ) -> hl.expr.StructExpression:
     """
-    Generates struct liftover expression.
+    Generate struct liftover expression.
 
     Struct contains:
         - locus: Liftover coordinates
@@ -107,7 +106,7 @@ def default_lift_data(
     t: Union[hl.MatrixTable, hl.Table], remove_failed_sites: bool = True,
 ) -> Union[hl.MatrixTable, hl.Table]:
     """
-    Lifts input Table or MatrixTable from one reference build to another.
+    Lift input Table or MatrixTable from one reference build to another.
 
     :param t: Table or MatrixTable.
     :return: Table or MatrixTable with liftover annotations.
@@ -147,7 +146,7 @@ def liftover_using_gnomad_map(ht: hl.Table, data_type: str):
     Liftover a gnomAD v2 table using already-established liftover file.
 
     .. note::
-        This function shuffles! 
+        This function shuffles!
 
     :param ht: Input Hail Table.
     :param data_type: Which gnomAD data type to map across. One of "exomes" or "genomes".

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -112,7 +112,9 @@ def plot_hail_hist(
     hide_zeros: bool = False,
 ) -> bokeh.plotting.Figure:
     """
-    hist_data can (and should) come straight from ht.aggregate(hl.agg.hist(ht.data, start, end, bins))
+    Plot histogram from Hail hist aggregation.
+
+    `hist_data` can (and should) come straight from ht.aggregate(hl.agg.hist(ht.data, start, end, bins))
 
     :param hist_data: Data to plot
     :param title: Plot title
@@ -124,7 +126,6 @@ def plot_hail_hist(
     :param hide_zeros: Remove hist bars with 0 count
     :return: Histogram plot
     """
-
     return plot_multi_hail_hist(
         {"hist": hist_data},
         title=title,
@@ -150,7 +151,8 @@ def plot_multi_hail_hist(
     alpha: float = None,
 ) -> bokeh.plotting.Figure:
     """
-    Plots multiple histograms on the same plot.
+    Plot multiple histograms on the same plot.
+
     Each histogram can (and should) come straight from ht.aggregate(hl.agg.hist(ht.data, start, end, bins))
 
     Example usage:
@@ -170,7 +172,6 @@ def plot_multi_hail_hist(
     :param alpha: Alpha value (if None, then 1.0/len(hist_data) is used)
     :return: Histogram plot
     """
-
     low = int(log)
 
     if alpha is None:
@@ -272,7 +273,9 @@ def plot_hail_hist_cumulative(
     hover_mode: str = "mouse",
 ) -> bokeh.plotting.Figure:
     """
-    hist_data can (and should) come straight from ht.aggregate(hl.agg.hist(ht.data, start, end, bins))
+    Plot cumulative histogram from Hail hist aggregation.
+
+    `hist_data` can (and should) come straight from ht.aggregate(hl.agg.hist(ht.data, start, end, bins))
 
     :param hist_data: Data to plot
     :param title: Plot title
@@ -344,7 +347,8 @@ def plot_hail_file_metadata(
     t_path: str,
 ) -> Optional[Union[Grid, Tabs, bokeh.plotting.Figure]]:
     """
-    Takes path to hail Table or MatrixTable (gs://bucket/path/hail.mt), outputs Grid or Tabs, respectively.
+    Take path to hail Table or MatrixTable (gs://bucket/path/hail.mt), outputs Grid or Tabs, respectively.
+
     Or if an unordered Table is provided, a Figure with file sizes is output.
     If metadata file or rows directory is missing, returns None.
     """
@@ -638,7 +642,7 @@ def pair_plot(
     tooltip_cols: List[str] = None,
 ) -> Column:
     """
-    Plots each column of `data` against each other and returns a grid of plots.
+    Plot each column of `data` against each other and returns a grid of plots.
 
     The diagonal contains a histogram of each column, or a density plot if labels are provided.
     The lower diagonal contains scatter plots of each column against each other.
@@ -654,7 +658,6 @@ def pair_plot(
     :param tooltip_cols: Additional columns that should be displayed in tooltip
     :return: Grid of plots (column of rows)
     """
-
     if tooltip_cols is None:
         tooltip_cols = [] if label_col is None else [label_col]
     elif label_col not in tooltip_cols:

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -347,7 +347,7 @@ def plot_hail_file_metadata(
     t_path: str,
 ) -> Optional[Union[Grid, Tabs, bokeh.plotting.Figure]]:
     """
-    Take path to hail Table or MatrixTable (gs://bucket/path/hail.mt), outputs Grid or Tabs, respectively.
+    Take path to hail Table or MatrixTable (gs://bucket/path/hail.mt), output Grid or Tabs, respectively.
 
     Or if an unordered Table is provided, a Figure with file sizes is output.
     If metadata file or rows directory is missing, returns None.

--- a/gnomad/utils/reference_genome.py
+++ b/gnomad/utils/reference_genome.py
@@ -19,7 +19,7 @@ def get_reference_ht(
     filter_n: bool = True,
 ) -> hl.Table:
     """
-    Creates a reference Table with locus and alleles (containing only the reference allele by default) from the given reference genome.
+    Create a reference Table with locus and alleles (containing only the reference allele by default) from the given reference genome.
 
     .. note::
 
@@ -87,7 +87,8 @@ def get_reference_ht(
 
 def add_reference_sequence(ref: hl.ReferenceGenome) -> hl.ReferenceGenome:
     """
-    Adds the fasta sequence to a Hail reference genome.
+    Add the fasta sequence to a Hail reference genome.
+
     Only GRCh37 and GRCh38 references are supported.
 
     :param ref: Input reference genome.
@@ -121,7 +122,7 @@ def get_reference_genome(
     add_sequence: bool = False,
 ) -> hl.ReferenceGenome:
     """
-    Returns the reference genome associated with the input Locus expression
+    Return the reference genome associated with the input Locus expression.
 
     :param locus: Input locus
     :param add_sequence: If set, the fasta sequence is added to the reference genome

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -26,8 +26,7 @@ INFO_ARRAY_SUM_AGG_FIELDS = ["SB", "RAW_MQandDP"]
 
 def compute_last_ref_block_end(mt: hl.MatrixTable) -> hl.Table:
     """
-    This function takes a sparse MT and computes for each row the genomic position of the
-    most upstream reference block overlapping that row.
+    Compute the genomic position of the most upstream reference block overlapping each row on a sparse MT.
 
     Note that since reference blocks do not extend beyond contig boundaries, only the position is kept.
 
@@ -87,7 +86,7 @@ def densify_sites(
     semi_join_rows: bool = True,
 ) -> hl.MatrixTable:
     """
-    Creates a dense version of the input sparse MT at the sites in `sites_ht` reading the minimal amount of data required.
+    Create a dense version of the input sparse MT at the sites in `sites_ht` reading the minimal amount of data required.
 
     Note that only rows that appear both in `mt` and `sites_ht` are returned.
 
@@ -152,16 +151,16 @@ def _get_info_agg_expr(
     prefix: str = "",
 ) -> Dict[str, hl.expr.Aggregation]:
     """
-    Helper function containing code to create Aggregators for both site or AS info expression aggregations.
+    Create Aggregators for both site or AS info expression aggregations.
 
-    Notes:
+    .. note::
 
-    1. If `SB` is specified in array_sum_agg_fields, it will be aggregated as `AS_SB_TABLE`, according to GATK standard nomenclature.
-    2. If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
-    3. If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
-    4. If the fields to be aggregate (`sum_agg_fields`, `int32_sum_agg_fields`, `median_agg_fields`) are passed as list of str,
-       then they should correspond to entry fields in `mt` or in `mt.gvcf_info`.
-       Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
+        - If `SB` is specified in array_sum_agg_fields, it will be aggregated as `AS_SB_TABLE`, according to GATK standard nomenclature.
+        - If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
+        - If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
+        - If the fields to be aggregate (`sum_agg_fields`, `int32_sum_agg_fields`, `median_agg_fields`) are passed as
+          list of str, then they should correspond to entry fields in `mt` or in `mt.gvcf_info`.
+        - Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
 
     :param mt: Input MT
     :param sum_agg_fields: Fields to aggregate using sum.
@@ -288,16 +287,16 @@ def get_as_info_expr(
     alt_alleles_range_array_field: str = "alt_alleles_range_array",
 ) -> hl.expr.StructExpression:
     """
-    Returns an allele-specific annotation Struct containing typical VCF INFO fields from GVCF INFO fields stored in the MT entries.
+    Return an allele-specific annotation Struct containing typical VCF INFO fields from GVCF INFO fields stored in the MT entries.
 
-    Notes:
+    .. note::
 
-    1. If `SB` is specified in array_sum_agg_fields, it will be aggregated as `AS_SB_TABLE`, according to GATK standard nomenclature.
-    2. If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
-    3. If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
-    4. If the fields to be aggregate (`sum_agg_fields`, `int32_sum_agg_fields`, `median_agg_fields`) are passed as list of str,
-       then they should correspond to entry fields in `mt` or in `mt.gvcf_info`.
-       Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
+        - If `SB` is specified in array_sum_agg_fields, it will be aggregated as `AS_SB_TABLE`, according to GATK standard nomenclature.
+        - If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
+        - If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
+        - If the fields to be aggregate (`sum_agg_fields`, `int32_sum_agg_fields`, `median_agg_fields`) are passed as list of str,
+          then they should correspond to entry fields in `mt` or in `mt.gvcf_info`.
+        - Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
 
     :param mt: Input Matrix Table
     :param sum_agg_fields: Fields to aggregate using sum.
@@ -386,15 +385,15 @@ def get_site_info_expr(
     ] = INFO_ARRAY_SUM_AGG_FIELDS,
 ) -> hl.expr.StructExpression:
     """
-    Creates a site-level annotation Struct aggregating typical VCF INFO fields from GVCF INFO fields stored in the MT entries.
+    Create a site-level annotation Struct aggregating typical VCF INFO fields from GVCF INFO fields stored in the MT entries.
 
-    Notes:
+    .. note::
 
-    1. If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
-    2. If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
-    3. If the fields to be aggregate (`sum_agg_fields`, `int32_sum_agg_fields`, `median_agg_fields`) are passed as list of str,
-       then they should correspond to entry fields in `mt` or in `mt.gvcf_info`.
-       Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
+        - If `RAW_MQandDP` is specified in array_sum_agg_fields, it will be used for the `MQ` calculation and then dropped according to GATK recommendation.
+        - If `RAW_MQ` and `MQ_DP` are given, they will be used for the `MQ` calculation and then dropped according to GATK recommendation.
+        - If the fields to be aggregate (`sum_agg_fields`, `int32_sum_agg_fields`, `median_agg_fields`) are passed as
+          list of str, then they should correspond to entry fields in `mt` or in `mt.gvcf_info`.
+        - Priority is given to entry fields in `mt` over those in `mt.gvcf_info` in case of a name clash.
 
     :param mt: Input Matrix Table
     :param sum_agg_fields: Fields to aggregate using sum.
@@ -438,9 +437,11 @@ def default_compute_info(
     mt: hl.MatrixTable, site_annotations: bool = False, n_partitions: int = 5000
 ) -> hl.Table:
     """
-    Computes a HT with the typical GATK allele-specific (AS) info fields 
-    as well as ACs and lowqual fields.
-    Note that this table doesn't split multi-allelic sites.
+    Compute a HT with the typical GATK allele-specific (AS) info fields as well as ACs and lowqual fields.
+
+    .. note::
+
+        This table doesn't split multi-allelic sites.
 
     :param mt: Input MatrixTable. Note that this table should be filtered to nonref sites.
     :param site_annotations: Whether to also generate site level info fields. Default is False.
@@ -505,7 +506,7 @@ def split_info_annotation(
     info_expr: hl.expr.StructExpression, a_index: hl.expr.Int32Expression
 ) -> hl.expr.StructExpression:
     """
-    Splits multi-allelic allele-specific info fields.
+    Split multi-allelic allele-specific info fields.
 
     :param info_expr: Field containing info struct.
     :param a_index: Allele index. Output by hl.split_multi or hl.split_multi_hts.
@@ -527,7 +528,7 @@ def split_lowqual_annotation(
     lowqual_expr: hl.expr.ArrayExpression, a_index: hl.expr.Int32Expression
 ) -> hl.expr.BooleanExpression:
     """
-    Splits multi-allelic low QUAL annotation.
+    Split multi-allelic low QUAL annotation.
 
     :param lowqual_expr: Field containing low QUAL annotation.
     :param a_index: Allele index. Output by hl.split_multi or hl.split_multi_hts.
@@ -545,22 +546,24 @@ def impute_sex_ploidy(
     chr_y: Optional[str] = None,
 ) -> hl.Table:
     """
-    Imputes sex ploidy from a sparse Matrix Table by normalizing the coverage of chromosomes X and Y using
-    the coverage of an autosomal chromosome (by default chr20).
+    Impute sex ploidy from a sparse MatrixTable.
 
-    Coverage is computed using the median block coverage (summed over the block size) and the non-ref coverage at non-ref genotypes.
+    Sex ploidy is imputed by normalizing the coverage of chromosomes X and Y using the coverage of an autosomal
+    chromosome (by default chr20).
+
+    Coverage is computed using the median block coverage (summed over the block size) and the non-ref coverage at
+    non-ref genotypes.
 
     :param mt: Input sparse Matrix Table
-    :param excluded_calling_intervals: Optional table of intervals to exclude from the computation. 
+    :param excluded_calling_intervals: Optional table of intervals to exclude from the computation.
         Used only when determining contig size (not used when computing chromosome depth).
-    :param included_calling_intervals: Optional table of intervals to use in the computation. 
+    :param included_calling_intervals: Optional table of intervals to use in the computation.
         Used only when determining contig size (not used when computing chromosome depth).
     :param normalization_contig: Which chromosome to normalize by
     :param chr_x: Optional X Chromosome contig name (by default uses the X contig in the reference)
     :param chr_y: Optional Y Chromosome contig name (by default uses the Y contig in the reference)
     :return: Table with mean coverage over chromosomes 20, X and Y and sex chromosomes ploidy based on normalized coverage.
     """
-
     ref = get_reference_genome(mt.locus, add_sequence=True)
     if chr_x is None:
         if len(ref.x_contigs) != 1:
@@ -654,7 +657,9 @@ def compute_coverage_stats(
     coverage_over_x_bins: List[int] = [1, 5, 10, 15, 20, 25, 30, 50, 100],
 ) -> hl.Table:
     """
-    Computes the following coverage statistics for every base of the `reference_ht` provided:
+    Compute coverage statistics for every base of the `reference_ht` provided.
+
+    The following coverage stats are calculated:
         - mean
         - median
         - total DP
@@ -669,7 +674,6 @@ def compute_coverage_stats(
     :param coverage_over_x_bins: List of boundaries for computing samples over X
     :return: Table with per-base coverage stats
     """
-
     n_samples = mt.count_cols()
     print(f"Computing coverage stats on {n_samples} samples.")
 
@@ -746,7 +750,7 @@ def filter_ref_blocks(
     t: Union[hl.MatrixTable, hl.Table]
 ) -> Union[hl.MatrixTable, hl.Table]:
     """
-    Filters ref blocks out of the Table or MatrixTable.
+    Filter ref blocks out of the Table or MatrixTable.
 
     :param t: Input MT/HT
     :return: MT/HT with ref blocks removed

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -277,7 +277,9 @@ def ht_to_vcf_mt(
     pipe_delimited_annotations: List[str] = INFO_VCF_AS_PIPE_DELIMITED_FIELDS,
 ) -> hl.MatrixTable:
     """
-    Creates a MT ready for vcf export from a HT. In particular, the following conversions are done:
+    Create a MT ready for vcf export from a HT.
+
+    In particular, the following conversions are done:
     - All int64 are coerced to int32
     - Fields specified by `pipe_delimited_annotations` will be converted from arrays to pipe-delimited strings
 
@@ -390,8 +392,7 @@ def index_globals(
     label_delimiter: str = "_",
 ) -> Dict[str, int]:
     """
-    Create a dictionary keyed by the specified label groupings with values describing the corresponding index of each grouping entry
-    in the meta_array annotation
+    Create a dictionary keyed by the specified label groupings with values describing the corresponding index of each grouping entry in the meta_array annotation.
 
     :param globals_array: Ordered list containing dictionary entries describing all the grouping combinations contained in the globals_array annotation.
        Keys are the grouping type (e.g., 'group', 'pop', 'sex') and values are the grouping attribute (e.g., 'adj', 'eas', 'XY').
@@ -599,7 +600,7 @@ def add_as_info_dict(
     info_dict: Dict[str, Dict[str, str]] = INFO_DICT, as_fields: List[str] = AS_FIELDS
 ) -> Dict[str, Dict[str, str]]:
     """
-    Updates info dictionary with allele-specific terms and their descriptions.
+    Update info dictionary with allele-specific terms and their descriptions.
 
     Used in VCF export.
 
@@ -634,7 +635,7 @@ def make_vcf_filter_dict(
     snp_cutoff: float, indel_cutoff: float, inbreeding_cutoff: float
 ) -> Dict[str, str]:
     """
-    Generates dictionary of Number and Description attributes to be used in the VCF header, specifically for FILTER annotations.
+    Generate dictionary of Number and Description attributes to be used in the VCF header, specifically for FILTER annotations.
 
     Generates descriptions for:
         - AC0 filter
@@ -664,8 +665,7 @@ def make_hist_bin_edges_expr(
     ht: hl.Table, hists: List[str] = HISTS, prefix: str = ""
 ) -> Dict[str, str]:
     """
-    Create dictionaries containing variant histogram annotations and their associated bin edges, formatted into a string
-    separated by pipe delimiters.
+    Create dictionaries containing variant histogram annotations and their associated bin edges, formatted into a string separated by pipe delimiters.
 
     :param ht: Table containing histogram variant annotations.
     :param hists: List of variant histogram annotations. Default is HISTS.

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -109,7 +109,7 @@ Set containing loss-of-function consequence strings.
 
 def get_vep_help(vep_config_path: Optional[str] = None):
     """
-    Returns the output of vep --help which includes the VEP version.
+    Return the output of vep --help which includes the VEP version.
 
     .. warning::
         If no `vep_config_path` is supplied, this function will only work for Dataproc clusters
@@ -130,7 +130,7 @@ def get_vep_help(vep_config_path: Optional[str] = None):
 
 def get_vep_context(ref: Optional[str] = None) -> VersionedTableResource:
     """
-    Get VEP context resource for the genome build `ref`
+    Get VEP context resource for the genome build `ref`.
 
     :param ref: Genome build. If None, `hl.default_reference` is used
     :return: VEPed context resource
@@ -154,7 +154,7 @@ def vep_or_lookup_vep(
     ht, reference_vep_ht=None, reference=None, vep_config_path=None, vep_version=None
 ):
     """
-    VEP a table, or lookup variants in a reference database
+    VEP a table, or lookup variants in a reference database.
 
     .. warning::
         If `reference_vep_ht` is supplied, no check is performed to confirm `reference_vep_ht` was
@@ -167,7 +167,6 @@ def vep_or_lookup_vep(
     :param vep_version: Version of VEPed context Table to use (if None, the default `vep_context` resource will be used)
     :return: VEPed Table
     """
-
     if reference is None:
         reference = hl.default_reference().name
 
@@ -246,8 +245,9 @@ def process_consequences(
     penalize_flags: bool = True,
 ) -> Union[hl.MatrixTable, hl.Table]:
     """
-    Adds most_severe_consequence (worst consequence for a transcript) into [vep_root].transcript_consequences,
-    and worst_csq_by_gene, any_lof into [vep_root]
+    Add most_severe_consequence into [vep_root].transcript_consequences, and worst_csq_by_gene, any_lof into [vep_root].
+
+    `most_severe_consequence` is the worst consequence for a transcript.
 
     :param mt: Input MT
     :param vep_root: Root for vep annotation (probably vep)
@@ -260,9 +260,7 @@ def process_consequences(
     def find_worst_transcript_consequence(
         tcl: hl.expr.ArrayExpression,
     ) -> hl.expr.StructExpression:
-        """
-        Gets worst transcript_consequence from an array of em
-        """
+        """Get worst transcript_consequence from an array of em."""
         flag_score = 500
         no_flag_score = flag_score * (1 + penalize_flags)
 
@@ -381,7 +379,6 @@ def vep_struct_to_csq(
     :param csq_fields: The | delimited list of fields to include in the CSQ (in that order)
     :return: The corresponding CSQ strings
     """
-
     _csq_fields = [f.lower() for f in csq_fields.split("|")]
 
     def get_csq_from_struct(
@@ -481,8 +478,7 @@ def get_most_severe_consequence_for_summary(
     loftee_labels: List[str] = LOFTEE_LABELS,
 ) -> hl.Table:
     """
-    Prepares hail Table for summary statistics generation 
-    (number of variants by functional class, number of variants by functional class per sample).
+    Prepare a hail Table for summary statistics generation.
 
     Adds the following annotations:
         - most_severe_csq: Most severe consequence for variant
@@ -502,7 +498,7 @@ def get_most_severe_consequence_for_summary(
         csq_list: hl.expr.ArrayExpression, protein_coding: bool
     ) -> hl.expr.StructExpression:
         """
-        Processes VEP consequences to generate summary annotations.
+        Process VEP consequences to generate summary annotations.
 
         :param csq_list: VEP consequences list to be processed.
         :param protein_coding: Whether variant is in a protein-coding transcript.

--- a/gnomad/variant_qc/evaluation.py
+++ b/gnomad/variant_qc/evaluation.py
@@ -20,8 +20,8 @@ def compute_ranked_bin(
     n_bins: int = 100,
     desc: bool = True,
 ) -> hl.Table:
-    """
-    Returns a table with a bin for each row based on the ranking of `score_expr`.
+    r"""
+    Return a table with a bin for each row based on the ranking of `score_expr`.
 
     The bin is computed by dividing the `score_expr` into `n_bins` bins containing approximately equal numbers of elements.
     This is done by ranking the rows by `score_expr` (and a random number in cases where multiple variants have the same score)
@@ -62,7 +62,6 @@ def compute_ranked_bin(
     :param desc: Whether to bin the score in descending order
     :return: Table with the requested bin annotations
     """
-
     if compute_snv_indel_separately:
         # For each bin, add a SNV / indel stratification
         bin_expr = {
@@ -170,8 +169,9 @@ def compute_grouped_binned_ht(
     bin_ht: hl.Table, checkpoint_path: Optional[str] = None,
 ) -> hl.GroupedTable:
     """
-    Groups a Table that has been annotated with bins (`compute_ranked_bin` or `create_binned_ht`). The table will be
-    grouped by bin_id (bin, biallelic, etc.), contig, snv, bi_allelic and singleton.
+    Group a Table that has been annotated with bins (`compute_ranked_bin` or `create_binned_ht`).
+
+    The table will be grouped by bin_id (bin, biallelic, etc.), contig, snv, bi_allelic and singleton.
 
     .. note::
 
@@ -221,8 +221,7 @@ def compute_binned_truth_sample_concordance(
     add_bins: Dict[str, hl.expr.BooleanExpression] = {},
 ) -> hl.Table:
     """
-    Determines the concordance (TP, FP, FN) between a truth sample within the callset and the samples truth data
-    grouped by bins computed using `compute_ranked_bin`.
+    Determine the concordance (TP, FP, FN) between a truth sample within the callset and the samples truth data grouped by bins computed using `compute_ranked_bin`.
 
     .. note::
         The input 'ht` should contain three row fields:
@@ -314,7 +313,7 @@ def create_truth_sample_ht(
     mt: hl.MatrixTable, truth_mt: hl.MatrixTable, high_confidence_intervals_ht: hl.Table
 ) -> hl.Table:
     """
-    Computes a table comparing a truth sample in callset vs the truth.
+    Compute a table comparing a truth sample in callset vs the truth.
 
     :param mt: MT of truth sample from callset to be compared to truth
     :param truth_mt: MT of truth sample
@@ -326,8 +325,7 @@ def create_truth_sample_ht(
         truth_mt: hl.MatrixTable, high_confidence_intervals_ht: hl.Table
     ) -> hl.Table:
         """
-        Splits a truth sample MT and filter it to the given high confidence intervals.
-        Then "flatten" it as a HT by annotating GT in a row field.
+        Split a truth sample MT, filter it to the given high confidence intervals, and then "flatten" it as a HT by annotating GT in a row field.
 
         :param truth_mt: Truth sample MT
         :param high_confidence_intervals_ht: High confidence intervals
@@ -372,7 +370,8 @@ def add_rank(
     subrank_expr: Optional[Dict[str, hl.expr.BooleanExpression]] = None,
 ) -> hl.Table:
     """
-    Adds rank based on the `score_expr`. Rank is added for snvs and indels separately.
+    Add rank based on the `score_expr`. Rank is added for snvs and indels separately.
+
     If one or more `subrank_expr` are provided, then subrank is added based on all sites for which the boolean expression is true.
 
     In addition, variant counts (snv, indel separately) is added as a global (`rank_variant_counts`).
@@ -382,7 +381,6 @@ def add_rank(
     :param subrank_expr: Any subranking to be added in the form name_of_subrank: subrank_filtering_expr
     :return: Table with rankings added
     """
-
     key = ht.key
     if subrank_expr is None:
         subrank_expr = {}

--- a/gnomad/variant_qc/ld.py
+++ b/gnomad/variant_qc/ld.py
@@ -58,7 +58,7 @@ def get_r_for_pair_of_variants(
 
 def get_r_within_gene_in_pop(pop: str, gene: str):
     """
-    Gets LD information (`r`) for all pairs of variants within `gene` for a given `pop`.
+    Get LD information (`r`) for all pairs of variants within `gene` for a given `pop`.
 
     Warning: this returns a table quadratic in number of variants. Exercise caution with large genes.
 
@@ -79,7 +79,7 @@ def get_r_within_gene(
     reference_genome: str = None,
 ):
     """
-    Gets LD information (`r`) for all pairs of variants within `gene`.
+    Get LD information (`r`) for all pairs of variants within `gene`.
 
     Warning: this returns a table quadratic in number of variants. Exercise caution with large genes.
 

--- a/gnomad/variant_qc/pipeline.py
+++ b/gnomad/variant_qc/pipeline.py
@@ -38,7 +38,7 @@ def create_binned_ht(
     add_substrat: Optional[Dict[str, hl.expr.BooleanExpression]] = None,
 ) -> hl.Table:
     """
-    Annotate each row of `ht` with a bin based on the score annotation into `n_bins` equally-sized bins.
+    Annotate each row of `ht` with a bin based on binning the score annotation into `n_bins` equally-sized bins.
 
     This is meant as a default wrapper for `compute_ranked_bin`.
 

--- a/gnomad/variant_qc/pipeline.py
+++ b/gnomad/variant_qc/pipeline.py
@@ -125,9 +125,8 @@ def score_bin_agg(
 
         This function uses `ht._parent` to get the origin Table from the GroupedTable for the aggregation
 
-    This can easily be combined with the GroupedTable returned by `compute_grouped_binned_ht`
+    This can easily be combined with the GroupedTable returned by `compute_grouped_binned_ht`, For example:
 
-    Example:
     .. code-block:: python
 
         binned_ht = create_binned_ht(...)

--- a/gnomad/variant_qc/pipeline.py
+++ b/gnomad/variant_qc/pipeline.py
@@ -38,8 +38,9 @@ def create_binned_ht(
     add_substrat: Optional[Dict[str, hl.expr.BooleanExpression]] = None,
 ) -> hl.Table:
     """
-    This is meant as a default wrapper for `compute_ranked_bin`. It annotates table with a bin, where variants are
-    binned based on score into `n_bins` equally-sized bins.
+    Annotate each row of `ht` with a bin based on the score annotation into `n_bins` equally-sized bins.
+
+    This is meant as a default wrapper for `compute_ranked_bin`.
 
     .. note::
 
@@ -72,7 +73,7 @@ def create_binned_ht(
         new_id: str,
     ) -> Dict[str, hl.expr.BooleanExpression]:
         """
-        Updates a dictionary of expressions to add another stratification
+        Update a dictionary of expressions to add another stratification.
 
         :param bin_expr: Dictionary of expressions to add another stratification to
         :param new_expr: New Boolean expression to add to `bin_expr`
@@ -118,8 +119,7 @@ def score_bin_agg(
     ht: hl.GroupedTable, fam_stats_ht: hl.Table
 ) -> Dict[str, hl.expr.Aggregation]:
     """
-    Default aggregation function to add aggregations for min/max of score, number of ClinVar variants, number of truth
-    variants (omni, mills, hapmap, and kgp_phase1), and family statistics.
+    Make dict of aggregations for min/max of score, number of ClinVar variants, number of truth variants, and family statistics.
 
     .. note::
 
@@ -128,7 +128,6 @@ def score_bin_agg(
     This can easily be combined with the GroupedTable returned by `compute_grouped_binned_ht`
 
     Example:
-
     .. code-block:: python
 
         binned_ht = create_binned_ht(...)
@@ -255,7 +254,7 @@ def generate_trio_stats(
     mt: hl.MatrixTable, autosomes_only: bool = True, bi_allelic_only: bool = True
 ) -> hl.Table:
     """
-    Default function to run `generate_trio_stats_expr` to get trio stats stratified by raw and adj
+    Run `generate_trio_stats_expr` with variant QC pipeline defaults to get trio stats stratified by raw and adj.
 
     .. note::
 
@@ -299,10 +298,13 @@ def generate_sib_stats(
     bi_allelic_only: bool = True,
 ) -> hl.Table:
     """
-    This is meant as a default wrapper for `generate_sib_stats_expr`. It returns a hail table with counts of variants
-    shared by pairs of siblings in `relatedness_ht`.
+    Generate a hail table with counts of variants shared by pairs of siblings in `relatedness_ht`.
 
-    This function takes a hail Table with a row for each pair of individuals i,j in the data that are related (it's OK to have unrelated samples too).
+    This is meant as a default wrapper for `generate_sib_stats_expr`.
+
+    This function takes a hail Table with a row for each pair of individuals i,j in the data that are related
+    (it's OK to have unrelated samples too).
+
     The `relationship_col` should be a column specifying the relationship between each two samples as defined by
     the constants in `gnomad.utils.relatedness`. This relationship_col will be used to filter to only pairs of
     samples that are annotated as `SIBLINGS`.
@@ -382,7 +384,6 @@ def train_rf_model(
     :param test_expr: An expression specifying variants to hold out for testing and use for evaluation only.
     :return: Table with TP and FP training sets used in the RF training and the resulting RF model.
     """
-
     ht = ht.annotate(_tp=tp_expr, _fp=fp_expr, rf_test=test_expr)
 
     rf_ht = sample_training_examples(

--- a/gnomad/variant_qc/random_forest.py
+++ b/gnomad/variant_qc/random_forest.py
@@ -25,7 +25,7 @@ def run_rf_test(
     mt: hl.MatrixTable, output: str = "/tmp"
 ) -> Tuple[pyspark.ml.PipelineModel, hl.Table]:
     """
-    Runs a dummy test RF on a given MT.
+    Run a dummy test RF on a given MT.
 
     1. Creates row annotations and labels to run model on
     2. Trains a RF pipeline model (including median imputation of missing values in created annotations)
@@ -36,7 +36,6 @@ def run_rf_test(
     :param output: Output files prefix to save the RF model
     :return: RF model and MatrixTable after applying RF model
     """
-
     mt = mt.annotate_rows(
         feature1=hl.rand_bool(0.1),
         feature2=hl.rand_norm(0.0, 1.0),
@@ -92,13 +91,12 @@ def run_rf_test(
 
 def check_ht_fields_for_spark(ht: hl.Table, fields: List[str]) -> None:
     """
-    Checks specified fields of a hail table for Spark DataFrame conversion (type and name)
+    Check specified fields of a hail table for Spark DataFrame conversion (type and name).
 
     :param ht: input Table
     :param fields: Fields to test
     :return: None
     """
-
     allowed_types = [
         hl.tfloat,
         hl.tfloat32,
@@ -134,7 +132,7 @@ def get_columns_quantiles(
     ht: hl.Table, fields: List[str], quantiles: List[float], relative_error: int = 0.001
 ) -> Dict[str, List[float]]:
     """
-    Computes approximate quantiles of specified numeric fields from non-missing values. Non-numeric fields are ignored.
+    Compute approximate quantiles of specified numeric fields from non-missing values. Non-numeric fields are ignored.
 
     This function returns a Dict of column name -> list of quantiles in the same order specified.
     If a column only has NAs, None is returned.
@@ -145,7 +143,6 @@ def get_columns_quantiles(
     :param relative_error: The relative error on the quantile approximation
     :return: Dict of column -> quantiles
     """
-
     check_ht_fields_for_spark(ht, fields)
 
     df = ht.key_by().select(*fields).to_spark()
@@ -181,7 +178,6 @@ def median_impute_features(
     :param strata: Whether to impute features median by specific strata (default False).
     :return: Feature Table imputed using approximate median values.
     """
-
     logger.info("Computing feature medians for imputation of missing numeric values")
     numerical_features = [
         k for k, v in ht.row.dtype.items() if v == hl.tint or v == hl.tfloat
@@ -233,7 +229,8 @@ def ht_to_rf_df(
     ht: hl.Table, features: List[str], label: str, index: str = None
 ) -> pyspark.sql.DataFrame:
     """
-    Creates a Spark dataframe ready for RF from a HT.
+    Create a Spark dataframe ready for RF from a HT.
+
     Rows with any missing features are dropped.
     Missing labels are replaced with 'NA'
 
@@ -247,7 +244,6 @@ def ht_to_rf_df(
     :param index: Optional index column to keep (E.g. for joining results back at later stage)
     :return: Spark Dataframe
     """
-
     cols_to_keep = features + [label]
     if index:
         cols_to_keep.append(index)
@@ -269,7 +265,6 @@ def get_features_importance(
     :param assembler_index: index of the VectorAssembler stage
     :return: feature importance for each feature in the RF model
     """
-
     feature_names = [
         x[: -len("_indexed")] if x.endswith("_indexed") else x
         for x in rf_pipeline.stages[assembler_index].getInputCols()
@@ -280,7 +275,7 @@ def get_features_importance(
 
 def get_labels(rf_pipeline: pyspark.ml.PipelineModel) -> List[str]:
     """
-    Returns the labels from the StringIndexer stage at index 0 from an RF pipeline model
+    Return the labels from the StringIndexer stage at index 0 from an RF pipeline model.
 
     :param rf_pipeline: Input pipeline
     :return: labels
@@ -309,7 +304,6 @@ def test_model(
     :param prediction_col_name: Where to store the prediction
     :return: A list containing structs with {label, prediction, n}
     """
-
     ht = apply_rf_model(
         ht.filter(hl.is_defined(ht[label])),
         rf_model,
@@ -347,7 +341,7 @@ def apply_rf_model(
     prediction_col_name: str = "rf_prediction",
 ) -> hl.Table:
     """
-    Applies a Random Forest (RF) pipeline model to a Table and annotate the RF probabilities and predictions.
+    Apply a Random Forest (RF) pipeline model to a Table and annotate the RF probabilities and predictions.
 
     :param ht: Input HT
     :param rf_model: Random Forest pipeline model
@@ -357,7 +351,6 @@ def apply_rf_model(
     :param prediction_col_name: Name of the column that will store the RF predictions
     :return: Table with RF columns
     """
-
     logger.info("Applying RF model.")
 
     check_ht_fields_for_spark(ht, features + [label])
@@ -411,7 +404,7 @@ def save_model(
     rf_pipeline: pyspark.ml.PipelineModel, out_path: str, overwrite: bool = False
 ) -> None:
     """
-    Saves a Random Forest pipeline model.
+    Save a Random Forest pipeline model.
 
     :param rf_pipeline: Pipeline to save
     :param out_path: Output path
@@ -427,7 +420,7 @@ def save_model(
 
 def load_model(input_path: str) -> pyspark.ml.PipelineModel:
     """
-    Loads a Random Forest pipeline model.
+    Load a Random Forest pipeline model.
 
     :param input_path: Location of model to load
     :return: Random Forest pipeline model
@@ -444,7 +437,7 @@ def train_rf(
     max_depth: int = 5,
 ) -> pyspark.ml.PipelineModel:
     """
-    Trains a Random Forest (RF) pipeline model.
+    Train a Random Forest (RF) pipeline model.
 
     :param ht: Input HT
     :param features: List of columns to be used as features
@@ -453,7 +446,6 @@ def train_rf(
     :param max_depth: Maximum tree depth
     :return: Random Forest pipeline model
     """
-
     logger.info(
         "Training RF model using:\n"
         "features: {}\n"
@@ -527,7 +519,7 @@ def train_rf(
 
 def get_rf_runs(rf_json_fp: str) -> Dict:
     """
-    Loads RF run data from JSON file.
+    Load RF run data from JSON file.
 
     :param rf_json_fp: File path to rf json file.
     :return: Dictionary containing the content of the JSON file, or an empty dictionary if the file wasn't found.
@@ -549,7 +541,7 @@ def get_run_data(
     test_results: List[hl.tstruct],
 ) -> Dict:
     """
-    Creates a Dict containing information about the RF input arguments and feature importance
+    Create a Dict containing information about the RF input arguments and feature importance.
 
     :param Dict of bool keyed by str input_args: Dictionary of model input arguments
     :param List of str test_intervals: Intervals withheld from training to be used in testing
@@ -582,14 +574,13 @@ def pretty_print_runs(
     runs: Dict, label_col: str = "rf_label", prediction_col_name: str = "rf_prediction"
 ) -> None:
     """
-    Prints the information for the RF runs loaded from the json file storing the RF run hashes -> info
+    Print the information for the RF runs loaded from the json file storing the RF run hashes -> info.
 
     :param runs: Dictionary containing JSON input loaded from RF run file
     :param label_col: Name of the RF label column
     :param prediction_col_name: Name of the RF prediction column
     :return: Nothing -- only prints information
     """
-
     for run_hash, run_data in runs.items():
         print(f"\n=== {run_hash} ===")
         testing_results = (

--- a/gnomad/variant_qc/training.py
+++ b/gnomad/variant_qc/training.py
@@ -17,8 +17,10 @@ def sample_training_examples(
     test_expr: Optional[hl.expr.BooleanExpression] = None,
 ) -> hl.Table:
     """
-    Returns a Table of all positive and negative training examples in `ht` with an annotation indicating those that
-    should be used for training given a true positive (TP) to false positive (FP) ratio.
+    Return a Table of all positive and negative training examples in `ht` with an annotation indicating those that should be used for training.
+
+    If `fp_to_tp` is greater than 0, this true positive (TP) to false positive (FP) ratio will be used to determine
+    sampling of training variants.
 
     The returned Table has the following annotations:
         - train: indicates if the variant should be used for training. A row is given False for the annotation if True
@@ -37,7 +39,6 @@ def sample_training_examples(
     :param test_expr: Optional expression to exclude a set of variants from training set. Still contains TP/FP label annotation.
     :return: Table subset with corresponding TP and FP examples with desired FP to TP ratio.
     """
-
     ht = ht.select(
         _tp=hl.or_else(tp_expr, False),
         _fp=hl.or_else(fp_expr, False),


### PR DESCRIPTION
These are just the easy fixes to docstrings reported by `pydocstyle`. The remaining problems are actual missing docstrings and will take more thought to add.