### PR TITLE
Add options for reading public resources from Registry of Open Data on AWS and Azure Open Datasets

### DIFF
--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -9,6 +9,8 @@ class GnomadPublicResourceSource(Enum):
 
     GNOMAD = "gnomAD"
     GOOGLE_CLOUD_PUBLIC_DATASETS = "Google Cloud Public Datasets"
+    REGISTRY_OF_OPEN_DATA_ON_AWS = "Registry of Open Data on AWS"
+    AZURE_OPEN_DATASETS = "Azure Open Datasets"
 
 
 DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE = GnomadPublicResourceSource.GNOMAD

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -490,6 +490,12 @@ class GnomadPublicResource(BaseResource, ABC):
         if resource_source == GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS:
             return f"gs://gcp-public-data--gnomad{relative_path}"
 
+        if resource_source == GnomadPublicResourceSource.REGISTRY_OF_OPEN_DATA_ON_AWS:
+            return f"s3a://gnomad-public-us-east-1{relative_path}"
+
+        if resource_source == GnomadPublicResourceSource.AZURE_OPEN_DATASETS:
+            return f"wasbs://dataset@datasetgnomad.blob.core.windows.net{relative_path}"
+
         return (
             f"{resource_source.rstrip('/')}{relative_path}"  # pylint: disable=no-member
         )

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -127,6 +127,26 @@ def gnomad_public_resource_test_parameters(
         ),
         (
             f"gs://gnomad-public{path}",
+            GnomadPublicResourceSource.REGISTRY_OF_OPEN_DATA_ON_AWS,
+            f"s3a://gnomad-public-us-east-1{path}",
+        ),
+        (
+            f"gs://gnomad-public-requester-pays{path}",
+            GnomadPublicResourceSource.REGISTRY_OF_OPEN_DATA_ON_AWS,
+            f"s3a://gnomad-public-us-east-1{path}",
+        ),
+        (
+            f"gs://gnomad-public{path}",
+            GnomadPublicResourceSource.AZURE_OPEN_DATASETS,
+            f"wasbs://dataset@datasetgnomad.blob.core.windows.net{path}",
+        ),
+        (
+            f"gs://gnomad-public-requester-pays{path}",
+            GnomadPublicResourceSource.AZURE_OPEN_DATASETS,
+            f"wasbs://dataset@datasetgnomad.blob.core.windows.net{path}",
+        ),
+        (
+            f"gs://gnomad-public{path}",
             "gs://my-bucket/gnomad-resources",
             f"gs://my-bucket/gnomad-resources{path}",
         ),


### PR DESCRIPTION
Currently, there are options to read gnomAD public resources from either our `gnomad-public-requester-pays` bucket or the Google Cloud Public Datasets `gcp-public-data--gnomad` bucket.

This adds options to read them from the Registry of Open Datasets on AWS S3 bucket or the Azure Open Datasets storage container.

To select a source, use:
```python
from gnomad.resources.config import gnomad_public_resource_configuration, GnomadPublicResourceSource

# Choose one
gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GNOMAD
gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
gnomad_public_resource_configuration.source = GnomadPublicResourceSource.REGISTRY_OF_OPEN_DATA_ON_AWS
gnomad_public_resource_configuration.source = GnomadPublicResourceSource.AZURE_OPEN_DATASETS
```

Reading Hail objects from GCS, S3, or Azure Blob Storage also requires the appropriate "connector".

- Dataproc clusters are pre-configured to read `gs` URLs. To read `gs` URLs locally, use https://github.com/broadinstitute/install-gcs-connector.
- To read `s3a` URLs locally, use https://gist.github.com/danking/f8387f5681b03edc5babdf36e14140bc. I'm not sure how things work on EMR clusters, whether they are configured to use `s3a` URLs or another scheme (see [hadoop-aws docs ](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Other_S3_Connectors) for more information).
- HDInsight clusters are pre-configured to read `wasb(s)` URLs. To read `wasb(s)` URLs locally, use https://gist.github.com/danking/118c795e9f4e00b82d3555379b65eb3b (see [this Zulip thread about the Azure storage connector](https://hail.zulipchat.com/#narrow/stream/123010-Hail-Query.200.2E2.20support/topic/Azure.20.20storage.20connector) for more information).

Thanks to @danking for finding the Azure URL pattern, testing it on an HDInsight cluster, and figuring out how to install the Azure storage connector locally.

Resolves #255