### PR TITLE
Add changelog to project URLs on PyPI project page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""Setup script."""
+
 import setuptools
 
 
@@ -25,6 +27,7 @@ setuptools.setup(
         "Documentation": "https://broadinstitute.github.io/gnomad_methods/",
         "Source Code": "https://github.com/broadinstitute/gnomad_methods",
         "Issues": "https://github.com/broadinstitute/gnomad_methods/issues",
+        "Change Log": "https://broadinstitute.github.io/gnomad_methods/changelog.html",
     },
     classifiers=[
         "Topic :: Scientific/Engineering :: Bio-Informatics",


### PR DESCRIPTION
Make the [changelog](https://broadinstitute.github.io/gnomad_methods/changelog.html) easier to find from the PyPI project page.

![Screen Shot 2021-04-28 at 2 27 16 PM](https://user-images.githubusercontent.com/1156625/116455359-f65a3100-a82e-11eb-99e7-cd25800d1c6e.png)
