### PR TITLE
Remove module imports from __init__.py files

### DIFF
--- a/gnomad/assessment/__init__.py
+++ b/gnomad/assessment/__init__.py
@@ -1,3 +1,1 @@
 # noqa: D104
-
-from gnomad.assessment import validity_checks

--- a/gnomad/sample_qc/__init__.py
+++ b/gnomad/sample_qc/__init__.py
@@ -1,3 +1,1 @@
 # noqa: D104
-
-from gnomad.sample_qc import ancestry, filtering, pipeline, platform, relatedness, sex

--- a/gnomad/utils/__init__.py
+++ b/gnomad/utils/__init__.py
@@ -1,14 +1,1 @@
 # noqa: D104
-
-from gnomad.utils import (
-    annotations,
-    file_utils,
-    filtering,
-    gen_stats,
-    intervals,
-    plotting,
-    reference_genome,
-    slack,
-    sparse_mt,
-    vep,
-)

--- a/gnomad/variant_qc/__init__.py
+++ b/gnomad/variant_qc/__init__.py
@@ -1,3 +1,1 @@
 # noqa: D104
-
-from gnomad.variant_qc import evaluation, ld, pipeline, random_forest


### PR DESCRIPTION
I've been trying to figure out why Pylint reports no errors in gnomad_qc despite several v2 scripts importing a function that no longer exists (`gnomad.utils.slack.try_slack`). These module imports in `__init__.py` files seem to confuse Pylint.

I don't think they serve a purpose. It looks like I [suggested them](https://github.com/broadinstitute/gnomad_methods/pull/207#pullrequestreview-382012887) as an alternative to `from module import *`. But I don't think we have any code that relies on them by importing `*` from one of these packages.