### PR TITLE
Fix annotation type helper functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -11,7 +11,6 @@ disable=
   # Warnings present in existing code. These should be fixed and removed from this list.
   cell-var-from-loop,
   dangerous-default-value,
-  isinstance-second-argument-not-valid-type,
   protected-access,
   raise-missing-from,
   redefined-builtin,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Added function `build_vcf_export_reference` to create a subset reference based on an existing reference genome [(#381)](https://github.com/broadinstitute/gnomad_methods/pull/381)
 * Added function `rekey_new_reference` to re-key a Table or MatrixTable with a new reference genome [(#381)](https://github.com/broadinstitute/gnomad_methods/pull/381)
 * Modified `SEXES` in utils/vcf to be 'XX' and 'XY' instead of 'female' and 'male' [(#381)](https://github.com/broadinstitute/gnomad_methods/pull/381)
+* Fix `annotation_type_is_numeric` and `annotation_type_in_vcf_info` [(#379)](https://github.com/broadinstitute/gnomad_methods/pull/379)
 
 ## Version 0.5.0 - April 22nd, 2021
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -767,12 +767,7 @@ def annotation_type_is_numeric(t: Any) -> bool:
     :param t: Type to test
     :return: If the input type is numeric
     """
-    return (
-        isinstance(t, hl.tint32)
-        or isinstance(t, hl.tint64)
-        or isinstance(t, hl.tfloat32)
-        or isinstance(t, hl.tfloat64)
-    )
+    return t in (hl.tint32, hl.tint64, hl.tfloat32, hl.tfloat64)
 
 
 def annotation_type_in_vcf_info(t: Any) -> bool:
@@ -788,10 +783,11 @@ def annotation_type_in_vcf_info(t: Any) -> bool:
     """
     return (
         annotation_type_is_numeric(t)
-        or isinstance(t, hl.tstr)
-        or isinstance(t, hl.tarray)
-        or isinstance(t, hl.tset)
-        or isinstance(t, hl.tbool)
+        or t in (hl.tstr, hl.tbool)
+        or (
+            isinstance(t, (hl.tarray, hl.tset))
+            and annotation_type_in_vcf_info(t.element_type)
+        )
     )
 
 


### PR DESCRIPTION
Currently, `annotation_type_is_numeric` and `annotation_type_in_vcf_info` do not work.

`isinstance(t, hl.tint32)`, `isinstance(t, hl.tstr)` etc. raise TypeErrors because `hl.tstr`, `hl.int32`, etc. are not Python types (they are instances of a HailType class).

Pylint detects this issue, but we were ignoring this warning.

Related to #378