### PR TITLE
Support multiple resource buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added function `make_faf_index_dict` to create a look-up Dictionary for entries contained in the filter allele frequency annotation array [(#349)](https://github.com/broadinstitute/gnomad_methods/pull/349/files)
 * Added function `make_freq_index_dict` to create a look-up Dictionary for entries contained in the frequency annotation array [(#349)](https://github.com/broadinstitute/gnomad_methods/pull/349/files)
 * VersionedResource objects are no longer subclasses of BaseResource [(#359)](https://github.com/broadinstitute/gnomad_methods/pull/359)
+* gnomAD resources can now be imported from different sources [(#373)](https://github.com/broadinstitute/gnomad_methods/pull/373)
 
 ## Version 0.5.0 - April 22nd, 2021
 

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -8,6 +8,7 @@ class GnomadPublicResourceSource(Enum):
     """Sources for public gnomAD resources."""
 
     GNOMAD = "gnomAD"
+    GOOGLE_CLOUD_PUBLIC_DATASETS = "Google Cloud Public Datasets"
 
 
 DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE = GnomadPublicResourceSource.GNOMAD

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -1,7 +1,7 @@
 """Configuration for loading resources."""
 
-import typing
 from enum import Enum
+from typing import Union
 
 
 class GnomadPublicResourceSource(Enum):
@@ -17,12 +17,12 @@ DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE = GnomadPublicResourceSource.GNOMAD
 class _GnomadPublicResourceConfiguration:
     """Configuration for public gnomAD resources."""
 
-    __source: typing.Union[
+    __source: Union[
         GnomadPublicResourceSource, str
     ] = DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE
 
     @property
-    def source(self) -> typing.Union[GnomadPublicResourceSource, str]:
+    def source(self) -> Union[GnomadPublicResourceSource, str]:
         """
         Get the source for public gnomAD resource files.
 
@@ -33,7 +33,7 @@ class _GnomadPublicResourceConfiguration:
         return self.__source
 
     @source.setter
-    def source(self, source: typing.Union[GnomadPublicResourceSource, str]) -> None:
+    def source(self, source: Union[GnomadPublicResourceSource, str]) -> None:
         """
         Set the default source for resource files.
 

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -1,0 +1,46 @@
+"""Configuration for loading resources."""
+
+import typing
+from enum import Enum
+
+
+class GnomadPublicResourceSource(Enum):
+    """Sources for public gnomAD resources."""
+
+    GNOMAD = "gnomAD"
+
+
+DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE = GnomadPublicResourceSource.GNOMAD
+
+
+class _GnomadPublicResourceConfiguration:
+    """Configuration for public gnomAD resources."""
+
+    __source: typing.Union[
+        GnomadPublicResourceSource, str
+    ] = DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE
+
+    @property
+    def source(self) -> typing.Union[GnomadPublicResourceSource, str]:
+        """
+        Get the source for public gnomAD resource files.
+
+        This is used to determine which URLs gnomAD resources will be loaded from.
+
+        :returns: Source name or path to root of resources directory
+        """
+        return self.__source
+
+    @source.setter
+    def source(self, source: typing.Union[GnomadPublicResourceSource, str]) -> None:
+        """
+        Set the default source for resource files.
+
+        This is used to determine which URLs gnomAD resources will be loaded from.
+
+        :param source: Source name or path to root of resources directory
+        """
+        self.__source = source
+
+
+gnomad_public_resource_configuration = _GnomadPublicResourceConfiguration()

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -2,7 +2,7 @@
 
 from gnomad.resources.resource_utils import (
     DataException,
-    TableResource,
+    GnomadPublicTableResource,
     VersionedTableResource,
 )
 
@@ -124,7 +124,9 @@ def public_release(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_release_ht_path(data_type, release))
+            release: GnomadPublicTableResource(
+                path=_public_release_ht_path(data_type, release)
+            )
             for release in releases
         },
     )
@@ -150,7 +152,9 @@ def coverage(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_coverage_ht_path(data_type, release))
+            release: GnomadPublicTableResource(
+                path=_public_coverage_ht_path(data_type, release)
+            )
             for release in releases
         },
     )
@@ -176,13 +180,15 @@ def liftover(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_liftover_data_path(data_type, release))
+            release: GnomadPublicTableResource(
+                path=_liftover_data_path(data_type, release)
+            )
             for release in releases
         },
     )
 
 
-def public_pca_loadings(subpop: str = "") -> TableResource:
+def public_pca_loadings(subpop: str = "") -> GnomadPublicTableResource:
     """
     Return the TableResource containing sites and loadings from population PCA.
 
@@ -194,7 +200,7 @@ def public_pca_loadings(subpop: str = "") -> TableResource:
             'Available subpops are "eas" or "nfe", default value "" for global'
         )
 
-    return TableResource(path=_public_pca_ht_path(subpop))
+    return GnomadPublicTableResource(path=_public_pca_ht_path(subpop))
 
 
 def release_vcf_path(data_type: str, version: str, contig: str) -> str:

--- a/gnomad/resources/grch37/gnomad_ld.py
+++ b/gnomad/resources/grch37/gnomad_ld.py
@@ -1,6 +1,9 @@
 # noqa: D100
 
-from gnomad.resources.resource_utils import TableResource, BlockMatrixResource
+from gnomad.resources.resource_utils import (
+    GnomadPublicTableResource,
+    GnomadPublicBlockMatrixResource,
+)
 from gnomad.resources.grch37.gnomad import CURRENT_EXOME_RELEASE, CURRENT_GENOME_RELEASE
 from typing import Optional
 
@@ -67,16 +70,16 @@ def _ld_scores_path(
     return f'gs://gnomad-public-requester-pays/release/{version}/ld/scores/gnomad.{data_type}.r{version}.{pop}.{"adj." if adj else ""}ld_scores.ht'
 
 
-def ld_matrix(pop: str) -> BlockMatrixResource:
+def ld_matrix(pop: str) -> GnomadPublicBlockMatrixResource:
     """Get resource for the LD matrix for the given population."""
-    return BlockMatrixResource(path=_ld_matrix_path("genomes", pop))
+    return GnomadPublicBlockMatrixResource(path=_ld_matrix_path("genomes", pop))
 
 
-def ld_index(pop: str) -> TableResource:
+def ld_index(pop: str) -> GnomadPublicTableResource:
     """Get resource for the LD indices for the given population."""
-    return TableResource(path=_ld_index_path("genomes", pop))
+    return GnomadPublicTableResource(path=_ld_index_path("genomes", pop))
 
 
-def ld_scores(pop: str) -> TableResource:
+def ld_scores(pop: str) -> GnomadPublicTableResource:
     """Get resource for the LD scores for the given population."""
-    return TableResource(path=_ld_scores_path("genomes", pop))
+    return GnomadPublicTableResource(path=_ld_scores_path("genomes", pop))

--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -1,15 +1,15 @@
 # noqa: D100
 
 from gnomad.resources.resource_utils import (
-    MatrixTableResource,
-    TableResource,
+    GnomadPublicMatrixTableResource,
+    GnomadPublicTableResource,
     VersionedMatrixTableResource,
     VersionedTableResource,
     import_sites_vcf,
 )
 import hail as hl
 
-na12878_giab = MatrixTableResource(
+na12878_giab = GnomadPublicMatrixTableResource(
     path="gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.mt",
     import_func=hl.import_vcf,
     import_args={
@@ -20,7 +20,7 @@ na12878_giab = MatrixTableResource(
     },
 )
 
-hapmap = TableResource(
+hapmap = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/hapmap/hapmap_3.3.b37.ht",
     import_func=import_sites_vcf,
     import_args={
@@ -31,7 +31,7 @@ hapmap = TableResource(
     },
 )
 
-kgp_omni = TableResource(
+kgp_omni = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/kgp/1000G_omni2.5.b37.ht",
     import_func=import_sites_vcf,
     import_args={
@@ -42,7 +42,7 @@ kgp_omni = TableResource(
     },
 )
 
-mills = TableResource(
+mills = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.ht",
     import_func=import_sites_vcf,
     import_args={
@@ -53,7 +53,7 @@ mills = TableResource(
     },
 )
 
-syndip = MatrixTableResource(
+syndip = GnomadPublicMatrixTableResource(
     path="gs://gnomad-public/resources/grch37/syndip/hybrid.m37m.mt",
     import_func=hl.import_vcf,
     import_args={
@@ -67,7 +67,7 @@ syndip = MatrixTableResource(
 vep_context = VersionedTableResource(
     default_version="85",
     versions={
-        "85": TableResource(
+        "85": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/context/grch37_context_vep_annotated.ht",
         )
     },
@@ -76,7 +76,7 @@ vep_context = VersionedTableResource(
 dbsnp = VersionedTableResource(
     default_version="20180423",
     versions={
-        "20180423": TableResource(
+        "20180423": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch37/dbsnp/All_20180423.ht",
             import_func=import_sites_vcf,
             import_args={
@@ -93,7 +93,7 @@ dbsnp = VersionedTableResource(
 clinvar = VersionedTableResource(
     default_version="20181028",
     versions={
-        "20181028": TableResource(
+        "20181028": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch37/clinvar/clinvar_20181028.vep.ht",
             import_func=import_sites_vcf,
             import_args={
@@ -110,7 +110,7 @@ clinvar = VersionedTableResource(
 kgp_phase_3 = VersionedMatrixTableResource(
     default_version="phase_3_split",
     versions={
-        "phase_3_split": MatrixTableResource(
+        "phase_3_split": GnomadPublicMatrixTableResource(
             path="gs://gnomad-public/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.split.mt",
             import_func=hl.import_vcf,
             import_args={
@@ -121,7 +121,7 @@ kgp_phase_3 = VersionedMatrixTableResource(
                 "reference_genome": "GRCh37",
             },
         ),
-        "phase_3": MatrixTableResource(
+        "phase_3": GnomadPublicMatrixTableResource(
             path="gs://gnomad-public/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.mt",
             import_func=hl.import_vcf,
             import_args={
@@ -138,7 +138,7 @@ kgp_phase_3 = VersionedMatrixTableResource(
 kgp = VersionedTableResource(
     default_version="phase_1_hc",
     versions={
-        "phase_1_hc": TableResource(
+        "phase_1_hc": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.ht",
             import_func=import_sites_vcf,
             import_args={
@@ -152,13 +152,15 @@ kgp = VersionedTableResource(
     },
 )
 
-cpg_sites = TableResource(path="gs://gnomad-public/resources/grch37/cpg_sites/cpg.ht")
+cpg_sites = GnomadPublicTableResource(
+    path="gs://gnomad-public/resources/grch37/cpg_sites/cpg.ht"
+)
 
-methylation_sites = TableResource(
+methylation_sites = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/methylation_sites/methylation.ht"
 )
 
-lcr_intervals = TableResource(
+lcr_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -167,7 +169,7 @@ lcr_intervals = TableResource(
     },
 )
 
-decoy_intervals = TableResource(
+decoy_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.ht",
     import_func=hl.import_bed,
     import_args={
@@ -176,7 +178,7 @@ decoy_intervals = TableResource(
     },
 )
 
-purcell_5k_intervals = TableResource(
+purcell_5k_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/purcell_5k_intervals/purcell5k.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -185,7 +187,7 @@ purcell_5k_intervals = TableResource(
     },
 )
 
-seg_dup_intervals = TableResource(
+seg_dup_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.ht",
     import_func=hl.import_bed,
     import_args={
@@ -194,7 +196,7 @@ seg_dup_intervals = TableResource(
     },
 )
 
-exome_hc_intervals = TableResource(
+exome_hc_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -203,7 +205,7 @@ exome_hc_intervals = TableResource(
     },
 )
 
-high_coverage_intervals = TableResource(
+high_coverage_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/broad_intervals/high_coverage.auto.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -212,7 +214,7 @@ high_coverage_intervals = TableResource(
     },
 )
 
-exome_calling_intervals = TableResource(
+exome_calling_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -221,7 +223,7 @@ exome_calling_intervals = TableResource(
     },
 )
 
-exome_evaluation_intervals = TableResource(
+exome_evaluation_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -230,7 +232,7 @@ exome_evaluation_intervals = TableResource(
     },
 )
 
-genome_evaluation_intervals = TableResource(
+genome_evaluation_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -239,7 +241,7 @@ genome_evaluation_intervals = TableResource(
     },
 )
 
-na12878_hc_intervals = TableResource(
+na12878_hc_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_intervals.ht",
     import_func=hl.import_bed,
     import_args={
@@ -248,7 +250,7 @@ na12878_hc_intervals = TableResource(
     },
 )
 
-syndip_hc_intervals = TableResource(
+syndip_hc_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch37/syndip/syndip_highconf_genome_intervals.ht",
     import_func=hl.import_bed,
     import_args={

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -1,9 +1,9 @@
 # noqa: D100
 
 from gnomad.resources.resource_utils import (
-    TableResource,
+    GnomadPublicTableResource,
     VersionedMatrixTableResource,
-    MatrixTableResource,
+    GnomadPublicMatrixTableResource,
     VersionedTableResource,
     DataException,
 )
@@ -147,7 +147,7 @@ DOWNSAMPLINGS = [
 gnomad_syndip = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
-        "3.0": MatrixTableResource(
+        "3.0": GnomadPublicMatrixTableResource(
             path="gs://gnomad-public/truth-sets/hail-0.2/gnomad_v3_syndip.b38.mt"
         )
     },
@@ -156,7 +156,7 @@ gnomad_syndip = VersionedMatrixTableResource(
 na12878 = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
-        "3.0": MatrixTableResource(
+        "3.0": GnomadPublicMatrixTableResource(
             path="gs://gnomad-public/truth-sets/hail-0.2/gnomad_v3_na12878.mt"
         )
     },
@@ -209,7 +209,9 @@ def public_release(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_release_ht_path(data_type, release))
+            release: GnomadPublicTableResource(
+                path=_public_release_ht_path(data_type, release)
+            )
             for release in releases
         },
     )
@@ -237,7 +239,9 @@ def coverage(data_type: str) -> VersionedTableResource:
     return VersionedTableResource(
         current_release,
         {
-            release: TableResource(path=_public_coverage_ht_path(data_type, release))
+            release: GnomadPublicTableResource(
+                path=_public_coverage_ht_path(data_type, release)
+            )
             for release in releases
         },
     )

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -2,8 +2,8 @@
 
 from gnomad.resources.resource_utils import (
     GnomadPublicTableResource,
-    VersionedMatrixTableResource,
     GnomadPublicMatrixTableResource,
+    VersionedMatrixTableResource,
     VersionedTableResource,
     DataException,
 )

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -3,8 +3,8 @@
 from gnomad.resources.resource_utils import (
     DBSNP_B154_CHR_CONTIG_RECODING,
     GnomadPublicTableResource,
-    VersionedTableResource,
     GnomadPublicMatrixTableResource,
+    VersionedTableResource,
     VersionedMatrixTableResource,
     import_sites_vcf,
     NO_CHR_TO_CHR_CONTIG_RECODING,

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -2,9 +2,9 @@
 
 from gnomad.resources.resource_utils import (
     DBSNP_B154_CHR_CONTIG_RECODING,
-    TableResource,
+    GnomadPublicTableResource,
     VersionedTableResource,
-    MatrixTableResource,
+    GnomadPublicMatrixTableResource,
     VersionedMatrixTableResource,
     import_sites_vcf,
     NO_CHR_TO_CHR_CONTIG_RECODING,
@@ -57,7 +57,7 @@ def _import_dbsnp(**kwargs) -> hl.Table:
 
 
 # Resources with no versioning needed
-purcell_5k_intervals = TableResource(
+purcell_5k_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/purcell_5k_intervals/purcell5k.ht",
     import_func=_import_purcell_5k,
     import_args={
@@ -65,7 +65,7 @@ purcell_5k_intervals = TableResource(
     },
 )
 
-na12878_giab = MatrixTableResource(
+na12878_giab = GnomadPublicMatrixTableResource(
     path="gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.mt",
     import_func=hl.import_vcf,
     import_args={
@@ -76,7 +76,7 @@ na12878_giab = MatrixTableResource(
     },
 )
 
-na12878_giab_hc_intervals = TableResource(
+na12878_giab_hc_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7_hc_regions.ht",
     import_func=hl.import_bed,
     import_args={
@@ -90,7 +90,7 @@ na12878_giab_hc_intervals = TableResource(
 vep_context = VersionedTableResource(
     default_version="95",
     versions={
-        "95": TableResource(
+        "95": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/context/grch38_context_vep_annotated.ht",
         )
     },
@@ -99,7 +99,7 @@ vep_context = VersionedTableResource(
 syndip = VersionedMatrixTableResource(
     default_version="20180222",
     versions={
-        "20180222": MatrixTableResource(
+        "20180222": GnomadPublicMatrixTableResource(
             path="gs://gnomad-public/resources/grch38/syndip/syndip.b38_20180222.mt",
             import_func=hl.import_vcf,
             import_args={
@@ -115,7 +115,7 @@ syndip = VersionedMatrixTableResource(
 syndip_hc_intervals = VersionedTableResource(
     default_version="20180222",
     versions={
-        "20180222": TableResource(
+        "20180222": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch38/syndip/syndip_b38_20180222_hc_regions.ht",
             import_func=hl.import_bed,
             import_args={
@@ -131,7 +131,7 @@ syndip_hc_intervals = VersionedTableResource(
 clinvar = VersionedTableResource(
     default_version="20190923",
     versions={
-        "20190923": TableResource(
+        "20190923": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch38/clinvar/clinvar_20190923.ht",
             import_func=_import_clinvar,
             import_args={
@@ -149,7 +149,7 @@ clinvar = VersionedTableResource(
 dbsnp = VersionedTableResource(
     default_version="b154",
     versions={
-        "b154": TableResource(
+        "b154": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_20200514.ht",
             import_func=_import_dbsnp,
             import_args={
@@ -162,7 +162,7 @@ dbsnp = VersionedTableResource(
                 "reference_genome": "GRCh38",
             },
         ),
-        "b151": TableResource(
+        "b151": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.ht",
             import_func=import_sites_vcf,
             import_args={
@@ -178,7 +178,7 @@ dbsnp = VersionedTableResource(
     },
 )
 
-hapmap = TableResource(
+hapmap = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/hapmap/hapmap_3.3.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
@@ -188,7 +188,7 @@ hapmap = TableResource(
     },
 )
 
-kgp_omni = TableResource(
+kgp_omni = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/kgp/1000G_omni2.5.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
@@ -201,7 +201,7 @@ kgp_omni = TableResource(
 kgp = VersionedTableResource(
     default_version="phase_1_hc",
     versions={
-        "phase_1_hc": TableResource(
+        "phase_1_hc": GnomadPublicTableResource(
             path="gs://gnomad-public/resources/grch38/kgp/1000G_phase1.snps.high_confidence.hg38.ht",
             import_func=import_sites_vcf,
             import_args={
@@ -213,7 +213,7 @@ kgp = VersionedTableResource(
     },
 )
 
-mills = TableResource(
+mills = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/mills/Mills_and_1000G_gold_standard.indels.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
@@ -223,7 +223,7 @@ mills = TableResource(
     },
 )
 
-lcr_intervals = TableResource(
+lcr_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/lcr_intervals/LCRFromHengHg38.ht",
     import_func=hl.import_locus_intervals,
     import_args={
@@ -233,7 +233,7 @@ lcr_intervals = TableResource(
     },
 )
 
-seg_dup_intervals = TableResource(
+seg_dup_intervals = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/seg_dup_intervals/GRCh38_segdups.ht",
     import_func=hl.import_bed,
     import_args={
@@ -242,7 +242,7 @@ seg_dup_intervals = TableResource(
     },
 )
 
-telomeres_and_centromeres = TableResource(
+telomeres_and_centromeres = GnomadPublicTableResource(
     path="gs://gnomad-public/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht",
     import_func=hl.import_bed,
     import_args={

--- a/gnomad/resources/import_resources.py
+++ b/gnomad/resources/import_resources.py
@@ -1,13 +1,18 @@
 # noqa: D100
 
+import argparse
 import itertools
 import textwrap
 from inspect import getmembers
 from typing import Dict, Tuple, Optional
+
+from gnomad.resources.config import (
+    GnomadPublicResourceSource,
+    gnomad_public_resource_configuration,
+)
 from gnomad.resources.resource_utils import BaseResource, BaseVersionedResource
 import gnomad.resources.grch37 as grch37
 import gnomad.resources.grch38 as grch38
-import argparse
 
 
 # Generate a dictionary of resource available for import for a given genome build
@@ -83,6 +88,8 @@ all_resources = {**grch37_resources, **grch38_resources}
 
 def main(args):
     """Import selected resources."""
+    gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GNOMAD
+
     for resource_arg in args.resources:
         resource_name, resource = all_resources[resource_arg]
         print(f"Importing {resource_name}...")

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -17,6 +17,9 @@ from gnomad.resources.config import (
 logger = logging.getLogger("gnomad.resources")
 
 
+GNOMAD_PUBLIC_BUCKETS = ("gnomad-public", "gnomad-public-requester-pays")
+
+
 # Resource classes
 class BaseResource(ABC):
     """
@@ -369,9 +372,6 @@ class VersionedBlockMatrixResource(BaseVersionedResource, BlockMatrixResource):
 
     def __init__(self, default_version: str, versions: Dict[str, BlockMatrixResource]):
         super().__init__(default_version, versions)
-
-
-GNOMAD_PUBLIC_BUCKETS = ("gnomad-public", "gnomad-public-requester-pays")
 
 
 class GnomadPublicResource(BaseResource, ABC):

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -8,7 +8,10 @@ from typing import Any, Callable, Dict, List, Optional
 import hail as hl
 from hail.linalg import BlockMatrix
 
-from .config import GnomadPublicResourceSource, gnomad_public_resource_configuration
+from gnomad.resources.config import (
+    GnomadPublicResourceSource,
+    gnomad_public_resource_configuration,
+)
 
 
 logger = logging.getLogger("gnomad.resources")

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -399,7 +399,7 @@ class GnomadPublicResource(BaseResource, ABC):
 
     def _set_path(self, path):
         if not any(
-            path.startswith(f"gs://{bucket}") for bucket in GNOMAD_PUBLIC_BUCKETS
+            path.startswith(f"gs://{bucket}/") for bucket in GNOMAD_PUBLIC_BUCKETS
         ):
             raise ValueError(
                 f"GnomadPublicResource requires a path to a file in one of the public gnomAD buckets ({', '.join(GNOMAD_PUBLIC_BUCKETS)})"

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -387,6 +387,9 @@ class GnomadPublicResource(BaseResource, ABC):
             self._path,
         )
 
+        if resource_source == GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS:
+            return f"gs://gcp-public-data--gnomad{relative_path}"
+
         return f"{resource_source.rstrip('/')}{relative_path}"
 
     def _set_path(self, path):

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -390,7 +390,9 @@ class GnomadPublicResource(BaseResource, ABC):
         if resource_source == GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS:
             return f"gs://gcp-public-data--gnomad{relative_path}"
 
-        return f"{resource_source.rstrip('/')}{relative_path}"
+        return (
+            f"{resource_source.rstrip('/')}{relative_path}"  # pylint: disable=no-member
+        )
 
     def _set_path(self, path):
         if not any(

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -51,10 +51,23 @@ class BaseResource(ABC):
             )
 
     def __repr__(self):
-        attr_str = [f"path={self.path}"]
+        attr_str = [f"path={self._path}"]
         if self.import_args is not None:
             attr_str.append(f"import_args={self.import_args}")
         return f'{self.__class__.__name__}({",".join(attr_str)})'
+
+    def _get_path(self):
+        return self._path
+
+    def _set_path(self, path):
+        self._path = path  # pylint: disable=attribute-defined-outside-init
+
+    # Defining path property this way instead of using a decorator allows _get_path and _set_path
+    # to be overridden in subclasses without having to reconfigure the property.
+    path = property(
+        fget=lambda self: self._get_path(),
+        fset=lambda self, path: self._set_path(path),
+    )
 
     @abstractmethod
     def import_resource(self, overwrite: bool = True, **kwargs) -> None:

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -384,7 +384,7 @@ class GnomadPublicResource(BaseResource, ABC):
 
         relative_path = reduce(
             lambda path, bucket: path[5 + len(bucket) :]
-            if path.startswith(f"gs://{bucket}")
+            if path.startswith(f"gs://{bucket}/")
             else path,
             GNOMAD_PUBLIC_BUCKETS,
             self._path,

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -364,6 +364,39 @@ class VersionedBlockMatrixResource(BaseVersionedResource, BlockMatrixResource):
         super().__init__(default_version, versions)
 
 
+GNOMAD_PUBLIC_BUCKETS = ("gnomad-public", "gnomad-public-requester-pays")
+
+
+class GnomadPublicResource(BaseResource, ABC):
+    """Base class for the gnomAD project's public resources."""
+
+    def _set_path(self, path):
+        if not any(
+            path.startswith(f"gs://{bucket}") for bucket in GNOMAD_PUBLIC_BUCKETS
+        ):
+            raise ValueError(
+                f"GnomadPublicResource requires a path to a file in one of the public gnomAD buckets ({', '.join(GNOMAD_PUBLIC_BUCKETS)})"
+            )
+
+        return super()._set_path(path)
+
+
+class GnomadPublicTableResource(TableResource, GnomadPublicResource):
+    """Resource class for a public Hail Table published by the gnomAD project."""
+
+
+class GnomadPublicMatrixTableResource(MatrixTableResource, GnomadPublicResource):
+    """Resource class for a public Hail MatrixTable published by the gnomAD project."""
+
+
+class GnomadPublicPedigreeResource(PedigreeResource, GnomadPublicResource):
+    """Resource class for a public pedigree published by the gnomAD project."""
+
+
+class GnomadPublicBlockMatrixResource(BlockMatrixResource, GnomadPublicResource):
+    """Resource class for a public Hail BlockMatrix published by the gnomAD project."""
+
+
 class DataException(Exception):  # noqa: D101
     pass
 

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -1,5 +1,6 @@
 """Tests for resource classes."""
 
+from typing import List, Tuple, Union
 from unittest.mock import patch
 
 import pytest
@@ -79,7 +80,9 @@ class TestBlockMatrixResource:
         assert ds == read_block_matrix.return_value
 
 
-def gnomad_public_resource_test_parameters(path: str):
+def gnomad_public_resource_test_parameters(
+    path: str,
+) -> List[Tuple[str, Union[GnomadPublicResourceSource, str], str]]:
     """
     Get parameters for gnomAD public resource tests.
 

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -113,3 +113,145 @@ class TestGnomadPublicTableResource:
 
         resource.ht()
         read_table.assert_called_with(expected_read_path)
+
+
+class TestGnomadPublicMatrixTableResource:
+    """Tests for GnomadPublicMatrixTableResource."""
+
+    @pytest.mark.parametrize(
+        "resource_path,source,expected_read_path",
+        [
+            (
+                "gs://gnomad-public/matrix_table.mt",
+                GnomadPublicResourceSource.GNOMAD,
+                "gs://gnomad-public/matrix_table.mt",
+            ),
+            (
+                "gs://gnomad-public/matrix_table.mt",
+                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+                "gs://gcp-public-data--gnomad/matrix_table.mt",
+            ),
+            (
+                "gs://gnomad-public/matrix_table.mt",
+                "gs://my-bucket/gnomad-resources",
+                "gs://my-bucket/gnomad-resources/matrix_table.mt",
+            ),
+        ],
+    )
+    @patch("hail.read_matrix_table")
+    def test_read_gnomad_public_matrix_table_resource(
+        self, read_matrix_table, resource_path, source, expected_read_path
+    ):
+        """Test that MatrixTable can be read from different sources."""
+        resource = resource_utils.GnomadPublicMatrixTableResource(resource_path)
+
+        gnomad_public_resource_configuration.source = source
+
+        resource.mt()
+        read_matrix_table.assert_called_with(expected_read_path)
+
+
+class TestGnomadPublicPedigreeResource:
+    """Tests for GnomadPublicPedigreeResource."""
+
+    @pytest.mark.parametrize(
+        "resource_path,source,expected_read_path",
+        [
+            (
+                "gs://gnomad-public/pedigree.ped",
+                GnomadPublicResourceSource.GNOMAD,
+                "gs://gnomad-public/pedigree.ped",
+            ),
+            (
+                "gs://gnomad-public/pedigree.ped",
+                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+                "gs://gcp-public-data--gnomad/pedigree.ped",
+            ),
+            (
+                "gs://gnomad-public/pedigree.ped",
+                "gs://my-bucket/gnomad-resources",
+                "gs://my-bucket/gnomad-resources/pedigree.ped",
+            ),
+        ],
+    )
+    @patch("hail.Pedigree.read")
+    def test_read_gnomad_public_pedigree_resource(
+        self, read_pedigree, resource_path, source, expected_read_path
+    ):
+        """Test that Pedigree can be read from different sources."""
+        resource = resource_utils.GnomadPublicPedigreeResource(resource_path)
+
+        gnomad_public_resource_configuration.source = source
+
+        resource.pedigree()
+        read_pedigree.assert_called()
+        assert read_pedigree.call_args[0][0] == expected_read_path
+
+    @pytest.mark.parametrize(
+        "resource_path,source,expected_read_path",
+        [
+            (
+                "gs://gnomad-public/pedigree.fam",
+                GnomadPublicResourceSource.GNOMAD,
+                "gs://gnomad-public/pedigree.fam",
+            ),
+            (
+                "gs://gnomad-public/pedigree.fam",
+                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+                "gs://gcp-public-data--gnomad/pedigree.fam",
+            ),
+            (
+                "gs://gnomad-public/pedigree.fam",
+                "gs://my-bucket/gnomad-resources",
+                "gs://my-bucket/gnomad-resources/pedigree.fam",
+            ),
+        ],
+    )
+    @patch("hail.import_fam")
+    def test_import_gnomad_public_pedigree_resource(
+        self, import_fam, resource_path, source, expected_read_path
+    ):
+        """Test that pedigree can be imported from different sources."""
+        resource = resource_utils.GnomadPublicPedigreeResource(resource_path)
+
+        gnomad_public_resource_configuration.source = source
+
+        resource.ht()
+        import_fam.assert_called()
+        assert import_fam.call_args[0][0] == expected_read_path
+
+
+class TestGnomadPublicBlockMatrixResource:
+    """Tests for GnomadPublicBlockMatrixResource."""
+
+    @pytest.mark.parametrize(
+        "resource_path,source,expected_read_path",
+        [
+            (
+                "gs://gnomad-public/block_matrix.bm",
+                GnomadPublicResourceSource.GNOMAD,
+                "gs://gnomad-public/block_matrix.bm",
+            ),
+            (
+                "gs://gnomad-public/block_matrix.bm",
+                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+                "gs://gcp-public-data--gnomad/block_matrix.bm",
+            ),
+            (
+                "gs://gnomad-public/block_matrix.bm",
+                "gs://my-bucket/gnomad-resources",
+                "gs://my-bucket/gnomad-resources/block_matrix.bm",
+            ),
+        ],
+    )
+    @patch("hail.linalg.BlockMatrix.read")
+    def test_read_gnomad_public_block_matrix_resource(
+        self, read_block_matrix, resource_path, source, expected_read_path
+    ):
+        """Test that BlockMatrix can be read from different sources."""
+        resource = resource_utils.GnomadPublicBlockMatrixResource(resource_path)
+
+        gnomad_public_resource_configuration.source = source
+
+        resource.bm()
+        read_block_matrix.assert_called_with(expected_read_path)

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -79,28 +79,37 @@ class TestBlockMatrixResource:
         assert ds == read_block_matrix.return_value
 
 
+def gnomad_public_resource_test_parameters(path: str):
+    """
+    Get parameters for gnomAD public resource tests.
+
+    :param path: Path to resource file inside gnomAD bucket.
+    """
+    return [
+        (
+            f"gs://gnomad-public{path}",
+            GnomadPublicResourceSource.GNOMAD,
+            f"gs://gnomad-public{path}",
+        ),
+        (
+            f"gs://gnomad-public{path}",
+            GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+            f"gs://gcp-public-data--gnomad{path}",
+        ),
+        (
+            f"gs://gnomad-public{path}",
+            "gs://my-bucket/gnomad-resources",
+            f"gs://my-bucket/gnomad-resources{path}",
+        ),
+    ]
+
+
 class TestGnomadPublicTableResource:
     """Tests for GnomadPublicTableResource."""
 
     @pytest.mark.parametrize(
         "resource_path,source,expected_read_path",
-        [
-            (
-                "gs://gnomad-public/table.ht",
-                GnomadPublicResourceSource.GNOMAD,
-                "gs://gnomad-public/table.ht",
-            ),
-            (
-                "gs://gnomad-public/table.ht",
-                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
-                "gs://gcp-public-data--gnomad/table.ht",
-            ),
-            (
-                "gs://gnomad-public/table.ht",
-                "gs://my-bucket/gnomad-resources",
-                "gs://my-bucket/gnomad-resources/table.ht",
-            ),
-        ],
+        gnomad_public_resource_test_parameters("/table.ht"),
     )
     @patch("hail.read_table")
     def test_read_gnomad_public_table_resource(
@@ -120,23 +129,7 @@ class TestGnomadPublicMatrixTableResource:
 
     @pytest.mark.parametrize(
         "resource_path,source,expected_read_path",
-        [
-            (
-                "gs://gnomad-public/matrix_table.mt",
-                GnomadPublicResourceSource.GNOMAD,
-                "gs://gnomad-public/matrix_table.mt",
-            ),
-            (
-                "gs://gnomad-public/matrix_table.mt",
-                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
-                "gs://gcp-public-data--gnomad/matrix_table.mt",
-            ),
-            (
-                "gs://gnomad-public/matrix_table.mt",
-                "gs://my-bucket/gnomad-resources",
-                "gs://my-bucket/gnomad-resources/matrix_table.mt",
-            ),
-        ],
+        gnomad_public_resource_test_parameters("/matrix_table.mt"),
     )
     @patch("hail.read_matrix_table")
     def test_read_gnomad_public_matrix_table_resource(
@@ -156,23 +149,7 @@ class TestGnomadPublicPedigreeResource:
 
     @pytest.mark.parametrize(
         "resource_path,source,expected_read_path",
-        [
-            (
-                "gs://gnomad-public/pedigree.ped",
-                GnomadPublicResourceSource.GNOMAD,
-                "gs://gnomad-public/pedigree.ped",
-            ),
-            (
-                "gs://gnomad-public/pedigree.ped",
-                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
-                "gs://gcp-public-data--gnomad/pedigree.ped",
-            ),
-            (
-                "gs://gnomad-public/pedigree.ped",
-                "gs://my-bucket/gnomad-resources",
-                "gs://my-bucket/gnomad-resources/pedigree.ped",
-            ),
-        ],
+        gnomad_public_resource_test_parameters("/pedigree.ped"),
     )
     @patch("hail.Pedigree.read")
     def test_read_gnomad_public_pedigree_resource(
@@ -189,23 +166,7 @@ class TestGnomadPublicPedigreeResource:
 
     @pytest.mark.parametrize(
         "resource_path,source,expected_read_path",
-        [
-            (
-                "gs://gnomad-public/pedigree.fam",
-                GnomadPublicResourceSource.GNOMAD,
-                "gs://gnomad-public/pedigree.fam",
-            ),
-            (
-                "gs://gnomad-public/pedigree.fam",
-                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
-                "gs://gcp-public-data--gnomad/pedigree.fam",
-            ),
-            (
-                "gs://gnomad-public/pedigree.fam",
-                "gs://my-bucket/gnomad-resources",
-                "gs://my-bucket/gnomad-resources/pedigree.fam",
-            ),
-        ],
+        gnomad_public_resource_test_parameters("/pedigree.fam"),
     )
     @patch("hail.import_fam")
     def test_import_gnomad_public_pedigree_resource(
@@ -226,23 +187,7 @@ class TestGnomadPublicBlockMatrixResource:
 
     @pytest.mark.parametrize(
         "resource_path,source,expected_read_path",
-        [
-            (
-                "gs://gnomad-public/block_matrix.bm",
-                GnomadPublicResourceSource.GNOMAD,
-                "gs://gnomad-public/block_matrix.bm",
-            ),
-            (
-                "gs://gnomad-public/block_matrix.bm",
-                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
-                "gs://gcp-public-data--gnomad/block_matrix.bm",
-            ),
-            (
-                "gs://gnomad-public/block_matrix.bm",
-                "gs://my-bucket/gnomad-resources",
-                "gs://my-bucket/gnomad-resources/block_matrix.bm",
-            ),
-        ],
+        gnomad_public_resource_test_parameters("/block_matrix.bm"),
     )
     @patch("hail.linalg.BlockMatrix.read")
     def test_read_gnomad_public_block_matrix_resource(

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -92,12 +92,27 @@ def gnomad_public_resource_test_parameters(path: str):
             f"gs://gnomad-public{path}",
         ),
         (
+            f"gs://gnomad-public-requester-pays{path}",
+            GnomadPublicResourceSource.GNOMAD,
+            f"gs://gnomad-public-requester-pays{path}",
+        ),
+        (
             f"gs://gnomad-public{path}",
             GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
             f"gs://gcp-public-data--gnomad{path}",
         ),
         (
+            f"gs://gnomad-public-requester-pays{path}",
+            GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+            f"gs://gcp-public-data--gnomad{path}",
+        ),
+        (
             f"gs://gnomad-public{path}",
+            "gs://my-bucket/gnomad-resources",
+            f"gs://my-bucket/gnomad-resources{path}",
+        ),
+        (
+            f"gs://gnomad-public-requester-pays{path}",
             "gs://my-bucket/gnomad-resources",
             f"gs://my-bucket/gnomad-resources{path}",
         ),

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -3,6 +3,10 @@
 from unittest.mock import patch
 
 from gnomad.resources import resource_utils
+from gnomad.resources.config import (
+    gnomad_public_resource_configuration,
+    GnomadPublicResourceSource,
+)
 
 
 class TestTableResource:
@@ -71,3 +75,31 @@ class TestBlockMatrixResource:
         ds = resource.bm()
         read_block_matrix.assert_called_with("gs://gnomad-public/block_matrix.bm")
         assert ds == read_block_matrix.return_value
+
+
+class TestGnomadPublicTableResource:
+    """Tests for GnomadPublicTableResource."""
+
+    @patch("hail.read_table")
+    def test_gnomad_public_table_resource(self, read_table):
+        """Test that Table can be read from gnomAD bucket."""
+        resource = resource_utils.GnomadPublicTableResource(
+            "gs://gnomad-public/table.ht"
+        )
+
+        gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GNOMAD
+
+        resource.ht()
+        read_table.assert_called_with("gs://gnomad-public/table.ht")
+
+    @patch("hail.read_table")
+    def test_gnomad_public_table_resource_custom_source(self, read_table):
+        """Test that Table can be read from custom source."""
+        resource = resource_utils.GnomadPublicTableResource(
+            "gs://gnomad-public/table.ht"
+        )
+
+        gnomad_public_resource_configuration.source = "gs://my-bucket/gnomad-resources"
+
+        resource.ht()
+        read_table.assert_called_with("gs://my-bucket/gnomad-resources/table.ht")

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -93,6 +93,22 @@ class TestGnomadPublicTableResource:
         read_table.assert_called_with("gs://gnomad-public/table.ht")
 
     @patch("hail.read_table")
+    def test_gnomad_public_table_resource_google_cloud_public_datasets(
+        self, read_table
+    ):
+        """Test that Table can be read from Google Cloud Public Datasets bucket."""
+        resource = resource_utils.GnomadPublicTableResource(
+            "gs://gnomad-public/table.ht"
+        )
+
+        gnomad_public_resource_configuration.source = (
+            GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
+        )
+
+        resource.ht()
+        read_table.assert_called_with("gs://gcp-public-data--gnomad/table.ht")
+
+    @patch("hail.read_table")
     def test_gnomad_public_table_resource_custom_source(self, read_table):
         """Test that Table can be read from custom source."""
         resource = resource_utils.GnomadPublicTableResource(


### PR DESCRIPTION
This adds support for multiple resource buckets in order to provide access to resources hosted on different cloud providers through our resources framework (#255, #263, #264).

This adds a `GnomadPublicResource` resource class and subclasses for each resource type (`GnomadPublicTableResource`, `GnomadPublicMatrixTableResource`, etc). When reading data, `GnomadPublicResource` rewrite their `path` attribute based on the value of `gnomad.resources.config.gnomad_public_resource_configuration.source`.

Thus, to read resources from `gcp-public-data--gnomad` instead of `gnomad-public-requester-pays`,

```python
from gnomad.resources.config import gnomad_public_resource_configuration, GnomadPublicResourceSource
from gnomad.resources.grch37 import gnomad

gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS

ds = gnomad.public_release("exomes").ht()
```

Alternatively, a custom path can be used (for example, if someone has created their own copy of the gnomAD public buckets).

```python
from gnomad.resources.config import gnomad_public_resource_configuration, GnomadPublicResourceSource
from gnomad.resources.grch37 import gnomad

gnomad_public_resource_configuration.source = "gs://my-bucket/gnomad-resources"

ds = gnomad.public_release("exomes").ht()
```