### PR TITLE
Allow setting the default source for public resources with an environment variable

### DIFF
--- a/docs/resource_sources.rst
+++ b/docs/resource_sources.rst
@@ -5,7 +5,7 @@ gnomAD data is available through `multiple cloud providers' public datasets prog
 
 The functions in the :doc:`gnomad.resources </api_reference/resources/index>` package can be configured to load data from different sources.
 
-By default, resources are loaded from Google Cloud Public Datasets.
+By default, resources are loaded from Google Cloud Public Datasets. This can be configured using the ``GNOMAD_DEFAULT_PUBLIC_RESOURCE_SOURCE`` environment variable.
 
 To load resources from a different source (for example, the gnomAD project's public GCS bucket), use:
 
@@ -43,3 +43,13 @@ Alternatively, instead of using one of the pre-defined public sources, a custom 
     from gnomad.resources.config import gnomad_public_resource_configuration
 
     gnomad_public_resource_configuration.source = "gs://my-bucket/gnomad-resources"
+
+Environment Configuration
+-------------------------
+
+The default source can be configured through the ``GNOMAD_DEFAULT_PUBLIC_RESOURCE_SOURCE`` environment variable. This variable can be set to either the name of one of the public datasets programs or the URL of a custom source.
+
+Examples:
+
+- ``GNOMAD_DEFAULT_PUBLIC_RESOURCE_SOURCE="Google Cloud Public Datasets"``
+- ``GNOMAD_DEFAULT_PUBLIC_RESOURCE_SOURCE="gs://my-bucket/gnomad-resources"``

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -1,8 +1,12 @@
 """Configuration for loading resources."""
 
+import logging
 import os
 from enum import Enum
 from typing import Union
+
+
+logger = logging.getLogger(__name__)
 
 
 class GnomadPublicResourceSource(Enum):
@@ -29,8 +33,15 @@ def get_default_public_resource_source() -> Union[GnomadPublicResourceSource, st
         # Convert to a GnomadPublicResourceSource enum if possible
         try:
             default_source = GnomadPublicResourceSource(default_source_from_env)
+            logger.info(
+                "Using configured source for gnomAD resources: %s", default_source.value
+            )
             return default_source
         except ValueError:
+            logger.info(
+                "Using configured custom source for gnomAD resources: %s",
+                default_source_from_env,
+            )
             return default_source_from_env
 
     return GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -13,17 +13,19 @@ class GnomadPublicResourceSource(Enum):
     AZURE_OPEN_DATASETS = "Azure Open Datasets"
 
 
-DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE = (
-    GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
-)
+def get_default_public_resource_source() -> Union[GnomadPublicResourceSource, str]:
+    """
+    Get the default source for public gnomAD resources.
+
+    :returns: Default resource source
+    """
+    return GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
 
 
 class _GnomadPublicResourceConfiguration:
     """Configuration for public gnomAD resources."""
 
-    __source: Union[  # pylint: disable=unused-private-member
-        GnomadPublicResourceSource, str
-    ] = DEFAULT_GNOMAD_PUBLIC_RESOURCE_SOURCE
+    _source: Union[GnomadPublicResourceSource, str, None] = None
 
     @property
     def source(self) -> Union[GnomadPublicResourceSource, str]:
@@ -34,7 +36,10 @@ class _GnomadPublicResourceConfiguration:
 
         :returns: Source name or path to root of resources directory
         """
-        return self.__source
+        if self._source is None:
+            self._source = get_default_public_resource_source()
+
+        return self._source
 
     @source.setter
     def source(self, source: Union[GnomadPublicResourceSource, str]) -> None:
@@ -45,7 +50,7 @@ class _GnomadPublicResourceConfiguration:
 
         :param source: Source name or path to root of resources directory
         """
-        self.__source = source
+        self._source = source
 
 
 gnomad_public_resource_configuration = _GnomadPublicResourceConfiguration()

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -1,5 +1,6 @@
 """Configuration for loading resources."""
 
+import os
 from enum import Enum
 from typing import Union
 
@@ -19,6 +20,15 @@ def get_default_public_resource_source() -> Union[GnomadPublicResourceSource, st
 
     :returns: Default resource source
     """
+    default_source_from_env = os.getenv("GNOMAD_DEFAULT_PUBLIC_RESOURCE_SOURCE", None)
+    if default_source_from_env:
+        # Convert to a GnomadPublicResourceSource enum if possible
+        try:
+            default_source = GnomadPublicResourceSource(default_source_from_env)
+            return default_source
+        except ValueError:
+            return default_source_from_env
+
     return GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS
 
 

--- a/gnomad/resources/config.py
+++ b/gnomad/resources/config.py
@@ -17,6 +17,10 @@ class GnomadPublicResourceSource(Enum):
 def get_default_public_resource_source() -> Union[GnomadPublicResourceSource, str]:
     """
     Get the default source for public gnomAD resources.
+    
+    .. note::
+    
+        Default is pulled from the `GNOMAD_DEFAULT_PUBLIC_RESOURCE_SOURCE` environment variable if it exists. Otherwise `GOOGLE_CLOUD_PUBLIC_DATASETS` is used.
 
     :returns: Default resource source
     """

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -1,5 +1,6 @@
 """Tests for resource classes."""
 
+import os
 from typing import List, Tuple, Union
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ import pytest
 
 from gnomad.resources import resource_utils
 from gnomad.resources.config import (
+    get_default_public_resource_source,
     gnomad_public_resource_configuration,
     GnomadPublicResourceSource,
 )
@@ -132,6 +134,32 @@ class TestDefaultPublicResourceSource:
                 "gs://gnomad-public-requester-pays/example.ht"
             )
             assert resource.path == expected_path
+
+    @pytest.mark.parametrize(
+        "configured_default_source,expected_default_source",
+        [
+            ("gnomAD", GnomadPublicResourceSource.GNOMAD),
+            (
+                "Google Cloud Public Datasets",
+                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+            ),
+            (
+                "Registry of Open Data on AWS",
+                GnomadPublicResourceSource.REGISTRY_OF_OPEN_DATA_ON_AWS,
+            ),
+            ("Azure Open Datasets", GnomadPublicResourceSource.AZURE_OPEN_DATASETS),
+            ("gs://my-bucket/gnomad-resources", "gs://my-bucket/gnomad-resources"),
+        ],
+    )
+    def test_get_default_source_from_environment(
+        self, configured_default_source, expected_default_source
+    ):
+        """Test that default source is read from environment variable."""
+        with patch.dict(
+            os.environ,
+            {"GNOMAD_DEFAULT_PUBLIC_RESOURCE_SOURCE": configured_default_source},
+        ):
+            assert get_default_public_resource_source() == expected_default_source
 
 
 def gnomad_public_resource_test_parameters(

--- a/tests/resources/test_resource_utils.py
+++ b/tests/resources/test_resource_utils.py
@@ -96,6 +96,44 @@ class TestBlockMatrixResource:
         assert ds == read_block_matrix.return_value
 
 
+class TestDefaultPublicResourceSource:
+    """Tests for default public resource source."""
+
+    @pytest.mark.parametrize(
+        "default_source,expected_path",
+        [
+            (
+                GnomadPublicResourceSource.GOOGLE_CLOUD_PUBLIC_DATASETS,
+                "gs://gcp-public-data--gnomad/example.ht",
+            ),
+            (
+                GnomadPublicResourceSource.REGISTRY_OF_OPEN_DATA_ON_AWS,
+                "s3a://gnomad-public-us-east-1/example.ht",
+            ),
+            (
+                GnomadPublicResourceSource.AZURE_OPEN_DATASETS,
+                "wasbs://dataset@datasetgnomad.blob.core.windows.net/example.ht",
+            ),
+            (
+                "gs://my-bucket/gnomad-resources",
+                "gs://my-bucket/gnomad-resources/example.ht",
+            ),
+        ],
+    )
+    def test_read_from_default_source(self, default_source, expected_path):
+        """Test that resource paths are based on default source when no source is configured."""
+        gnomad_public_resource_configuration._source = None
+
+        with patch(
+            "gnomad.resources.config.get_default_public_resource_source",
+            return_value=default_source,
+        ):
+            resource = resource_utils.GnomadPublicTableResource(
+                "gs://gnomad-public-requester-pays/example.ht"
+            )
+            assert resource.path == expected_path
+
+
 def gnomad_public_resource_test_parameters(
     path: str,
 ) -> List[Tuple[str, Union[GnomadPublicResourceSource, str], str]]:


### PR DESCRIPTION
Some users may always prefer to use the AWS or Azure copies of gnomAD resources. This allows them to set a default source in an environment variable instead of having to configure it in every pipeline.

Once hail-is/hail#11230 is merged, `get_default_public_resource_source` can be extended to use Hail's guess for the current cloud provider to set the default resource source.

Related to #433