### PR TITLE
Replace gnomad-public bucket in resource paths

### DIFF
--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -90,7 +90,7 @@ def _public_pca_ht_path(subpop: str) -> str:
     :return: Path to release Table
     """
     subpop = f".{subpop}" if subpop else ""
-    return f"gs://gnomad-public/release/2.1/pca/gnomad.r2.1.pca_loadings{subpop}.ht"
+    return f"gs://gnomad-public-requester-pays/release/2.1/pca/gnomad.r2.1.pca_loadings{subpop}.ht"
 
 
 def _liftover_data_path(data_type: str, version: str) -> str:
@@ -213,4 +213,4 @@ def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     :return: Path to VCF
     """
     contig = f".{contig}" if contig else ""
-    return f"gs://gnomad-public/release/{version}/vcf/{data_type}/gnomad.{data_type}.r{version}.sites{contig}.vcf.bgz"
+    return f"gs://gnomad-public-requester-pays/release/{version}/vcf/{data_type}/gnomad.{data_type}.r{version}.sites{contig}.vcf.bgz"

--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -10,10 +10,10 @@ from gnomad.resources.resource_utils import (
 import hail as hl
 
 na12878_giab = GnomadPublicMatrixTableResource(
-    path="gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.mt",
+    path="gs://gnomad-public-requester-pays/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.mt",
     import_func=hl.import_vcf,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.vcf.bgz",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.vcf.bgz",
         "force_bgz": True,
         "min_partitions": 100,
         "reference_genome": "GRCh37",
@@ -21,10 +21,10 @@ na12878_giab = GnomadPublicMatrixTableResource(
 )
 
 hapmap = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/hapmap/hapmap_3.3.b37.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/hapmap/hapmap_3.3.b37.ht",
     import_func=import_sites_vcf,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/hapmap/hapmap_3.3.b37.vcf.bgz",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/hapmap/hapmap_3.3.b37.vcf.bgz",
         "force_bgz": True,
         "min_partitions": 100,
         "reference_genome": "GRCh37",
@@ -32,10 +32,10 @@ hapmap = GnomadPublicTableResource(
 )
 
 kgp_omni = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/kgp/1000G_omni2.5.b37.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/kgp/1000G_omni2.5.b37.ht",
     import_func=import_sites_vcf,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/kgp/1000G_omni2.5.b37.vcf.bgz",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/kgp/1000G_omni2.5.b37.vcf.bgz",
         "force_bgz": True,
         "min_partitions": 100,
         "reference_genome": "GRCh37",
@@ -43,10 +43,10 @@ kgp_omni = GnomadPublicTableResource(
 )
 
 mills = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.ht",
     import_func=import_sites_vcf,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.vcf.bgz",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/mills/Mills_and_1000G_gold_standard.indels.b37.vcf.bgz",
         "force_bgz": True,
         "min_partitions": 100,
         "reference_genome": "GRCh37",
@@ -54,10 +54,10 @@ mills = GnomadPublicTableResource(
 )
 
 syndip = GnomadPublicMatrixTableResource(
-    path="gs://gnomad-public/resources/grch37/syndip/hybrid.m37m.mt",
+    path="gs://gnomad-public-requester-pays/resources/grch37/syndip/hybrid.m37m.mt",
     import_func=hl.import_vcf,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/syndip/hybrid.m37m.vcf.bgz",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/syndip/hybrid.m37m.vcf.bgz",
         "min_partitions": 100,
         "reference_genome": "GRCh37",
     },
@@ -77,10 +77,10 @@ dbsnp = VersionedTableResource(
     default_version="20180423",
     versions={
         "20180423": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch37/dbsnp/All_20180423.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch37/dbsnp/All_20180423.ht",
             import_func=import_sites_vcf,
             import_args={
-                "path": "gs://gnomad-public/resources/grch37/dbsnp/All_20180423.vcf.bgz",
+                "path": "gs://gnomad-public-requester-pays/resources/grch37/dbsnp/All_20180423.vcf.bgz",
                 "force_bgz": True,
                 "skip_invalid_loci": True,
                 "min_partitions": 100,
@@ -94,10 +94,10 @@ clinvar = VersionedTableResource(
     default_version="20181028",
     versions={
         "20181028": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch37/clinvar/clinvar_20181028.vep.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch37/clinvar/clinvar_20181028.vep.ht",
             import_func=import_sites_vcf,
             import_args={
-                "path": "gs://gnomad-public/resources/grch37/clinvar/clinvar_20181028.vcf.bgz",
+                "path": "gs://gnomad-public-requester-pays/resources/grch37/clinvar/clinvar_20181028.vcf.bgz",
                 "force_bgz": True,
                 "skip_invalid_loci": True,
                 "min_partitions": 100,
@@ -111,7 +111,7 @@ kgp_phase_3 = VersionedMatrixTableResource(
     default_version="phase_3_split",
     versions={
         "phase_3_split": GnomadPublicMatrixTableResource(
-            path="gs://gnomad-public/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.split.mt",
+            path="gs://gnomad-public-requester-pays/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.split.mt",
             import_func=hl.import_vcf,
             import_args={
                 "path": "gs://genomics-public-data/1000-genomes-phase-3/vcf-20150220/ALL.chr*.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf",
@@ -122,7 +122,7 @@ kgp_phase_3 = VersionedMatrixTableResource(
             },
         ),
         "phase_3": GnomadPublicMatrixTableResource(
-            path="gs://gnomad-public/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.mt",
+            path="gs://gnomad-public-requester-pays/resources/grch37/kgp/1000Genomes_phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.mt",
             import_func=hl.import_vcf,
             import_args={
                 "path": "gs://genomics-public-data/1000-genomes-phase-3/vcf-20150220/ALL.chr*.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf",
@@ -139,10 +139,10 @@ kgp = VersionedTableResource(
     default_version="phase_1_hc",
     versions={
         "phase_1_hc": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.ht",
             import_func=import_sites_vcf,
             import_args={
-                "path": "gs://gnomad-public/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.vcf.bgz",
+                "path": "gs://gnomad-public-requester-pays/resources/grch37/kgp/1000G_phase1.snps.high_confidence.b37.vcf.bgz",
                 "force_bgz": True,
                 "skip_invalid_loci": True,
                 "min_partitions": 100,
@@ -153,108 +153,108 @@ kgp = VersionedTableResource(
 )
 
 cpg_sites = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/cpg_sites/cpg.ht"
+    path="gs://gnomad-public-requester-pays/resources/grch37/cpg_sites/cpg.ht"
 )
 
 methylation_sites = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/methylation_sites/methylation.ht"
+    path="gs://gnomad-public-requester-pays/resources/grch37/methylation_sites/methylation.ht"
 )
 
 lcr_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/lcr_intervals/LCR.GRCh37_compliant.interval_list",
         "reference_genome": "GRCh37",
     },
 )
 
 decoy_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.ht",
     import_func=hl.import_bed,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.bed",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/decoy_intervals/mm-2-merged.GRCh37_compliant.bed",
         "reference_genome": "GRCh37",
     },
 )
 
 purcell_5k_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/purcell_5k_intervals/purcell5k.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/purcell_5k_intervals/purcell5k.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/purcell_5k_intervals/purcell5k.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/purcell_5k_intervals/purcell5k.interval_list",
         "reference_genome": "GRCh37",
     },
 )
 
 seg_dup_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.ht",
     import_func=hl.import_bed,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.bed",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/seg_dup_intervals/hg19_self_chain_split_both.bed",
         "reference_genome": "GRCh37",
     },
 )
 
 exome_hc_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/exomes_high_coverage.auto.interval_list",
         "reference_genome": "GRCh37",
     },
 )
 
 high_coverage_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/high_coverage.auto.interval_list.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/high_coverage.auto.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/broad_intervals/high_coverage.auto.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/high_coverage.auto.interval_list",
         "reference_genome": "GRCh37",
     },
 )
 
 exome_calling_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/exome_calling_regions.v1.interval_list",
         "reference_genome": "GRCh37",
     },
 )
 
 exome_evaluation_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/exome_evaluation_regions.v1.noheader.interval_list",
         "reference_genome": "GRCh37",
     },
 )
 
 genome_evaluation_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/broad_intervals/hg19-v0-wgs_evaluation_regions.v1.interval_list",
         "reference_genome": "GRCh37",
     },
 )
 
 na12878_hc_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_intervals.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/na12878/NA12878_GIAB_highconf_intervals.ht",
     import_func=hl.import_bed,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.bed",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/na12878/NA12878_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-Solid-10X_CHROM1-X_v3.3_highconf.bed",
         "reference_genome": "GRCh37",
     },
 )
 
 syndip_hc_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch37/syndip/syndip_highconf_genome_intervals.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch37/syndip/syndip_highconf_genome_intervals.ht",
     import_func=hl.import_bed,
     import_args={
-        "path": "gs://gnomad-public/resources/grch37/syndip/hybrid.m37m.bed",
+        "path": "gs://gnomad-public-requester-pays/resources/grch37/syndip/hybrid.m37m.bed",
         "reference_genome": "GRCh37",
     },
 )

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -221,7 +221,7 @@ gnomad_syndip = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
         "3.0": GnomadPublicMatrixTableResource(
-            path="gs://gnomad-public/truth-sets/hail-0.2/gnomad_v3_syndip.b38.mt"
+            path="gs://gnomad-public-requester-pays/truth-sets/hail-0.2/gnomad_v3_syndip.b38.mt"
         )
     },
 )
@@ -230,7 +230,7 @@ na12878 = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
         "3.0": GnomadPublicMatrixTableResource(
-            path="gs://gnomad-public/truth-sets/hail-0.2/gnomad_v3_na12878.mt"
+            path="gs://gnomad-public-requester-pays/truth-sets/hail-0.2/gnomad_v3_na12878.mt"
         )
     },
 )
@@ -347,7 +347,7 @@ def coverage_tsv_path(data_type: str, version: Optional[str] = None) -> str:
                 f"Version {version} of gnomAD genomes for GRCh38 does not exist"
             )
 
-    return f"gs://gnomad-public/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.summary.tsv.bgz"
+    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.summary.tsv.bgz"
 
 
 def release_vcf_path(data_type: str, version: str, contig: str) -> str:
@@ -361,4 +361,4 @@ def release_vcf_path(data_type: str, version: str, contig: str) -> str:
     """
     contig = f".{contig}" if contig else ""
     version_prefix = "r" if version.startswith("3.0") else "v"
-    return f"gs://gnomad-public/release/{version}/vcf/{data_type}/gnomad.{data_type}.{version_prefix}{version}.sites{contig}.vcf.bgz"
+    return f"gs://gnomad-public-requester-pays/release/{version}/vcf/{data_type}/gnomad.{data_type}.{version_prefix}{version}.sites{contig}.vcf.bgz"

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -58,18 +58,18 @@ def _import_dbsnp(**kwargs) -> hl.Table:
 
 # Resources with no versioning needed
 purcell_5k_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/purcell_5k_intervals/purcell5k.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/purcell_5k_intervals/purcell5k.ht",
     import_func=_import_purcell_5k,
     import_args={
-        "path": "gs://gnomad-public/resources/grch38/purcell_5k_intervals/purcell5k.interval_list",
+        "path": "gs://gnomad-public-requester-pays/resources/grch38/purcell_5k_intervals/purcell5k.interval_list",
     },
 )
 
 na12878_giab = GnomadPublicMatrixTableResource(
-    path="gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.mt",
+    path="gs://gnomad-public-requester-pays/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.mt",
     import_func=hl.import_vcf,
     import_args={
-        "path": "gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz",
+        "path": "gs://gnomad-public-requester-pays/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz",
         "force_bgz": True,
         "min_partitions": 100,
         "reference_genome": "GRCh38",
@@ -77,10 +77,10 @@ na12878_giab = GnomadPublicMatrixTableResource(
 )
 
 na12878_giab_hc_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7_hc_regions.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7_hc_regions.ht",
     import_func=hl.import_bed,
     import_args={
-        "path": "gs://gnomad-public/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7.bed",
+        "path": "gs://gnomad-public-requester-pays/resources/grch38/na12878/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7.bed",
         "reference_genome": "GRCh38",
         "skip_invalid_intervals": True,
     },
@@ -103,10 +103,10 @@ syndip = VersionedMatrixTableResource(
     default_version="20180222",
     versions={
         "20180222": GnomadPublicMatrixTableResource(
-            path="gs://gnomad-public/resources/grch38/syndip/syndip.b38_20180222.mt",
+            path="gs://gnomad-public-requester-pays/resources/grch38/syndip/syndip.b38_20180222.mt",
             import_func=hl.import_vcf,
             import_args={
-                "path": "gs://gnomad-public/resources/grch38/syndip/full.38.20180222.vcf.gz",
+                "path": "gs://gnomad-public-requester-pays/resources/grch38/syndip/full.38.20180222.vcf.gz",
                 "force_bgz": True,
                 "min_partitions": 100,
                 "reference_genome": "GRCh38",
@@ -119,10 +119,10 @@ syndip_hc_intervals = VersionedTableResource(
     default_version="20180222",
     versions={
         "20180222": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch38/syndip/syndip_b38_20180222_hc_regions.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch38/syndip/syndip_b38_20180222_hc_regions.ht",
             import_func=hl.import_bed,
             import_args={
-                "path": "gs://gnomad-public/resources/grch38/syndip/syndip.b38_20180222.bed",
+                "path": "gs://gnomad-public-requester-pays/resources/grch38/syndip/syndip.b38_20180222.bed",
                 "reference_genome": "GRCh38",
                 "skip_invalid_intervals": True,
                 "min_partitions": 10,
@@ -135,10 +135,10 @@ clinvar = VersionedTableResource(
     default_version="20190923",
     versions={
         "20190923": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch38/clinvar/clinvar_20190923.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch38/clinvar/clinvar_20190923.ht",
             import_func=_import_clinvar,
             import_args={
-                "path": "gs://gnomad-public/resources/grch38/clinvar/clinvar_20190923.vcf.gz",
+                "path": "gs://gnomad-public-requester-pays/resources/grch38/clinvar/clinvar_20190923.vcf.gz",
                 "force_bgz": True,
                 "contig_recoding": NO_CHR_TO_CHR_CONTIG_RECODING,
                 "skip_invalid_loci": True,
@@ -153,11 +153,11 @@ dbsnp = VersionedTableResource(
     default_version="b154",
     versions={
         "b154": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_20200514.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch38/dbsnp/dbsnp_b154_grch38_all_20200514.ht",
             import_func=_import_dbsnp,
             import_args={
-                "path": "gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_GCF_000001405.38_20200514.vcf.bgz",
-                "header_file": "gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b154_grch38_all_GCF_000001405.38_20200514.vcf.header",
+                "path": "gs://gnomad-public-requester-pays/resources/grch38/dbsnp/dbsnp_b154_grch38_all_GCF_000001405.38_20200514.vcf.bgz",
+                "header_file": "gs://gnomad-public-requester-pays/resources/grch38/dbsnp/dbsnp_b154_grch38_all_GCF_000001405.38_20200514.vcf.header",
                 "force_bgz": True,
                 "contig_recoding": DBSNP_B154_CHR_CONTIG_RECODING,
                 "skip_invalid_loci": True,
@@ -166,11 +166,11 @@ dbsnp = VersionedTableResource(
             },
         ),
         "b151": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.ht",
             import_func=import_sites_vcf,
             import_args={
-                "path": "gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.vcf.bgz",
-                "header_file": "gs://gnomad-public/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.vcf.header",
+                "path": "gs://gnomad-public-requester-pays/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.vcf.bgz",
+                "header_file": "gs://gnomad-public-requester-pays/resources/grch38/dbsnp/dbsnp_b151_grch38_all_20180418.vcf.header",
                 "force_bgz": True,
                 "contig_recoding": NO_CHR_TO_CHR_CONTIG_RECODING,
                 "skip_invalid_loci": True,
@@ -182,7 +182,7 @@ dbsnp = VersionedTableResource(
 )
 
 hapmap = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/hapmap/hapmap_3.3.hg38.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/hapmap/hapmap_3.3.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://genomics-public-data/resources/broad/hg38/v0/hapmap_3.3.hg38.vcf.gz",
@@ -192,7 +192,7 @@ hapmap = GnomadPublicTableResource(
 )
 
 kgp_omni = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/kgp/1000G_omni2.5.hg38.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/kgp/1000G_omni2.5.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://genomics-public-data/resources/broad/hg38/v0/1000G_omni2.5.hg38.vcf.gz",
@@ -205,7 +205,7 @@ kgp = VersionedTableResource(
     default_version="phase_1_hc",
     versions={
         "phase_1_hc": GnomadPublicTableResource(
-            path="gs://gnomad-public/resources/grch38/kgp/1000G_phase1.snps.high_confidence.hg38.ht",
+            path="gs://gnomad-public-requester-pays/resources/grch38/kgp/1000G_phase1.snps.high_confidence.hg38.ht",
             import_func=import_sites_vcf,
             import_args={
                 "path": "gs://genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz",
@@ -217,7 +217,7 @@ kgp = VersionedTableResource(
 )
 
 mills = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/mills/Mills_and_1000G_gold_standard.indels.hg38.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/mills/Mills_and_1000G_gold_standard.indels.hg38.ht",
     import_func=import_sites_vcf,
     import_args={
         "path": "gs://genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
@@ -227,29 +227,29 @@ mills = GnomadPublicTableResource(
 )
 
 lcr_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/lcr_intervals/LCRFromHengHg38.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/lcr_intervals/LCRFromHengHg38.ht",
     import_func=hl.import_locus_intervals,
     import_args={
-        "path": "gs://gnomad-public/resources/grch38/lcr_intervals/LCRFromHengHg38.txt",
+        "path": "gs://gnomad-public-requester-pays/resources/grch38/lcr_intervals/LCRFromHengHg38.txt",
         "reference_genome": "GRCh38",
         "skip_invalid_intervals": True,
     },
 )
 
 seg_dup_intervals = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/seg_dup_intervals/GRCh38_segdups.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/seg_dup_intervals/GRCh38_segdups.ht",
     import_func=hl.import_bed,
     import_args={
-        "path": "gs://gnomad-public/resources/grch38/seg_dup_intervals/GRCh38_segdups.bed",
+        "path": "gs://gnomad-public-requester-pays/resources/grch38/seg_dup_intervals/GRCh38_segdups.bed",
         "reference_genome": "GRCh38",
     },
 )
 
 telomeres_and_centromeres = GnomadPublicTableResource(
-    path="gs://gnomad-public/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht",
+    path="gs://gnomad-public-requester-pays/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht",
     import_func=hl.import_bed,
     import_args={
-        "path": "gs://gnomad-public/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.bed",
+        "path": "gs://gnomad-public-requester-pays/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.bed",
         "reference_genome": "GRCh38",
         "skip_invalid_intervals": True,
     },

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -18,10 +18,12 @@ class TestTableResource:
     @patch("hail.read_table")
     def test_read_table(self, read_table):
         """Test that Table is read from path."""
-        resource = resource_utils.TableResource("gs://gnomad-public/table.ht")
+        resource = resource_utils.TableResource(
+            "gs://gnomad-public-requester-pays/table.ht"
+        )
 
         ds = resource.ht()
-        read_table.assert_called_with("gs://gnomad-public/table.ht")
+        read_table.assert_called_with("gs://gnomad-public-requester-pays/table.ht")
         assert ds == read_table.return_value
 
 
@@ -32,11 +34,13 @@ class TestMatrixTableResource:
     def test_read_matrix_table(self, read_matrix_table):
         """Test that MatrixTable is read from path."""
         resource = resource_utils.MatrixTableResource(
-            "gs://gnomad-public/matrix_table.mt"
+            "gs://gnomad-public-requester-pays/matrix_table.mt"
         )
 
         ds = resource.mt()
-        read_matrix_table.assert_called_with("gs://gnomad-public/matrix_table.mt")
+        read_matrix_table.assert_called_with(
+            "gs://gnomad-public-requester-pays/matrix_table.mt"
+        )
         assert ds == read_matrix_table.return_value
 
 
@@ -46,22 +50,32 @@ class TestPedigreeResource:
     @patch("hail.Pedigree.read")
     def test_read_pedigree(self, read_pedigree):
         """Test that Pedigree is read from path."""
-        resource = resource_utils.PedigreeResource("gs://gnomad-public/pedigree.ped")
+        resource = resource_utils.PedigreeResource(
+            "gs://gnomad-public-requester-pays/pedigree.ped"
+        )
 
         ds = resource.pedigree()
         read_pedigree.assert_called()
         print(read_pedigree.call_args)
-        assert read_pedigree.call_args[0][0] == "gs://gnomad-public/pedigree.ped"
+        assert (
+            read_pedigree.call_args[0][0]
+            == "gs://gnomad-public-requester-pays/pedigree.ped"
+        )
         assert ds == read_pedigree.return_value
 
     @patch("hail.import_fam")
     def test_read_fam(self, import_fam):
         """Test that Table is imported from path."""
-        resource = resource_utils.PedigreeResource("gs://gnomad-public/pedigree.fam")
+        resource = resource_utils.PedigreeResource(
+            "gs://gnomad-public-requester-pays/pedigree.fam"
+        )
 
         ds = resource.ht()
         import_fam.assert_called()
-        assert import_fam.call_args[0][0] == "gs://gnomad-public/pedigree.fam"
+        assert (
+            import_fam.call_args[0][0]
+            == "gs://gnomad-public-requester-pays/pedigree.fam"
+        )
         assert ds == import_fam.return_value
 
 
@@ -72,11 +86,13 @@ class TestBlockMatrixResource:
     def test_read_block_matrix(self, read_block_matrix):
         """Test that BlockMatrix is read from path."""
         resource = resource_utils.BlockMatrixResource(
-            "gs://gnomad-public/block_matrix.bm"
+            "gs://gnomad-public-requester-pays/block_matrix.bm"
         )
 
         ds = resource.bm()
-        read_block_matrix.assert_called_with("gs://gnomad-public/block_matrix.bm")
+        read_block_matrix.assert_called_with(
+            "gs://gnomad-public-requester-pays/block_matrix.bm"
+        )
         assert ds == read_block_matrix.return_value
 
 


### PR DESCRIPTION
Files in gnomad-public were moved to gnomad-public-requester-pays.

https://gnomad.broadinstitute.org/news/2021-08-gnomad-hosted-public-files-moved-to-requester-pays-bucket/

This replaces gnomad-public with gnomad-public-requester-pays in resource paths. While going through the resources, I noticed a few (such as VCFs and coverage TSVs) that no longer exist in gnomad-public-requester-pays. We'll have to figure out what to do about those, but that can be done afterward. This at least fixes most of the resource paths.


Resolves #400