### PR TITLE
Update error message for when resource is not found in gnomAD bucket

### DIFF
--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -397,7 +397,7 @@ class GnomadPublicResource(BaseResource, ABC):
                 resource_source = gnomad_public_resource_configuration.source
                 if not self.is_resource_available():
                     if resource_source == GnomadPublicResourceSource.GNOMAD:
-                        message = "This resource is not currently available from the gnomAD project."
+                        message = "This resource is not currently available from the gnomAD project public buckets."
                     elif isinstance(resource_source, GnomadPublicResourceSource):
                         message = f"This resource is not currently available from {resource_source.value}."
                     else:

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -395,17 +395,23 @@ class GnomadPublicResource(BaseResource, ABC):
                 # If one of the known sources is selected, check if the resource is available.
                 # For custom sources, skip the check and attempt to read the resource.
                 resource_source = gnomad_public_resource_configuration.source
-                if (
-                    isinstance(resource_source, GnomadPublicResourceSource)
-                    and resource_source != GnomadPublicResourceSource.GNOMAD
-                ):
-                    if not self.is_resource_available():
-                        raise ResourceNotAvailable(
-                            f"This resource is not currently available from {resource_source.value}.\n\n"
-                            "To load resources directly from gnomAD instead, use:\n\n"
-                            ">>> from gnomad.resources.config import gnomad_public_resource_configuration, GnomadPublicResourceSource\n"
-                            ">>> gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GNOMAD"
-                        )
+                if not self.is_resource_available():
+                    if resource_source == GnomadPublicResourceSource.GNOMAD:
+                        message = "This resource is not currently available from the gnomAD project."
+                    elif isinstance(resource_source, GnomadPublicResourceSource):
+                        message = f"This resource is not currently available from {resource_source.value}."
+                    else:
+                        message = f"This resource is not currently available from {resource_source}."
+
+                    raise ResourceNotAvailable(
+                        f"{message}\n\n"
+                        "To load resources from a different source (for example, Google Cloud Public Datasets) instead, use:\n\n"
+                        ">>> from gnomad.resources.config import gnomad_public_resource_configuration, GnomadPublicResourceSource\n"
+                        ">>> gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS\n\n"
+                        "To get all available sources for gnomAD resources, use:\n\n"
+                        ">>> from gnomad.resources.config import GnomadPublicResourceSource\n"
+                        ">>> list(GnomadPublicResourceSource)"
+                    )
 
                 return original_method(self, *args, **kwargs)
 


### PR DESCRIPTION
Currently, if a resource is not available from the user's selected source, we show an error message directing them to use the gnomAD buckets. However, going forward, we won't host all resource files in our buckets once they are copied to cloud providers' buckets (this is already the case with VCFs).

This generalizes the error message to "try a different source" and adds instructions on how to find a list of all available sources.

Resolves #390
Related to #402