### PR TITLE
Add n_partitions option to get_qc_mt before LD pruning

### DIFF
--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -139,7 +139,7 @@ def get_qc_mt(
 
     In addition, the MT will be LD-pruned if `ld_r2` is set.
 
-    :param mt: Input MT
+    :param mt: Input MT.
     :param bi_allelic_only: Whether to only keep bi-allelic sites or include multi-allelic sites too.
     :param snv_only: Whether to only keep SNVs or include other variant types.
     :param adj_only: If set, only ADJ genotypes are kept. This filter is applied before the call rate and AF calculation.

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -188,7 +188,7 @@ def get_qc_mt(
     if ld_r2 is not None:
         if checkpoint_path:
             if partitions:
-                logger.info("Repartitioning MT and LD pruning")
+                logger.info("Checkpointing and repartitioning the MT and LD pruning")
                 qc_mt.write(checkpoint_path, overwrite=True)
                 qc_mt = hl.read_matrix_table(checkpoint_path, _n_partitions=partitions)
             else:

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -150,7 +150,7 @@ def get_qc_mt(
     :param filter_exome_low_coverage_regions: If set, only high coverage exome regions (computed from gnomAD are kept)
     :param high_conf_regions: If given, the data will be filtered to only include variants in those regions
     :param checkpoint_path: If given, the QC MT will be checkpointed to the specified path before running LD pruning. If not specified, persist will be used instead.
-    :param partitions: If given, the QC MT will be repartitioned to the specified number of partitions before running LD pruning. 'checkpoint_path' must also be specified as the MT will first be written to the checkpoint_path before being reread with with new number of partitions.
+    :param partitions: If given, the QC MT will be repartitioned to the specified number of partitions before running LD pruning. `checkpoint_path` must also be specified as the MT will first be written to the `checkpoint_path` before being reread with the new number of partitions.
     :return: Filtered MT
     """
     logger.info("Creating QC MatrixTable")

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -190,7 +190,9 @@ def get_qc_mt(
             if n_partitions:
                 logger.info("Checkpointing and repartitioning the MT and LD pruning")
                 qc_mt.write(checkpoint_path, overwrite=True)
-                qc_mt = hl.read_matrix_table(checkpoint_path, _n_partitions=n_partitions)
+                qc_mt = hl.read_matrix_table(
+                    checkpoint_path, _n_partitions=n_partitions
+                )
             else:
                 logger.info("Checkpointing the MT and LD pruning")
                 qc_mt = qc_mt.checkpoint(checkpoint_path, overwrite=True)


### PR DESCRIPTION
These edits add a 'partitions' parameter to the `get_qc_mt` function so that MTs can be repartitioned before the LD pruning step
