### PR TITLE
Run pydocstyle on tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check formatting
         run: black --check gnomad tests
       - name: Check docstrings
-        run: pydocstyle gnomad
+        run: pydocstyle gnomad tests
       - name: Run Pylint
         run: ./lint
       - name: Run tests

--- a/.pydocstylerc
+++ b/.pydocstylerc
@@ -1,5 +1,6 @@
 [pydocstyle]
 convention = pep257
+match = .*\.py
 add-ignore =
   D105, # Ignore missing docstring for magic methods.
   D107 # Ignore missing docstring for __init__ method. Parameters are documented in the class docstring.

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -1,11 +1,16 @@
+"""Tests for resource classes."""
+
 from unittest.mock import patch
 
 from gnomad.resources import resource_utils
 
 
 class TestTableResource:
+    """Tests for TableResource."""
+
     @patch("hail.read_table")
     def test_read_table(self, read_table):
+        """Test that Table is read from path."""
         resource = resource_utils.TableResource("gs://gnomad-public/table.ht")
 
         ds = resource.ht()
@@ -14,8 +19,11 @@ class TestTableResource:
 
 
 class TestMatrixTableResource:
+    """Tests for MatrixTableResource."""
+
     @patch("hail.read_matrix_table")
     def test_read_matrix_table(self, read_matrix_table):
+        """Test that MatrixTable is read from path."""
         resource = resource_utils.MatrixTableResource(
             "gs://gnomad-public/matrix_table.mt"
         )
@@ -26,8 +34,11 @@ class TestMatrixTableResource:
 
 
 class TestPedigreeResource:
+    """Tests for PedigreeResource."""
+
     @patch("hail.Pedigree.read")
     def test_read_pedigree(self, read_pedigree):
+        """Test that Pedigree is read from path."""
         resource = resource_utils.PedigreeResource("gs://gnomad-public/pedigree.ped")
 
         ds = resource.pedigree()
@@ -38,6 +49,7 @@ class TestPedigreeResource:
 
     @patch("hail.import_fam")
     def test_read_fam(self, import_fam):
+        """Test that Table is imported from path."""
         resource = resource_utils.PedigreeResource("gs://gnomad-public/pedigree.fam")
 
         ds = resource.ht()
@@ -47,8 +59,11 @@ class TestPedigreeResource:
 
 
 class TestBlockMatrixResource:
+    """Tests for BlockMatrixResource."""
+
     @patch("hail.linalg.BlockMatrix.read")
     def test_read_block_matrix(self, read_block_matrix):
+        """Test that BlockMatrix is read from path."""
         resource = resource_utils.BlockMatrixResource(
             "gs://gnomad-public/block_matrix.bm"
         )


### PR DESCRIPTION
Currently, PR checks run pydocstyle on files in the `gnomad` directory.

https://github.com/broadinstitute/gnomad_methods/blob/b5f83b81d42d95d3c1de3bd1b744b363690ac3ac/.github/workflows/ci.yml#L32-L33

Pre-commit hooks, however, run it on all Python files that changed in the commit.

https://github.com/broadinstitute/gnomad_methods/blob/b5f83b81d42d95d3c1de3bd1b744b363690ac3ac/.pre-commit-config.yaml#L15-L18

Thus, it's currently possible for a change to pass PR checks, get merged, and then cause pre-commit hooks to fail when it is pulled locally. This change brings PR checks and pre-commit hooks closer in line by running pydocstyle on tests in PR checks.