### PR TITLE
Clarify steps for tagging a new release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,10 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/#pack
   git log $LAST_RELEASE_TAG..
   ```
 
+  Especially if there are many changes in the release, organize the changelog by type.
+
+  See https://keepachangelog.com/en/1.0.0/#how for more information.
+
 - Update version in setup.py, replace "unreleased" heading in changelog with the version number, and commit.
   Push changes to the master branch on GitHub or submit a pull request.
   The new version number should be based on changes since the last release.
@@ -77,7 +81,7 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/#pack
 
   https://packaging.python.org/guides/distributing-packages-using-setuptools/#semantic-versioning-preferred
 
-- Once the version has been updated in the master branch on GitHub, tag the release.
+- Once the version and changelog have been updated in the master branch on GitHub, tag the release.
   The version tag should be applied to a commit on the master branch.
 
   The version number in the tag must match the version number in setup.py.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,15 +70,22 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/#pack
   ```
 
 - Update version in setup.py, replace "unreleased" heading in changelog with the version number, and commit.
+  Push changes to the master branch on GitHub or submit a pull request.
   The new version number should be based on changes since the last release.
 
   https://semver.org/
 
   https://packaging.python.org/guides/distributing-packages-using-setuptools/#semantic-versioning-preferred
 
-- Tag the release in git. The version number in the tag must match the version number in setup.py.
+- Once the version has been updated in the master branch on GitHub, tag the release.
+  The version tag should be applied to a commit on the master branch.
+
+  The version number in the tag must match the version number in setup.py.
 
   ```
+  git checkout master
+  git pull
+
   git tag v<version>
   git push origin v<version>
   ```


### PR DESCRIPTION
Clarify that release/version tags should be applied to a commit that is on the master branch and has been pushed to GitHub.