### PR TITLE
Add configuration for generating release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+<!-- Thank you for submitting a pull request.
+
+To make sure that this change is included in release notes, please:
+- Use a descriptive title for the pull request.
+- Apply one of the "Changelog" labels (if applicable).
+
+-->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - "Changelog: ignore"
+  categories:
+    - title: Breaking Changes
+      labels:
+        - "Changelog: breaking change"
+    - title: Bug fixes
+      labels:
+        - "Changelog: bug fix"
+    - title: New Features
+      labels:
+        - "Changelog: new feature"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
This [configures automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) to be grouped into sections based on labels applied to pull requests. The [labels](https://github.com/broadinstitute/gnomad_methods/labels) referenced in the configuration have already been created.

This also adds a [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) to remind authors about how to include changes in release notes.