### PR TITLE
Only ignore Pylint warnings that are present in existing code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check docstrings
         run: pydocstyle gnomad
       - name: Run Pylint
-        run: ./lint --disable=W --enable=logging-not-lazy,logging-format-interpolation,logging-fstring-interpolation
+        run: ./lint
       - name: Run tests
         run: python -m pytest
   docs:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,23 @@
 [MESSAGES CONTROL]
 
 disable=
-  unused-wildcard-import,
+  # Ignore refactor and convention categories
   R,
-  C
+  C,
+  # Allow TODO and FIXME comments
+  fixme,
+  # Ignore unnecessary-lambda because it has many false positives from hl.ArrayExpression.map, etc.
+  unnecessary-lambda,
+  # Warnings present in existing code. These should be fixed and removed from this list.
+  cell-var-from-loop,
+  dangerous-default-value,
+  f-string-without-interpolation,
+  isinstance-second-argument-not-valid-type,
+  protected-access,
+  raise-missing-from,
+  redefined-builtin,
+  redefined-outer-name,
+  unused-import,
+  unnecessary-pass,
+  unused-variable,
+  unused-wildcard-import


### PR DESCRIPTION
Currently, in PR checks, we disable all Pylint warnings and re-enable a few.

https://github.com/broadinstitute/gnomad_methods/blob/9ce5fdbf5a07e80ea96dc2acb6b5c3943c8f9c97/.github/workflows/ci.yml#L34-L35

This changes Pylint configuration to ignore only the specific warnings that are present in existing code.