### PR TITLE
Use Google Cloud Public Datasets as default source for public resources

### DIFF
--- a/docs/examples/vep.rst
+++ b/docs/examples/vep.rst
@@ -7,7 +7,7 @@ tied to a specific reference genome.
 
 .. code-block:: shell
 
-   hailctl dataproc start cluster-name --vep GRCh37 --packages gnomad --requester-pays-allow-buckets gnomad-public-requester-pays
+   hailctl dataproc start cluster-name --vep GRCh37 --packages gnomad
 
 .. note::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,10 +6,9 @@ Getting Started
     pip install hail
 
 2. Use ``hailctl`` to start a `Google Dataproc <https://cloud.google.com/dataproc/>`_ cluster with the
-   ``gnomad`` package installed and allow reading from the ``gnomad-public-requester-pays`` storage bucket
-   (see `Hail on the Cloud <https://hail.is/docs/0.2/hail_on_the_cloud.html>`_ for more detail on hailctl)::
+   ``gnomad`` package installed (see `Hail on the Cloud <https://hail.is/docs/0.2/hail_on_the_cloud.html>`_ for more detail on ``hailctl``)::
 
-    hailctl dataproc start cluster-name --packages gnomad --requester-pays-allow-buckets gnomad-public-requester-pays
+    hailctl dataproc start cluster-name --packages gnomad
 
 3. Connect to a `Jupyter Notebook <https://jupyter-notebook.readthedocs.io/en/stable/notebook.html>`_ on the cluster::
 

--- a/docs/resource_sources.rst
+++ b/docs/resource_sources.rst
@@ -5,15 +5,15 @@ gnomAD data is available through `multiple cloud providers' public datasets prog
 
 The functions in the :doc:`gnomad.resources </api_reference/resources/index>` package can be configured to load data from different sources.
 
-By default, resources are loaded from the gnomAD project's public Google Cloud Storage bucket ``gs://gnomad-public-requester-pays``. This bucket is `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_, meaning that charges for data access and transfer will be billed to your Google Cloud project.
+By default, resources are loaded from Google Cloud Public Datasets.
 
-To load resources from a different source (for example, Google Public Datasets), use:
+To load resources from a different source (for example, the gnomAD project's public GCS bucket), use:
 
 .. code-block:: python
 
     from gnomad.resources.config import gnomad_public_resource_configuration, GnomadPublicResourceSource
 
-    gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
+    gnomad_public_resource_configuration.source = GnomadPublicResourceSource.GNOMAD
 
 To see all available public sources for gnomAD resources, use:
 
@@ -23,6 +23,9 @@ To see all available public sources for gnomAD resources, use:
 
     list(GnomadPublicResourceSource)
 
+.. note::
+
+   The gnomAD project's bucket (``gs://gnomad-public-requester-pays``) is `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_, meaning that charges for data access and transfer will be billed to your Google Cloud project.
 
 Custom Sources
 --------------

--- a/docs/resource_sources.rst
+++ b/docs/resource_sources.rst
@@ -25,8 +25,13 @@ To see all available public sources for gnomAD resources, use:
 
 .. note::
 
-   The gnomAD project's bucket (``gs://gnomad-public-requester-pays``) is `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_, meaning that charges for data access and transfer will be billed to your Google Cloud project. Clusters must be configured to read requester pays buckets during creation.
-``hailctl dataproc start cluster-name --packages gnomad --requester-pays-allow-buckets gnomad-public-requester-pays``
+   The gnomAD project's bucket (``gs://gnomad-public-requester-pays``) is `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_, meaning that charges for data access and transfer will be billed to your Google Cloud project.
+
+   Clusters must be configured to read requester pays buckets during creation. For example,
+
+   .. code-block::
+
+      hailctl dataproc start cluster-name --packages gnomad --requester-pays-allow-buckets gnomad-public-requester-pays
 
 Custom Sources
 --------------

--- a/docs/resource_sources.rst
+++ b/docs/resource_sources.rst
@@ -25,7 +25,8 @@ To see all available public sources for gnomAD resources, use:
 
 .. note::
 
-   The gnomAD project's bucket (``gs://gnomad-public-requester-pays``) is `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_, meaning that charges for data access and transfer will be billed to your Google Cloud project.
+   The gnomAD project's bucket (``gs://gnomad-public-requester-pays``) is `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_, meaning that charges for data access and transfer will be billed to your Google Cloud project. Clusters must be configured to read requester pays buckets during creation.
+``hailctl dataproc start cluster-name --packages gnomad --requester-pays-allow-buckets gnomad-public-requester-pays``
 
 Custom Sources
 --------------

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -11,7 +11,9 @@ class GnomadPublicResourceSource(Enum):
     GOOGLE_CLOUD_PUBLIC_DATASETS = "Google Cloud Public Datasets"
 
 
-DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE = GnomadPublicResourceSource.GNOMAD
+DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE = (
+    GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
+)
 
 
 class _GnomadPublicResourceConfiguration:


### PR DESCRIPTION
Now that all files have been synced to Google Cloud Public Datasets, we can use it as the default source for resources. This will be a more pleasant experience for new users, since they won't have to deal with requester pays.

Resolves #264