### PR TITLE
Add pydocstyle to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,12 @@ jobs:
           pip install wheel
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      - name: Run Pylint
-        run: ./lint --disable=W
       - name: Check formatting
         run: black --check gnomad tests
+      - name: Check docstrings
+        run: pydocstyle gnomad
+      - name: Run Pylint
+        run: ./lint --disable=W
       - name: Run tests
         run: python -m pytest
   docs:


### PR DESCRIPTION
Now that both #367 and #368 are merged and pydocstyle runs successfully, it can be added to PR checks. This ensures that docstrings follow conventions even if a contributor isn't using the pre-commit hook added in #368.

This also reorders checks so that fast checks (Black and pydocstyle) are run before slower ones (Pylint and pytest). This avoids running the slow checks on PRs that require changes to formatting/docstrings.