### PR TITLE
Add pydocstyle to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,7 @@ repos:
       - id: black
         language_version: python3
         files: gnomad
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.0.0
+    hooks:
+      - id: pydocstyle

--- a/.pydocstylerc
+++ b/.pydocstylerc
@@ -1,0 +1,5 @@
+[pydocstyle]
+convention = pep257
+add-ignore =
+  D105, # Ignore missing docstring for magic methods.
+  D107 # Ignore missing docstring for __init__ method. Parameters are documented in the class docstring.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,14 @@ Use [Black](https://black.readthedocs.io/) to format code.
 black gnomad
 ```
 
+## Running pydocstyle
+
+Use [pydocstyle](https://www.pydocstyle.org/) to check that docstrings conform to [PEP 257](https://www.python.org/dev/peps/pep-0257/).
+
+```
+pydocstyle gnomad
+```
+
 ## Running tests
 
 Run tests using [pytest](https://docs.pytest.org/en/stable/).

--- a/gnomad/assessment/__init__.py
+++ b/gnomad/assessment/__init__.py
@@ -1,1 +1,3 @@
+# noqa: D104
+
 from gnomad.assessment import sanity_checks

--- a/gnomad/assessment/sanity_checks.py
+++ b/gnomad/assessment/sanity_checks.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Dict, List, Optional
 

--- a/gnomad/assessment/summary_stats.py
+++ b/gnomad/assessment/summary_stats.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Dict, Optional, Set
 

--- a/gnomad/resources/__init__.py
+++ b/gnomad/resources/__init__.py
@@ -1,1 +1,3 @@
+# noqa: D104
+
 from .resource_utils import *

--- a/gnomad/resources/grch37/__init__.py
+++ b/gnomad/resources/grch37/__init__.py
@@ -1,1 +1,3 @@
+# noqa: D104
+
 from .reference_data import *

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 from gnomad.resources.resource_utils import (
     DataException,
     TableResource,

--- a/gnomad/resources/grch37/gnomad_ld.py
+++ b/gnomad/resources/grch37/gnomad_ld.py
@@ -68,12 +68,15 @@ def _ld_scores_path(
 
 
 def ld_matrix(pop: str) -> BlockMatrixResource:
+    """Get resource for the LD matrix for the given population."""
     return BlockMatrixResource(path=_ld_matrix_path("genomes", pop))
 
 
 def ld_index(pop: str) -> TableResource:
+    """Get resource for the LD indices for the given population."""
     return TableResource(path=_ld_index_path("genomes", pop))
 
 
 def ld_scores(pop: str) -> TableResource:
+    """Get resource for the LD scores for the given population."""
     return TableResource(path=_ld_scores_path("genomes", pop))

--- a/gnomad/resources/grch37/gnomad_ld.py
+++ b/gnomad/resources/grch37/gnomad_ld.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 from gnomad.resources.resource_utils import TableResource, BlockMatrixResource
 from gnomad.resources.grch37.gnomad import CURRENT_EXOME_RELEASE, CURRENT_GENOME_RELEASE
 from typing import Optional

--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 from gnomad.resources.resource_utils import (
     MatrixTableResource,
     TableResource,

--- a/gnomad/resources/grch38/__init__.py
+++ b/gnomad/resources/grch38/__init__.py
@@ -1,1 +1,3 @@
+# noqa: D104
+
 from .reference_data import *

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 from gnomad.resources.resource_utils import (
     TableResource,
     VersionedMatrixTableResource,

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 from gnomad.resources.resource_utils import (
     DBSNP_B154_CHR_CONTIG_RECODING,
     TableResource,

--- a/gnomad/resources/import_resources.py
+++ b/gnomad/resources/import_resources.py
@@ -80,6 +80,7 @@ all_resources = {**grch37_resources, **grch38_resources}
 
 
 def main(args):
+    """Import selected resources."""
     for resource_arg in args.resources:
         resource_name, resource = all_resources[resource_arg]
         print(f"Importing {resource_name}...")

--- a/gnomad/resources/import_resources.py
+++ b/gnomad/resources/import_resources.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import itertools
 import textwrap
 from inspect import getmembers

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -371,7 +371,7 @@ class VersionedBlockMatrixResource(BaseVersionedResource, BlockMatrixResource):
         super().__init__(default_version, versions)
 
 
-class DataException(Exception):
+class DataException(Exception):  # noqa: D101
     pass
 
 
@@ -432,4 +432,5 @@ DBSNP_B154_CHR_CONTIG_RECODING = {
 
 
 def import_sites_vcf(**kwargs) -> hl.Table:
+    """Import site-level data from a VCF into a Hail Table."""
     return hl.import_vcf(**kwargs).rows()

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional

--- a/gnomad/sample_qc/__init__.py
+++ b/gnomad/sample_qc/__init__.py
@@ -1,1 +1,3 @@
+# noqa: D104
+
 from gnomad.sample_qc import ancestry, filtering, pipeline, platform, relatedness, sex

--- a/gnomad/sample_qc/ancestry.py
+++ b/gnomad/sample_qc/ancestry.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 import random
 from typing import Any, Counter, List, Optional, Tuple, Union

--- a/gnomad/sample_qc/filtering.py
+++ b/gnomad/sample_qc/filtering.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Dict, Iterable, List, Optional, Tuple
 

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import functools
 import logging
 import operator

--- a/gnomad/sample_qc/platform.py
+++ b/gnomad/sample_qc/platform.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import List, Optional, Tuple
 

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 import random
 from collections import defaultdict

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Tuple
 

--- a/gnomad/utils/__init__.py
+++ b/gnomad/utils/__init__.py
@@ -1,3 +1,5 @@
+# noqa: D104
+
 from gnomad.utils import (
     annotations,
     file_utils,

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import base64
 import gzip
 import logging

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -38,7 +38,7 @@ def write_temp_gcs(
     gcs_path: str,
     overwrite: bool = False,
     temp_path: Optional[str] = None,
-) -> None:
+) -> None:  # noqa: D103
     if not temp_path:
         temp_path = f"/tmp_{uuid.uuid4()}.h"
     t.write(temp_path, overwrite=True)

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import functools
 import logging
 import operator

--- a/gnomad/utils/gen_stats.py
+++ b/gnomad/utils/gen_stats.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 
 import hail as hl

--- a/gnomad/utils/intervals.py
+++ b/gnomad/utils/intervals.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 from typing import List
 
 import hail as hl

--- a/gnomad/utils/liftover.py
+++ b/gnomad/utils/liftover.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Tuple, Union
 

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import json
 import logging
 from typing import Callable, Dict, List, Optional, Union

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -44,7 +44,7 @@ logger.setLevel(logging.INFO)
 if "old_show" not in dir():
     old_show = hl.Table.show
 
-    def new_show(t, n=10, width=140, truncate=40, types=True):
+    def new_show(t, n=10, width=140, truncate=40, types=True):  # noqa: D103
         old_show(t, n, width, truncate, types)
 
     hl.Table.show = new_show
@@ -310,7 +310,7 @@ def plot_hail_hist_cumulative(
 
 def plot_hail_hist_both(
     hist_data: hl.Struct, title: str, normalize: bool = True, log: bool = False
-):
+):  # noqa: D103
     p1 = plot_hail_hist(hist_data, title, log)
     p2 = plot_hail_hist_cumulative(
         hist_data, f"{title} (Cumulative)", normalize, log=log
@@ -320,7 +320,7 @@ def plot_hail_hist_both(
     )
 
 
-def set_font_size(p, font_size: str = "12pt"):
+def set_font_size(p, font_size: str = "12pt"):  # noqa: D103
     p.title.text_font_size = font_size
     p.legend.label_text_font_size = font_size
     p.xaxis.axis_label_text_font_size = font_size
@@ -332,7 +332,7 @@ def set_font_size(p, font_size: str = "12pt"):
     return p
 
 
-def linear_and_log_tabs(plot_func: Callable, **kwargs) -> Tabs:
+def linear_and_log_tabs(plot_func: Callable, **kwargs) -> Tabs:  # noqa: D103
     panels = []
     for axis_type in ["linear", "log"]:
         fig = plot_func(**kwargs, axis_type=axis_type)
@@ -578,7 +578,7 @@ def plot_hail_file_metadata(
         return rows_grid
 
 
-def scale_file_sizes(file_sizes):
+def scale_file_sizes(file_sizes):  # noqa: D103
     min_file_size = min(file_sizes) * 1.1
     total_file_size = sum(file_sizes)
     all_scales = [("T", 1e12), ("G", 1e9), ("M", 1e6), ("K", 1e3), ("", 1e0)]
@@ -594,7 +594,7 @@ def scale_file_sizes(file_sizes):
     return total_file_size, file_sizes, scale
 
 
-def get_rows_data(rows_files):
+def get_rows_data(rows_files):  # noqa: D103
     file_sizes = []
     partition_bounds = []
     parts_file = [x["path"] for x in rows_files if x["path"].endswith("parts")]

--- a/gnomad/utils/reference_genome.py
+++ b/gnomad/utils/reference_genome.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import List, Optional, Union
 

--- a/gnomad/utils/slack.py
+++ b/gnomad/utils/slack.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import os
 import sys
 import time

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Dict, List, Optional, Union
 

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import copy
 import itertools
 import logging

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -339,6 +339,7 @@ def process_consequences(
 def filter_vep_to_canonical_transcripts(
     mt: Union[hl.MatrixTable, hl.Table], vep_root: str = "vep"
 ) -> Union[hl.MatrixTable, hl.Table]:
+    """Filter VEP transcript consequences to those in the canonical transcript."""
     canonical = mt[vep_root].transcript_consequences.filter(
         lambda csq: csq.canonical == 1
     )
@@ -353,6 +354,7 @@ def filter_vep_to_canonical_transcripts(
 def filter_vep_to_synonymous_variants(
     mt: Union[hl.MatrixTable, hl.Table], vep_root: str = "vep"
 ) -> Union[hl.MatrixTable, hl.Table]:
+    """Filter VEP transcript consequences to those with a most severe consequence of synonymous_variant."""
     synonymous = mt[vep_root].transcript_consequences.filter(
         lambda csq: csq.most_severe_consequence == "synonymous_variant"
     )

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import json
 import logging
 import os

--- a/gnomad/variant_qc/__init__.py
+++ b/gnomad/variant_qc/__init__.py
@@ -1,1 +1,3 @@
+# noqa: D104
+
 from gnomad.variant_qc import evaluation, ld, pipeline, random_forest

--- a/gnomad/variant_qc/evaluation.py
+++ b/gnomad/variant_qc/evaluation.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from collections import defaultdict
 from typing import Dict, List, Optional

--- a/gnomad/variant_qc/ld.py
+++ b/gnomad/variant_qc/ld.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import hail as hl
 from gnomad.resources.grch37.gnomad import public_release
 from gnomad.resources.grch37.gnomad_ld import ld_index, ld_matrix

--- a/gnomad/variant_qc/ld.py
+++ b/gnomad/variant_qc/ld.py
@@ -6,7 +6,9 @@ from gnomad.resources.grch37.gnomad_ld import ld_index, ld_matrix
 from hail.linalg import BlockMatrix
 
 
-def get_r_human_readable(pop: str, var1: str, var2: str, ref_genome: str = "GRCh37"):
+def get_r_human_readable(
+    pop: str, var1: str, var2: str, ref_genome: str = "GRCh37"
+):  # noqa: D103
     bm = ld_matrix(pop).bm()
     ht = ld_index(pop).ht()
     chrom, pos, ref, alt = var1.split("-")

--- a/gnomad/variant_qc/pipeline.py
+++ b/gnomad/variant_qc/pipeline.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import Dict, List, Optional, Tuple
 

--- a/gnomad/variant_qc/random_forest.py
+++ b/gnomad/variant_qc/random_forest.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import json
 import logging
 import pprint

--- a/gnomad/variant_qc/training.py
+++ b/gnomad/variant_qc/training.py
@@ -1,3 +1,5 @@
+# noqa: D100
+
 import logging
 from typing import List, Optional, Tuple
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black==19.10b0
 pre-commit==2.10.1
+pydocstyle==6.0.0
 pylint
 pytest==6.2.3


### PR DESCRIPTION
After #367, this adds the remaining changes necessary to successfully run [pydocstyle](https://www.pydocstyle.org/). It adds ignore comments for missing module/package level docstrings and adds or ignores a few missing function docstrings.