### PR TITLE
Add `gaussian_mixture_model_karyotype_assignment` function to assign sex karyotype using Gaussian mixture models

### DIFF
--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -395,7 +395,8 @@ def annotate_sex(
     if is_vds:
         if excluded_intervals is not None:
             raise NotImplementedError(
-                "The use of the parameter 'excluded_intervals' is currently not implemented for imputing sex chromosome ploidy on a VDS!"
+                "The use of the parameter 'excluded_intervals' is currently not implemented for imputing sex "
+                "chromosome ploidy on a VDS!"
             )
         # Begin by creating a ploidy estimate HT using the method defined by 'variants_only_x_ploidy'
         ploidy_ht = hl.vds.impute_sex_chromosome_ploidy(
@@ -473,8 +474,8 @@ def annotate_sex(
                     "chrY_mean_dp",
                     f"{normalization_contig}_mean_dp",
                 )
-                # If the `variants_only_y_ploidy' is True modify the name of the normalization contig mean DP to indicate
-                # that this is the variant dataset only mean DP (this will have already been added if
+                # If the `variants_only_y_ploidy' is True modify the name of the normalization contig mean DP to
+                # indicate that this is the variant dataset only mean DP (this will have already been added if
                 # 'variants_only_x_ploidy' was also True).
                 if variants_only_y_ploidy:
                     ploidy_ht = ploidy_ht.rename(
@@ -489,6 +490,7 @@ def annotate_sex(
             raise NotImplementedError(
                 "Imputing sex ploidy does not exist yet for dense data."
             )
+
     ploidy_ht = ploidy_ht.annotate_globals(
         variants_only_x_ploidy=variants_only_x_ploidy,
         variants_only_y_ploidy=variants_only_y_ploidy,
@@ -513,9 +515,10 @@ def annotate_sex(
 
         mt = hl.filter_intervals(mt, x_locus_intervals)
         if sites_ht is not None:
-            if aaf_expr == None:
+            if aaf_expr is None:
                 logger.warning(
-                    "sites_ht was provided, but aaf_expr is missing. Assuming name of field with alternate allele frequency is 'AF'."
+                    "sites_ht was provided, but aaf_expr is missing. Assuming name of field with alternate allele "
+                    "frequency is 'AF'."
                 )
                 aaf_expr = "AF"
             logger.info("Filtering to provided sites")

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -456,7 +456,7 @@ def annotate_sex(
             )
             ploidy_ht = ploidy_ht.rename(
                 {
-                    "autosomal_mean_dp": f"var_data_{normalization_contig}_mean_dp"
+                    f"{normalization_contig}_mean_dp": f"var_data_{normalization_contig}_mean_dp"
                     if variants_only_x_ploidy
                     else f"{normalization_contig}_mean_dp",
                 }

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -273,6 +273,7 @@ def infer_sex_karyotype(
     """
     logger.info("Inferring sex karyotype")
     if use_gaussian_mixture_model:
+        logger.info("Using Gaussian Mixture Model for karyotype assignment")
         gmm_sex_ht = gaussian_mixture_model_karyotype_assignment(ploidy_ht)
         x_ploidy_cutoffs, y_ploidy_cutoffs = get_ploidy_cutoffs(
             gmm_sex_ht,
@@ -281,6 +282,7 @@ def infer_sex_karyotype(
             aneuploidy_cutoff=aneuploidy_cutoff,
         )
     else:
+        logger.info("Using f-stat for karyotype assignment")
         x_ploidy_cutoffs, y_ploidy_cutoffs = get_ploidy_cutoffs(
             ploidy_ht,
             f_stat_cutoff=f_stat_cutoff,
@@ -364,7 +366,8 @@ def annotate_sex(
 
     :param mtds: Input MatrixTable or VariantDataset.
     :param is_sparse: Whether input MatrixTable is in sparse data format.
-    :param excluded_intervals: Optional table of intervals to exclude from the computation.
+    :param excluded_intervals: Optional table of intervals to exclude from the computation. This option is currently
+        not implemented for imputing sex chromosome ploidy on a VDS.
     :param included_intervals: Optional table of intervals to use in the computation. REQUIRED for exomes.
     :param normalization_contig: Which chromosome to use to normalize sex chromosome coverage. Used in determining sex
         chromosome ploidies.

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -536,7 +536,7 @@ def annotate_sex(
 
         logger.info("Annotating sex chromosome ploidy HT with impute_sex HT")
         ploidy_ht = ploidy_ht.annotate(**sex_ht[ploidy_ht.key])
-        ploidy_ht = ploidy_ht.annotate(f_stat_cutoff=f_stat_cutoff)
+        ploidy_ht = ploidy_ht.annotate_globals(f_stat_cutoff=f_stat_cutoff)
 
     if infer_karyotype:
         karyotype_ht = infer_sex_karyotype(

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -6,13 +6,13 @@ import operator
 
 import hail as hl
 from gnomad.sample_qc.sex import (
+    gaussian_mixture_model_karyotype_assignment,
     get_ploidy_cutoffs,
     get_sex_expr,
-    gaussian_mixture_model_karyotype_assignment,
 )
 from gnomad.utils.annotations import (
-    bi_allelic_site_inbreeding_expr,
     bi_allelic_expr,
+    bi_allelic_site_inbreeding_expr,
 )
 from gnomad.utils.filtering import filter_low_conf_regions, filter_to_adj
 from gnomad.utils.reference_genome import get_reference_genome

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -44,9 +44,9 @@ def filter_rows_for_qc(
     :param min_callrate: Minimum site call rate to keep. Not applied if set to ``None``.
     :param min_inbreeding_coeff_threshold: Minimum site inbreeding coefficient to keep. Not applied if set to ``None``.
     :param min_hardy_weinberg_threshold: Minimum site HW test p-value to keep. Not applied if set to ``None``.
-    :paramapply_hard_filters: Whether to apply standard GAKT default site hard filters: QD >= 2, FS <= 60 and MQ >= 30
-    :parambi_allelic_only: Whether to only keep bi-allelic sites or include multi-allelic sites too
-    :paramsnv_only: Whether to only keep SNVs or include other variant types
+    :param apply_hard_filters: Whether to apply standard GAKT default site hard filters: QD >= 2, FS <= 60 and MQ >= 30
+    :param bi_allelic_only: Whether to only keep bi-allelic sites or include multi-allelic sites too
+    :param snv_only: Whether to only keep SNVs or include other variant types
     :return: annotated and filtered table
     """
     annotation_expr = {}

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -268,7 +268,8 @@ def infer_sex_karyotype(
     :param use_gaussian_mixture_model: Use gaussian mixture model to split samples into 'XX' and 'XY' instead of f-stat.
     :param normal_ploidy_cutoff: Number of standard deviations to use when determining sex chromosome ploidy cutoffs.
         for XX, XY karyotypes.
-    :param aneuploidy_cutoff: Number of standard deviations to use when sex chromosome ploidy cutoffs for aneuploidies.
+    :param aneuploidy_cutoff: Number of standard deviations to use when determining sex chromosome ploidy cutoffs for
+        aneuploidies.
     :return: Table of samples imputed sex karyotype.
     """
     logger.info("Inferring sex karyotype")

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -177,8 +177,10 @@ def get_ploidy_cutoffs(
         determine means and standard deviations for these categories and are not used in the final karyotype annotation.
 
     :param ht: Table with f_stat and sex chromosome ploidies
-    :param f_stat_cutoff: f-stat to roughly divide 'XX' from 'XY' samples. Assumes XX samples are below cutoff and XY are above cutoff.
-    :param normal_ploidy_cutoff: Number of standard deviations to use when determining sex chromosome ploidy cutoffs for XX, XY karyotypes.
+    :param f_stat_cutoff: f-stat to roughly divide 'XX' from 'XY' samples. Assumes XX samples are below cutoff and XY
+        are above cutoff.
+    :param normal_ploidy_cutoff: Number of standard deviations to use when determining sex chromosome ploidy cutoffs
+        for XX, XY karyotypes.
     :param aneuploidy_cutoff: Number of standard deviations to use when sex chromosome ploidy cutoffs for aneuploidies.
     :param group_by_expr: Expression grouping samples into 'XX' and 'XY'. Can be used instead of and `f_stat_cutoff`.
     :return: Tuple of ploidy cutoff tuples: ((x_ploidy_cutoffs), (y_ploidy_cutoffs))
@@ -244,8 +246,10 @@ def get_sex_expr(
 
     :param chr_x_ploidy: Chromosome X ploidy (or relative ploidy)
     :param chr_y_ploidy: Chromosome Y ploidy (or relative ploidy)
-    :param x_ploidy_cutoffs: Tuple of X chromosome ploidy cutoffs: (upper cutoff for single X, (lower cutoff for double X, upper cutoff for double X), lower cutoff for triple X)
-    :param y_ploidy_cutoffs: Tuple of Y chromosome ploidy cutoffs: ((lower cutoff for single Y, upper cutoff for single Y), lower cutoff for double Y)
+    :param x_ploidy_cutoffs: Tuple of X chromosome ploidy cutoffs: (upper cutoff for single X, (lower cutoff for
+        double X, upper cutoff for double X), lower cutoff for triple X)
+    :param y_ploidy_cutoffs: Tuple of Y chromosome ploidy cutoffs: ((lower cutoff for single Y, upper cutoff for
+        single Y), lower cutoff for double Y)
     :return: Struct containing X_karyotype, Y_karyotype, and sex_karyotype
     """
     sex_expr = hl.struct(

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -79,9 +79,9 @@ def gaussian_mixture_model_karyotype_assignment(
     an X karyotype and a Y karyotype which are then combined into the sex karyotype.
 
     The following annotations are added:
-        - `karyotype_output_prefix`_x_karyotype
-        - `karyotype_output_prefix`_y_karyotype
-        - `karyotype_output_prefix`_karyotype = `karyotype_output_prefix`_x_karyotype + `karyotype_output_prefix`_y_karyotype
+        - {karyotype_output_prefix}_x_karyotype
+        - {karyotype_output_prefix_y_karyotype
+        - {karyotype_output_prefix}_karyotype = {karyotype_output_prefix}_x_karyotype + {karyotype_output_prefix}_y_karyotype
 
     .. note::
 

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -194,8 +194,12 @@ def get_ploidy_cutoffs(
     :param group_by_expr: Expression grouping samples into 'XX' and 'XY'. Can be used instead of and `f_stat_cutoff`.
     :return: Tuple of ploidy cutoff tuples: ((x_ploidy_cutoffs), (y_ploidy_cutoffs))
     """
-    if f_stat_cutoff is None and group_by_expr is None:
-        raise ValueError("One of 'f_stat_cutoff' or 'group_by_expr' must be supplied!")
+    if (f_stat_cutoff is None and group_by_expr is None) or (
+        f_stat_cutoff is not None and group_by_expr is not None
+    ):
+        raise ValueError(
+            "One and only one of 'f_stat_cutoff' or 'group_by_expr' must be supplied!"
+        )
 
     # If 'f_stat_cutoff' is supplied, group the sex chromosome ploidy table by f_stat cutoff
     if f_stat_cutoff is not None:

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -1,9 +1,12 @@
 # noqa: D100
 
 import logging
-from typing import Tuple
+from typing import Tuple, Union
 
 import hail as hl
+import numpy as np
+import pandas as pd
+from sklearn.mixture import GaussianMixture
 
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger(__name__)

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -197,6 +197,10 @@ def get_ploidy_cutoffs(
             hl.struct(x=hl.agg.stats(ht.chrX_ploidy), y=hl.agg.stats(ht.chrY_ploidy)),
         )
     )
+    if "xx" not in sex_stats:
+        raise ValueError("No samples are grouped as XX!")
+    if "xy" not in sex_stats:
+        raise ValueError("No samples are grouped as XY!")
     logger.info("XX stats: %s", sex_stats["xx"])
     logger.info("XY stats: %s", sex_stats["xy"])
 

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -159,7 +159,8 @@ def get_ploidy_cutoffs(
 
     .. note::
 
-        This assumes the input hail Table has the fields f_stat, chrX_ploidy, and chrY_ploidy.
+        This assumes the input hail Table has the fields chrX_ploidy, and chrY_ploidy, and f_stat if `f_stat_cutoff` is
+        set.
 
     Return a tuple of sex chromosome ploidy cutoffs: ((x_ploidy_cutoffs), (y_ploidy_cutoffs)).
     x_ploidy_cutoffs: (upper cutoff for single X, (lower cutoff for double X, upper cutoff for double X), lower cutoff for triple X)
@@ -168,12 +169,18 @@ def get_ploidy_cutoffs(
     Uses the normal_ploidy_cutoff parameter to determine the ploidy cutoffs for XX and XY karyotypes.
     Uses the aneuploidy_cutoff parameter to determine the cutoffs for sex aneuploidies.
 
-    Note that f-stat is used only to split the samples into roughly 'XX' and 'XY' categories and is not used in the final karyotype annotation.
+    .. note::
+
+        `f_stat_cutoff` or `group_by_expr` must be supplied. If `f_stat_cutoff` is supplied then f-stat is used to
+        split the samples into roughly 'XX' and 'XY'. If `group_by_expr` is supplied instead, then it must include an
+        annotation grouping samples by 'XX' and 'XY'. These are both only used to divide samples into XX and XY to
+        determine means and standard deviations for these categories and are not used in the final karyotype annotation.
 
     :param ht: Table with f_stat and sex chromosome ploidies
     :param f_stat_cutoff: f-stat to roughly divide 'XX' from 'XY' samples. Assumes XX samples are below cutoff and XY are above cutoff.
     :param normal_ploidy_cutoff: Number of standard deviations to use when determining sex chromosome ploidy cutoffs for XX, XY karyotypes.
     :param aneuploidy_cutoff: Number of standard deviations to use when sex chromosome ploidy cutoffs for aneuploidies.
+    :param group_by_expr: Expression grouping samples into 'XX' and 'XY'. Can be used instead of and `f_stat_cutoff`.
     :return: Tuple of ploidy cutoff tuples: ((x_ploidy_cutoffs), (y_ploidy_cutoffs))
     """
     if f_stat_cutoff is None and group_by_expr is None:

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -199,7 +199,7 @@ def get_ploidy_cutoffs(
 
     # If 'f_stat_cutoff' is supplied, group the sex chromosome ploidy table by f_stat cutoff
     if f_stat_cutoff is not None:
-        group_by_expr = hl.cond(ht.f_stat < f_stat_cutoff, "XX", "XY")
+        group_by_expr = hl.if_else(ht.f_stat < f_stat_cutoff, "XX", "XY")
 
     # Get mean/stdev for chrX/Y ploidies based on 'group_by_expr'
     sex_stats = ht.aggregate(

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -188,7 +188,7 @@ def get_ploidy_cutoffs(
 
     # If 'f_stat_cutoff' is supplied, group the sex chromosome ploidy table by f_stat cutoff
     if f_stat_cutoff is not None:
-        group_by_expr = hl.cond(ht.f_stat < f_stat_cutoff, "xx", "xy")
+        group_by_expr = hl.cond(ht.f_stat < f_stat_cutoff, "XX", "XY")
 
     # Get mean/stdev for chrX/Y ploidies based on 'group_by_expr'
     sex_stats = ht.aggregate(
@@ -197,32 +197,32 @@ def get_ploidy_cutoffs(
             hl.struct(x=hl.agg.stats(ht.chrX_ploidy), y=hl.agg.stats(ht.chrY_ploidy)),
         )
     )
-    if "xx" not in sex_stats:
+    if "XX" not in sex_stats:
         raise ValueError("No samples are grouped as XX!")
-    if "xy" not in sex_stats:
+    if "XX" not in sex_stats:
         raise ValueError("No samples are grouped as XY!")
-    logger.info("XX stats: %s", sex_stats["xx"])
-    logger.info("XY stats: %s", sex_stats["xy"])
+    logger.info("XX stats: %s", sex_stats["XX"])
+    logger.info("XY stats: %s", sex_stats["XY"])
 
     cutoffs = (
         (
-            sex_stats["xy"].x.mean + (normal_ploidy_cutoff * sex_stats["xy"].x.stdev),
+            sex_stats["XY"].x.mean + (normal_ploidy_cutoff * sex_stats["XY"].x.stdev),
             (
-                sex_stats["xx"].x.mean
-                - (normal_ploidy_cutoff * sex_stats["xx"].x.stdev),
-                sex_stats["xx"].x.mean
-                + (normal_ploidy_cutoff * sex_stats["xx"].x.stdev),
+                sex_stats["XX"].x.mean
+                - (normal_ploidy_cutoff * sex_stats["XX"].x.stdev),
+                sex_stats["XX"].x.mean
+                + (normal_ploidy_cutoff * sex_stats["XX"].x.stdev),
             ),
-            sex_stats["xx"].x.mean + (aneuploidy_cutoff * sex_stats["xx"].x.stdev),
+            sex_stats["XX"].x.mean + (aneuploidy_cutoff * sex_stats["XX"].x.stdev),
         ),
         (
             (
-                sex_stats["xx"].y.mean
-                + (normal_ploidy_cutoff * sex_stats["xx"].y.stdev),
-                sex_stats["xy"].y.mean
-                + (normal_ploidy_cutoff * sex_stats["xy"].y.stdev),
+                sex_stats["XX"].y.mean
+                + (normal_ploidy_cutoff * sex_stats["XX"].y.stdev),
+                sex_stats["XY"].y.mean
+                + (normal_ploidy_cutoff * sex_stats["XY"].y.stdev),
             ),
-            sex_stats["xy"].y.mean + (aneuploidy_cutoff * sex_stats["xy"].y.stdev),
+            sex_stats["XY"].y.mean + (aneuploidy_cutoff * sex_stats["XY"].y.stdev),
         ),
     )
 

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -661,11 +661,11 @@ def impute_sex_ploidy(
         if use_only_variants:
             if included_calling_intervals is not None:
                 chr_mt = chr_mt.filter_rows(
-                    hl.is_defined(included_calling_intervals[chr_mt.row_key])
+                    hl.is_defined(included_calling_intervals[chr_mt.locus])
                 )
             if excluded_calling_intervals is not None:
                 chr_mt = chr_mt.filter_rows(
-                    hl.is_missing(excluded_calling_intervals[chr_mt.row_key])
+                    hl.is_missing(excluded_calling_intervals[chr_mt.locus])
                 )
             return chr_mt.select_cols(
                 **{


### PR DESCRIPTION
Modify `get_ploidy_cutoffs` to accept an expression for grouping samples into 'XX' and 'XY' groupings.
Modify `annotate_sex` to allow for sex karyotype imputation to use a gaussian mixture model to determine grouping of samples into 'XX' and 'XY' for use in `get_ploidy_cutoffs`.
Modify `annotate_sex` to make computing f-stat and inferring sex karyotype optional.