### PR TITLE
Added description for GNOMAD_PUBLIC_BUCKETS

### DIFF
--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -18,7 +18,13 @@ logger = logging.getLogger("gnomad.resources")
 
 
 GNOMAD_PUBLIC_BUCKETS = ("gnomad-public", "gnomad-public-requester-pays")
+"""
+Public buckets used to stage gnomAD data.
 
+`gnomad-public` is a legacy bucket and contains one readme text file.
+The team writes output data to `gnomad-public-requester-pays`, and all data in this bucket
+syncs to the public bucket `gcp-public-data--gnomad`.
+"""
 
 # Resource classes
 class BaseResource(ABC):

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -22,7 +22,8 @@ GNOMAD_PUBLIC_BUCKETS = ("gnomad-public", "gnomad-public-requester-pays")
 Public buckets used to stage gnomAD data.
 
 `gnomad-public` is a legacy bucket and contains one readme text file.
-The team writes output data to `gnomad-public-requester-pays`, and all data in this bucket
+
+The gnomAD Production Team writes output data to `gnomad-public-requester-pays`, and all data in this bucket
 syncs to the public bucket `gcp-public-data--gnomad`.
 """
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.

To make sure that this change is included in release notes, please:
- Use a descriptive title for the pull request.
- Apply one of the "Changelog" labels (if applicable).

-->
This PR adds a description for the `GNOMAD_PUBLIC_BUCKETS constant`. Our current workflow is to write output data to a requester pays bucket, and all data within the requester pays bucket moves to a separate, non-requester pays public bucket. This workflow isn't super obvious in the repo, so I've added a note here to help clarify.