### PR TITLE
Add workflow to publish to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Use pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Use pip cache
         uses: actions/cache@v1
         with:
@@ -102,10 +102,10 @@ jobs:
         with:
           repository: broadinstitute/gnomad_qc
           path: gnomad_qc
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Use pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+jobs:
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name:
+        run: |
+          package_version=$(grep 'version' setup.py | sed -E 's|.*([0-9]+\.[0-9]+\.[0-9]+).*|\1|')
+          tag_version=$(echo "$GITHUB_REF" | sed -E 's|.*([0-9]+\.[0-9]+\.[0-9]+).*|\1|')
+          if [ "$package_version" != "$tag_version" ]; then
+            echo "Tag version (${tag_version}) does not match package version (${package_version})"
+            exit 1
+          fi
+
+          if ! grep -iq "version ${package_version}" CHANGELOG.md; then
+            echo "Missing changelog section for version ${package_version}"
+            exit 1
+          fi
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Use pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            pip-
+      - name: Install dependencies
+        run: |
+          pip install --upgrade setuptools
+          pip install wheel
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run Pylint
+        run: ./lint
+      - name: Run tests
+        run: python -m pytest
+      - name: Create distributions
+        run: python setup.py sdist bdist_wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
             echo "Missing changelog section for version ${package_version}"
             exit 1
           fi
-      - name: Setup Python
+      - name: Setup Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Use pip cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name:
+      - name: Validate version and changelog
         run: |
           package_version=$(grep 'version' setup.py | sed -E 's|.*([0-9]+\.[0-9]+\.[0-9]+).*|\1|')
           tag_version=$(echo "$GITHUB_REF" | sed -E 's|.*([0-9]+\.[0-9]+\.[0-9]+).*|\1|')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+# This workflow publishes the gnomad package to PyPI when a version tag is pushed to GitHub.
 name: Publish to PyPI
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,12 +60,6 @@ See instructions in [docs/README.md](./docs/README.md).
 
 https://packaging.python.org/guides/distributing-packages-using-setuptools/#packaging-your-project
 
-- Install tools.
-
-  ```
-  python -m pip install --upgrade setuptools wheel twine
-  ```
-
 - Make sure that the [changelog](./CHANGELOG.md) is up to date.
 
   To see changes since the last release, use:
@@ -82,11 +76,23 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/#pack
 
   https://packaging.python.org/guides/distributing-packages-using-setuptools/#semantic-versioning-preferred
 
-- Tag the release in git.
+- Tag the release in git. The version number in the tag must match the version number in setup.py.
 
   ```
   git tag v<version>
   git push origin v<version>
+  ```
+
+  When a `v<VERSION_NUMBER>` tag is pushed to GitHub, an Actions workflow will automatically publish the tagged code to PyPI.
+
+  New releases will automatically be posted in the #gnomad_notifications Slack channel (via the RSS Slack app).
+
+### Manually publishing a release
+
+- Install tools.
+
+  ```
+  python -m pip install --upgrade setuptools wheel twine
   ```
 
 - Remove any old builds.
@@ -107,5 +113,3 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/#pack
   ```
   twine upload dist/*
   ```
-
-- Announce new release on Slack.


### PR DESCRIPTION
When a tag matching `v<VERSION_NUMBER>` is pushed to GitHub, this workflow will publish the tagged code to PyPI. This means that anyone with write access to this repository can publish a new release, as opposed to currently depending on the few team members with PyPI accounts.

Resolves #356