### PR TITLE
Update to new RouterAsyncFS interface in Hail 0.2.79

### DIFF
--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -57,7 +57,7 @@ async def parallel_file_exists_async(
     ) as pbar:
         with ThreadPoolExecutor() as thread_pool:
             async with RouterAsyncFS(
-                "file", [LocalAsyncFS(thread_pool), GoogleStorageAsyncFS()]
+                "file", filesystems=[LocalAsyncFS(thread_pool), GoogleStorageAsyncFS()]
             ) as fs:
 
                 def check_existence_and_update_pbar_thunk(fpath: str) -> Callable:


### PR DESCRIPTION
hail-is/hail#11063 changed the interface of RouterAsyncFS. `filesystems` must now be passed as a keyword argument.