### PR TITLE
Handle tags created through GitHub in publish release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,11 +47,29 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-      - name: Create release notes
+      - name: Create GitHub Release
         uses: actions/github-script@v5
         with:
           script: |
-            await github.request(`POST /repos/${{ github.repository }}/releases`, {
-              tag_name: "${{ github.ref }}",
-              generate_release_notes: true
-            });
+            // Get repository and tag from workflow context
+            // https://docs.github.com/en/actions/learn-github-actions/contexts
+            const repo = "${{ github.event.repository.name }}"
+            const owner = "${{ github.event.repository.owner.name }}"
+            const tag = "${{ github.ref }}".replace(/^refs\/tags\//, "")
+
+            // Create a GitHub Release for the tag if one doesn't already exist
+            try {
+              await github.rest.repos.getReleaseByTag({ owner, repo, tag })
+              console.log("Release already exists")
+            } catch (error) {
+              if (error.status === 404) {
+                console.log("Creating release")
+                await github.rest.repos.createRelease({
+                  owner, repo,
+                  tag_name: tag,
+                  generate_release_notes: true
+                })
+              } else {
+                throw error
+              }
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ https://packaging.python.org/guides/distributing-packages-using-setuptools/#pack
 
   The tag can be created using GitHub by [creating a GitHub Release with a new tag](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release).
 
-  Or the tag can be created locally and pushed to GitHub using:
+  Alternatively, the tag can be created locally and pushed to GitHub using:
 
   ```
   git checkout main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,31 +61,35 @@ See instructions in [docs/README.md](./docs/README.md).
 https://packaging.python.org/guides/distributing-packages-using-setuptools/#packaging-your-project
 
 - Update version in setup.py and commit.
-  Push changes to the master branch on GitHub or submit a pull request.
+  Push changes to the main branch on GitHub or submit a pull request.
   The new version number should be based on changes since the last release.
 
   https://semver.org/
 
   https://packaging.python.org/guides/distributing-packages-using-setuptools/#semantic-versioning-preferred
 
-- Once the version has been updated in the master branch on GitHub, tag the release.
-  The version tag should be applied to a commit on the master branch.
+- Once the version has been updated in the main branch on GitHub, tag the release.
+  The version tag should be applied to a commit on the main branch.
 
   The version number in the tag must match the version number in setup.py.
 
+  The tag can be created using GitHub by [creating a GitHub Release with a new tag](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release).
+
+  Or the tag can be created locally and pushed to GitHub using:
+
   ```
-  git checkout master
+  git checkout main
   git pull
 
   git tag v<version>
   git push origin v<version>
   ```
 
-  When a `v<VERSION_NUMBER>` tag is pushed to GitHub, an Actions workflow will automatically publish the tagged code to PyPI.
+- When a `v<VERSION_NUMBER>` tag is pushed to GitHub, an Actions workflow will automatically publish the tagged code to PyPI.
 
   New releases will automatically be posted in the #gnomad_notifications Slack channel (via the RSS Slack app).
 
-- A [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) will be automatically created with
+- If the version tag was created locally and pushed to GitHub, then a [GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) will be automatically created with
   [release notes generated from pull requests](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
 
   Check the [Releases page](https://github.com/broadinstitute/gnomad_methods/releases) to make sure the generated release notes look ok


### PR DESCRIPTION
Currently, the GitHub Actions workflow for publishing a release assumes that the version is tag is created locally and pushed to GitHub. It automatically creates a corresponding GitHub Release with automatically generated release notes.

https://github.com/broadinstitute/gnomad_methods/blob/00365eb7b11ae1f93ad865f1c56917b04c19006f/CONTRIBUTING.md#publishing-a-release

https://github.com/broadinstitute/gnomad_methods/blob/00365eb7b11ae1f93ad865f1c56917b04c19006f/.github/workflows/publish.yml#L50-L57

However, it's also possible to create a tag through GitHub by manually [creating a GitHub Release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release).

In that case, the last step of the release workflow fails because a release already exists for the tag. This happened for the [0.6.2 release](https://github.com/broadinstitute/gnomad_methods/runs/6375842345?check_suite_focus=true) and caused confusion because, while everything ended in the desired state (version tagged, code published to PyPI, and release notes in a GitHub Release), the publish release workflow showed as failed.

This changes the publish release workflow to handled the case where a tag is created through GitHub by first checking if a GitHub Release already exists for the version tag before attempting to create one.