### PR TITLE
Fixed pops_to_exclude in faf_expr, popmax_expr

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -57,7 +57,11 @@ def pop_max_expr(
 
     :return: Popmax struct
     """
-    _pops_to_exclude = hl.literal(pops_to_exclude)
+    _pops_to_exclude = (
+        hl.literal(pops_to_exclude)
+        if pops_to_exclude is not None
+        else hl.empty_set(hl.tstr)
+    )
 
     # pylint: disable=invalid-unary-operand-type
     popmax_freq_indices = hl.range(0, hl.len(freq_meta)).filter(
@@ -169,7 +173,9 @@ def faf_expr(
     :return: (FAF expression, FAF metadata)
     """
     _pops_to_exclude = (
-        hl.literal(pops_to_exclude) if pops_to_exclude is not None else {}
+        hl.literal(pops_to_exclude)
+        if pops_to_exclude is not None
+        else hl.empty_set(hl.tstr)
     )
 
     # pylint: disable=invalid-unary-operand-type


### PR DESCRIPTION
When unspecified, `_pops_to_exclude` was throwing an error in the `faf_expr` (`AttributeError: 'dict' object has no attribute 'contains')` and `popmax_expr` functions (`hail.expr.expressions.base_expression.ExpressionException: Hail cannot impute the type of 'None'`). This update sets `_pops_to_exclude` to an empty SetExpression if no value is unspecified for this argument