### PR TITLE
Fix some Pylint warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,13 +11,10 @@ disable=
   # Warnings present in existing code. These should be fixed and removed from this list.
   cell-var-from-loop,
   dangerous-default-value,
-  f-string-without-interpolation,
   isinstance-second-argument-not-valid-type,
   protected-access,
   raise-missing-from,
   redefined-builtin,
   redefined-outer-name,
-  unused-import,
-  unnecessary-pass,
   unused-variable,
   unused-wildcard-import

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -87,7 +87,6 @@ class BaseResource(ABC):
         :param overwrite: If ``True``, overwrite an existing file at the destination.
         :param kwargs: Any other parameters to be passed to the underlying hail write function (acceptable parameters depend on specific resource types)
         """
-        pass
 
 
 class TableResource(BaseResource):

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -869,10 +869,10 @@ def generate_trio_stats_expr(
         an_child_expr = hl.agg.sum(hl.is_defined(proband_gt) * 2)
 
         return {
-            f"ac_parents": ac_parent_expr,
-            f"an_parents": an_parent_expr,
-            f"ac_children": ac_child_expr,
-            f"an_children": an_child_expr,
+            "ac_parents": ac_parent_expr,
+            "an_parents": an_parent_expr,
+            "ac_children": ac_child_expr,
+            "an_children": an_child_expr,
         }
 
     # Create transmission counters

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -259,8 +259,8 @@ def _get_info_agg_expr(
     # If both VarDP and QUALapprox are present, also compute QD.
     if f"{prefix}VarDP" in agg_expr and f"{prefix}QUALapprox" in agg_expr:
         logger.info(
-            f"Computing %sQD as %sQUALapprox/%sVarDP. "
-            f"Note that %sQD will be set to 0 if %sVarDP == 0.",
+            "Computing %sQD as %sQUALapprox/%sVarDP. "
+            "Note that %sQD will be set to 0 if %sVarDP == 0.",
             *[prefix] * 5,
         )
         var_dp = hl.int32(hl.agg.sum(int32_sum_agg_fields["VarDP"]))

--- a/gnomad/variant_qc/evaluation.py
+++ b/gnomad/variant_qc/evaluation.py
@@ -1,8 +1,7 @@
 # noqa: D100
 
 import logging
-from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import hail as hl
 

--- a/gnomad/variant_qc/training.py
+++ b/gnomad/variant_qc/training.py
@@ -1,10 +1,10 @@
 # noqa: D100
 
 import logging
-from typing import List, Optional, Tuple
+from pprint import pformat
+from typing import Optional, Tuple
 
 import hail as hl
-from pprint import pformat
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
#371 started checking Pylint warnings (previously, we only checked error and fatal level messages) in PR checks. However, some warnings were left ignored because they were present in existing code. This fixes a few of those warnings and removes them from the ignored list.

Descriptions of Pylint messages can be found at https://docs.pylint.org/en/stable/technical_reference/features.html.