### PR TITLE
Modify `merge_sample_qc_expr` to work with the additional VDS sample QC metrics: n_singleton_ti, n_singleton_tv, and r_ti_tv_singleton

### DIFF
--- a/gnomad/sample_qc/filtering.py
+++ b/gnomad/sample_qc/filtering.py
@@ -304,6 +304,8 @@ def merge_sample_qc_expr(
             "n_transition",
             "n_transversion",
             "n_star",
+            "n_singleton_ti",
+            "n_singleton_tv",
         ]
         + ["gq_over_" + f"{GQ}" for GQ in range(0, 70, 10)]
         + ["dp_over_" + f"{DP}" for DP in range(0, 40, 10)]
@@ -313,6 +315,7 @@ def merge_sample_qc_expr(
     ratio_metrics = [
         ("call_rate", "n_called", "n_not_called"),
         ("r_ti_tv", "n_transition", "n_transversion"),
+        ("r_ti_tv_singleton", "n_singleton_ti", "n_singleton_tv"),
         ("r_het_hom_var", "n_het", "n_hom_var"),
         ("r_insertion_deletion", "n_insertion", "n_deletion"),
     ]


### PR DESCRIPTION
We added three new metrics to the VDS sample QC output. This will modify `merge_sample_qc_expr` so that it handles those new annotations appropriately.
