### PR TITLE
Updates public release file paths from requester pays to gcp public bucket

### DIFF
--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -68,7 +68,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: Path to release Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
+    return f"gs://gcp-public-data--gnomad/release/{version}/ht/{data_type}/gnomad.{data_type}.r{version}.sites.ht"
 
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
@@ -79,7 +79,7 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: path to coverage Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
+    return f"gs://gcp-public-data--gnomad/release/{version}/coverage/{data_type}/gnomad.{data_type}.r{version}.coverage.ht"
 
 
 def _public_pca_ht_path(subpop: str) -> str:
@@ -90,7 +90,7 @@ def _public_pca_ht_path(subpop: str) -> str:
     :return: Path to release Table
     """
     subpop = f".{subpop}" if subpop else ""
-    return f"gs://gnomad-public-requester-pays/release/2.1/pca/gnomad.r2.1.pca_loadings{subpop}.ht"
+    return f"gs://gcp-public-data--gnomad/release/2.1/pca/gnomad.r2.1.pca_loadings{subpop}.ht"
 
 
 def _liftover_data_path(data_type: str, version: str) -> str:
@@ -101,7 +101,7 @@ def _liftover_data_path(data_type: str, version: str) -> str:
     :param version: One of the release versions of gnomAD on GRCh37
     :return: Path to chosen Table
     """
-    return f"gs://gnomad-public-requester-pays/release/{version}/liftover_grch38/ht/{data_type}/gnomad.{data_type}.r{version}.sites.liftover_grch38.ht"
+    return f"gs://gcp-public-data--gnomad/release/{version}/liftover_grch38/ht/{data_type}/gnomad.{data_type}.r{version}.sites.liftover_grch38.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -221,7 +221,7 @@ gnomad_syndip = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
         "3.0": GnomadPublicMatrixTableResource(
-            path="gs://gnomad-public-requester-pays/truth-sets/hail-0.2/gnomad_v3_syndip.b38.mt"
+            path="gs://gcp-public-data--gnomad/truth-sets/hail-0.2/gnomad_v3_syndip.b38.mt"
         )
     },
 )
@@ -230,7 +230,7 @@ na12878 = VersionedMatrixTableResource(
     default_version="3.0",
     versions={
         "3.0": GnomadPublicMatrixTableResource(
-            path="gs://gnomad-public-requester-pays/truth-sets/hail-0.2/gnomad_v3_na12878.mt"
+            path="gs://gcp-public-data--gnomad/truth-sets/hail-0.2/gnomad_v3_na12878.mt"
         )
     },
 )
@@ -245,7 +245,7 @@ def _public_release_ht_path(data_type: str, version: str) -> str:
     :return: Path to release Table
     """
     version_prefix = "r" if version.startswith("3.0") else "v"
-    return f"gs://gnomad-public-requester-pays/release/{version}/ht/{data_type}/gnomad.{data_type}.{version_prefix}{version}.sites.ht"
+    return f"gs://gcp-public-data--gnomad/release/{version}/ht/{data_type}/gnomad.{data_type}.{version_prefix}{version}.sites.ht"
 
 
 def _public_coverage_ht_path(data_type: str, version: str) -> str:
@@ -257,7 +257,7 @@ def _public_coverage_ht_path(data_type: str, version: str) -> str:
     :return: path to coverage Table
     """
     version_prefix = "r" if version.startswith("3.0") else "v"
-    return f"gs://gnomad-public-requester-pays/release/{version}/coverage/{data_type}/gnomad.{data_type}.{version_prefix}{version}.coverage.ht"
+    return f"gs://gcp-public-data--gnomad/release/{version}/coverage/{data_type}/gnomad.{data_type}.{version_prefix}{version}.coverage.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:


### PR DESCRIPTION
This updates release file paths from our requestor pays bucket to the GCP public bucket. The majority of the files have been removed from our requester pays bucket and so release file calls are failing. 