### PR TITLE
fix to faf description text

### DIFF
--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -667,17 +667,19 @@ def make_info_dict(
                 }
             else:
                 if ("XX" in combo_fields) | ("XY" in combo_fields):
-                    description_text = (
+                    faf_description_text = (
                         description_text + " in non-PAR regions of sex chromosomes only"
                     )
+                else:
+                    faf_description_text = description_text
                 combo_dict = {
                     metric_label_dict["faf95"]: {
                         "Number": "A",
-                        "Description": f"Filtering allele frequency (using Poisson 95% CI){for_combo}{description_text}",
+                        "Description": f"Filtering allele frequency (using Poisson 95% CI){for_combo}{faf_description_text}",
                     },
                     metric_label_dict["faf99"]: {
                         "Number": "A",
-                        "Description": f"Filtering allele frequency (using Poisson 99% CI){for_combo}{description_text}",
+                        "Description": f"Filtering allele frequency (using Poisson 99% CI){for_combo}{faf_description_text}",
                     },
                 }
             info_dict.update(combo_dict)


### PR DESCRIPTION
Added to fix this problem:

```##INFO=<ID=faf99_nfe_XY,Number=A,Type=Float,Description="Filtering allele frequency (using Poisson 99% CI) for XY samples of Non-Finnish European ancestry in non-PAR regions of sex chromosomes only in non-PAR regions of sex chromosomes only in non-PAR regions of sex chromosomes only in non-PAR regions of sex chromosomes only in non-PAR regions of sex chromosomes only in non-PAR regions of sex chromosomes only in non-PAR regions of sex chromosomes only in non-PAR regions of sex chromosomes only">```