### PR TITLE
Add update to Black version in requirements and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 19.10b0 # This should be kept in sync with the version in requirements-dev.in
+    rev: 22.3.0 # This should be kept in sync with the version in requirements-dev.in
     hooks:
       - id: black
         language_version: python3

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,4 @@
-black==19.10b0 # This should be kept in sync with the version in .pre-commit-config.yaml
+black==22.3.0 # This should be kept in sync with the version in .pre-commit-config.yaml
 pre-commit
 pydocstyle==6.0.0 # This should be kept in sync with the version in .pre-commit-config.yaml
 pylint


### PR DESCRIPTION
I got a pre-commit hook error when trying to commit.

The error was: `ImportError: cannot import name ‘_unicodefun’ from ‘click’ `

[This](https://github.com/psf/black/issues/2964) indicated that I needed to update the version of Black, and after that I was able to add a commit. 