### PR TITLE
Automatically publish GitHub Release with release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-      - name: Create Release Notes
+      - name: Create release notes
         uses: actions/github-script@v5
         with:
           script: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,3 +47,11 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create Release Notes
+        uses: actions/github-script@v5
+        with:
+          script: |
+            await github.request(`POST /repos/${{ github.repository }}/releases`, {
+              tag_name: "${{ github.ref }}",
+              generate_release_notes: true
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,12 +85,13 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/#pack
 
   New releases will automatically be posted in the #gnomad_notifications Slack channel (via the RSS Slack app).
 
-- [Create a GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release)
-  using the tag and add release notes.
+- A [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) will be automatically created with
+  [release notes generated from pull requests](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
 
-  Release notes can be [automatically generated from pull requests](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
+  Check the [Releases page](https://github.com/broadinstitute/gnomad_methods/releases) to make sure the generated release notes look ok
+  and edit them if necessary.
 
-  Alternatively, to see commits since the last release, use:
+  If needed, to see commits since the last release, use:
 
   ```
   LAST_RELEASE_TAG=$(git tag --list --sort=-committerdate | head -n1)


### PR DESCRIPTION
The last step in updating the release notes process. Currently, when a version tag (`v#.#.#`) is pushed, the tagged code is automatically published to PyPI. This extends that workflow to also automatically publish a corresponding [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) with [release notes generated from pull requests](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). This minimizes the chances of release notes being accidentally forgotten in the release process. Note that release notes can still be edited from the [Releases page](https://github.com/broadinstitute/gnomad_methods/releases) after the release is published.