### PR TITLE
Change branch name in CI workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   pylint:


### PR DESCRIPTION
Since renaming the default branch, the CI workflow (Pylint, etc.) is no longer running on commits to main because the workflow configuration still references the master branch.

While the CI workflow is running on PRs, it's also desirable to run it on commits to main since main is the version that's being published and used and it's possible for two concurrent PRs to make changes that pass independently but fail when combined. For example, if one PR added a use of a variable and another PR removed that variable.