### PR TITLE
Add `variants_filter_lcr`, `variants_filter_segdup` and `variants_snv_only` options to `annotate_sex` to filter variants prior to variant only ploidy imputation

### DIFF
--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -501,13 +501,9 @@ def annotate_sex(
         if variants_filter_lcr or variants_filter_segdup or variants_filter_decoy:
             logger.info(
                 "Filtering out variants in: %s",
-                ("segmental duplications, "
-                if variants_filter_segdup
-                else "") + ("low confidence regions, "
-                if variants_filter_lcr
-                else "") + (" decoy regions"
-                if variants_filter_decoy
-                else "")
+                ("segmental duplications, " if variants_filter_segdup else "")
+                + ("low confidence regions, " if variants_filter_lcr else "")
+                + (" decoy regions" if variants_filter_decoy else ""),
             )
             filtered_mt = filter_low_conf_regions(
                 filtered_mt,

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -453,7 +453,7 @@ def annotate_sex(
         )
         if is_vds:
             ploidy_ht = hl.vds.impute_sex_chromosome_ploidy(
-                hl.vds.filter_chromosomes(mtds, keep=ref_keep_contigs),
+                hl.vds.filter_intervals(mtds, ref_keep_locus_intervals),
                 calling_intervals=included_intervals,
                 normalization_contig=normalization_contig,
                 use_variant_dataset=False,

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -401,111 +401,122 @@ def annotate_sex(
                 "The use of the parameter 'excluded_intervals' is currently not implemented for imputing sex "
                 "chromosome ploidy on a VDS!"
             )
-        # Begin by creating a ploidy estimate HT using the method defined by 'variants_only_x_ploidy'
-        ploidy_ht = hl.vds.impute_sex_chromosome_ploidy(
-            mtds,
-            calling_intervals=included_intervals,
-            normalization_contig=normalization_contig,
-            use_variant_dataset=variants_only_x_ploidy,
-        )
-        ploidy_ht = ploidy_ht.rename(
-            {
-                "x_ploidy": "chrX_ploidy",
-                "y_ploidy": "chrY_ploidy",
-                "x_mean_dp": "chrX_mean_dp",
-                "y_mean_dp": "chrY_mean_dp",
-                "autosomal_mean_dp": f"var_data_{normalization_contig}_mean_dp"
-                if variants_only_x_ploidy
-                else f"{normalization_contig}_mean_dp",
-            }
-        )
-        # If 'variants_only_y_ploidy' is different from 'variants_only_x_ploidy' then re-run the ploidy estimation using
-        # the method defined by 'variants_only_y_ploidy' and re-annotate with the modified ploidy estimates.
-        if variants_only_y_ploidy != variants_only_x_ploidy:
-            y_ploidy_ht = hl.vds.impute_sex_chromosome_ploidy(
-                mtds,
-                calling_intervals=included_intervals,
-                normalization_contig=normalization_contig,
-                use_variant_dataset=variants_only_y_ploidy,
-            )
-            y_ploidy_idx = y_ploidy_ht[ploidy_ht.key]
-            ploidy_ht = ploidy_ht.annotate(
-                chrY_ploidy=y_ploidy_idx.y_ploidy,
-                chrY_mean_dp=y_ploidy_idx.y_mean_dp,
-            )
-
-            # If the `variants_only_y_ploidy' is True modify the name of the normalization contig mean DP to indicate
-            # that this is the variant dataset only mean DP (this will have already been added if
-            # 'variants_only_x_ploidy' was also True).
-            if variants_only_y_ploidy:
-                ploidy_ht = ploidy_ht.annotate(
-                    **{
-                        f"var_data_{normalization_contig}_mean_dp": y_ploidy_idx.autosomal_mean_dp
-                    }
-                )
-
         mt = mtds.variant_data
     else:
-        mt = mtds
-        if is_sparse:
-            ploidy_ht = impute_sex_ploidy(
-                mt,
-                excluded_intervals,
-                included_intervals,
-                normalization_contig,
-                use_only_variants=variants_only_x_ploidy,
-            )
-            ploidy_ht = ploidy_ht.rename(
-                {
-                    f"{normalization_contig}_mean_dp": f"var_data_{normalization_contig}_mean_dp"
-                    if variants_only_x_ploidy
-                    else f"{normalization_contig}_mean_dp",
-                }
-            )
-            # If 'variants_only_y_ploidy' is different from 'variants_only_x_ploidy' then re-run the ploidy estimation
-            # using the method defined by 'variants_only_y_ploidy' and re-annotate with the modified ploidy estimates.
-            if variants_only_y_ploidy != variants_only_x_ploidy:
-                y_ploidy_ht = impute_sex_ploidy(
-                    mt,
-                    excluded_intervals,
-                    included_intervals,
-                    normalization_contig,
-                    use_only_variants=variants_only_y_ploidy,
-                )
-                y_ploidy_ht.select(
-                    "chrY_ploidy",
-                    "chrY_mean_dp",
-                    f"{normalization_contig}_mean_dp",
-                )
-                # If the `variants_only_y_ploidy' is True modify the name of the normalization contig mean DP to
-                # indicate that this is the variant dataset only mean DP (this will have already been added if
-                # 'variants_only_x_ploidy' was also True).
-                if variants_only_y_ploidy:
-                    ploidy_ht = ploidy_ht.rename(
-                        {
-                            f"{normalization_contig}_mean_dp": f"var_data_{normalization_contig}_mean_dp"
-                        }
-                    )
-                # Re-annotate the ploidy HT with modified Y ploidy annotations
-                ploidy_ht = ploidy_ht.annotate(**y_ploidy_ht[ploidy_ht.key])
-
-        else:
+        if not is_sparse:
             raise NotImplementedError(
                 "Imputing sex ploidy does not exist yet for dense data."
             )
+        mt = mtds
+
+    # Determine the contigs that are needed for variant only and reference block only sex ploidy imputation
+    rg = get_reference_genome(mt.locus)
+    x_contigs = set(rg.x_contigs)
+    y_contigs = set(rg.y_contigs)
+    if variants_only_x_ploidy:
+        var_keep_contigs = x_contigs | {normalization_contig}
+        ref_keep_contigs = set()
+    else:
+        ref_keep_contigs = x_contigs | {normalization_contig}
+        var_keep_contigs = set()
+    if variants_only_y_ploidy:
+        var_keep_contigs = {normalization_contig} | var_keep_contigs | y_contigs
+    else:
+        ref_keep_contigs = {normalization_contig} | ref_keep_contigs | y_contigs
+
+    ref_keep_locus_intervals = [
+        hl.parse_locus_interval(contig, reference_genome=rg.name)
+        for contig in ref_keep_contigs
+    ]
+    var_keep_locus_intervals = [
+        hl.parse_locus_interval(contig, reference_genome=rg.name)
+        for contig in var_keep_contigs
+    ]
+    x_locus_intervals = [
+        hl.parse_locus_interval(contig, reference_genome=rg.name)
+        for contig in x_contigs
+    ]
+
+    if ref_keep_contigs:
+        logger.info(
+            "Imputing sex chromosome ploidy using only reference block depth information on the following contigs: %s",
+            ref_keep_contigs,
+        )
+        if is_vds:
+            ploidy_ht = hl.vds.impute_sex_chromosome_ploidy(
+                hl.vds.filter_chromosomes(mtds, keep=ref_keep_contigs),
+                calling_intervals=included_intervals,
+                normalization_contig=normalization_contig,
+                use_variant_dataset=False,
+            )
+            ploidy_ht = ploidy_ht.rename(
+                {
+                    "x_ploidy": "chrX_ploidy",
+                    "y_ploidy": "chrY_ploidy",
+                    "x_mean_dp": "chrX_mean_dp",
+                    "y_mean_dp": "chrY_mean_dp",
+                }
+            )
+        else:
+            ploidy_ht = impute_sex_ploidy(
+                hl.filter_intervals(mt, ref_keep_locus_intervals),
+                excluded_intervals,
+                included_intervals,
+                normalization_contig,
+                use_only_variants=False,
+            )
+        if variants_only_x_ploidy:
+            ploidy_ht = ploidy_ht.drop("chrX_ploidy", "chrX_mean_dp")
+        if variants_only_y_ploidy:
+            ploidy_ht = ploidy_ht.drop("chrY_ploidy", "chrY_mean_dp")
+
+    if var_keep_contigs:
+        logger.info(
+            "Imputing sex chromosome ploidy using only variant depth information on the following contigs: %s",
+            var_keep_contigs,
+        )
+        if is_vds:
+            var_ploidy_ht = hl.vds.impute_sex_chromosome_ploidy(
+                hl.vds.filter_intervals(vds, var_keep_locus_intervals),
+                calling_intervals=included_intervals,
+                normalization_contig=normalization_contig,
+                use_variant_dataset=True,
+            )
+            var_ploidy_ht = var_ploidy_ht.rename(
+                {
+                    "autosomal_mean_dp": f"var_data_{normalization_contig}_mean_dp",
+                    "x_ploidy": "chrX_ploidy",
+                    "y_ploidy": "chrY_ploidy",
+                    "x_mean_dp": "chrX_mean_dp",
+                    "y_mean_dp": "chrY_mean_dp",
+                }
+            )
+        else:
+            var_ploidy_ht = impute_sex_ploidy(
+                hl.filter_intervals(mt, var_keep_locus_intervals),
+                excluded_intervals,
+                included_intervals,
+                normalization_contig,
+                use_only_variants=True,
+            )
+            var_ploidy_ht = var_ploidy_ht.rename(
+                {
+                    f"{normalization_contig}_mean_dp": f"var_data_{normalization_contig}_mean_dp"
+                }
+            )
+
+        if ref_keep_contigs:
+            ploidy_ht = var_ploidy_ht.annotate(**ploidy_ht[var_ploidy_ht.key])
+        else:
+            ploidy_ht = var_ploidy_ht
 
     ploidy_ht = ploidy_ht.annotate_globals(
+        normalization_contig=normalization_contig,
         variants_only_x_ploidy=variants_only_x_ploidy,
         variants_only_y_ploidy=variants_only_y_ploidy,
     )
 
     if compute_fstat:
-        rg = get_reference_genome(mt.locus)
-        x_contigs = rg.x_contigs
-        x_locus_intervals = [
-            hl.parse_locus_interval(contig, reference_genome=rg.name)
-            for contig in x_contigs
-        ]
         logger.info("Filtering mt to biallelic SNPs in X contigs: %s", x_contigs)
         if "was_split" in list(mt.row):
             mt = mt.filter_rows(

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -501,13 +501,13 @@ def annotate_sex(
         if variants_filter_lcr or variants_filter_segdup or variants_filter_decoy:
             logger.info(
                 "Filtering out variants in: %s",
-                "segmental duplications "
+                ("segmental duplications, "
                 if variants_filter_segdup
-                else "" + "low confidence regions "
+                else "") + ("low confidence regions, "
                 if variants_filter_lcr
-                else "" + " decoy regions"
-                if variants_filter_lcr
-                else "",
+                else "") + (" decoy regions"
+                if variants_filter_decoy
+                else "")
             )
             filtered_mt = filter_low_conf_regions(
                 filtered_mt,

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -334,6 +334,9 @@ def annotate_sex(
     aaf_threshold: float = 0.001,
     variants_only_x_ploidy: bool = False,
     variants_only_y_ploidy: bool = False,
+    variants_filter_lcr: bool = True,
+    variants_filter_segdup: bool = True,
+    variants_snv_only: bool = False,
     compute_fstat: bool = True,
     infer_karyotype: bool = True,
     use_gaussian_mixture_model: bool = False,
@@ -380,6 +383,12 @@ def annotate_sex(
     :param aaf_threshold: Minimum alternate allele frequency to be used in f-stat calculations. Default is 0.001.
     :param variants_only_x_ploidy: Whether to use depth of only variant data for the x ploidy estimation.
     :param variants_only_y_ploidy: Whether to use depth of only variant data for the y ploidy estimation.
+    :param variants_filter_lcr: Whether to filter out variants in LCR regions for variants only ploidy estimation and
+        fraction of homozygous alternate variants on chromosome X. Default is True.
+    :param variants_filter_segdup: Whether to filter out variants in segdup regions for variants only ploidy estimation
+        and fraction of homozygous alternate variants on chromosome X. Default is True.
+    :param variants_snv_only: Whether to filter to only single nucleotide variants for variants only ploidy estimation
+        and fraction of homozygous alternate variants on chromosome X. Default is False.
     :param compute_fstat: Whether to compute f-stat. Default is True.
     :param infer_karyotype: Whether to infer sex karyotypes. Default is True.
     :param use_gaussian_mixture_model: Whether to use gaussian mixture model to split samples into 'XX' and 'XY'
@@ -472,12 +481,35 @@ def annotate_sex(
 
     if var_keep_contigs:
         logger.info(
+            "Filtering variants for variant only sex chromosome ploidy imputation."
+        )
+        filtered_mt = hl.filter_intervals(mt, var_keep_locus_intervals)
+        if variants_filter_lcr or variants_filter_segdup:
+            logger.info(
+                "Filtering out variants in %s",
+                f"segmental duplications {'and low confidence regions' if variants_filter_lcr else ''}"
+                if variants_filter_segdup
+                else " low confidence regions ",
+            )
+            filtered_mt = filter_low_conf_regions(
+                filtered_mt,
+                filter_lcr=variants_filter_lcr,
+                filter_decoy=False,
+                filter_segdup=variants_filter_segdup,
+            )
+        if variants_snv_only:
+            logger.info("Filtering to SNVs")
+            filtered_mt = filtered_mt.filter_rows(
+                hl.is_snp(filtered_mt.alleles[0], filtered_mt.alleles[1])
+            )
+
+        logger.info(
             "Imputing sex chromosome ploidy using only variant depth information on the following contigs: %s",
             var_keep_contigs,
         )
         if is_vds:
             var_ploidy_ht = hl.vds.impute_sex_chromosome_ploidy(
-                hl.vds.filter_intervals(vds, var_keep_locus_intervals),
+                hl.vds.VariantDataset(mtds.reference_data, filtered_mt),
                 calling_intervals=included_intervals,
                 normalization_contig=normalization_contig,
                 use_variant_dataset=True,
@@ -493,7 +525,7 @@ def annotate_sex(
             )
         else:
             var_ploidy_ht = impute_sex_ploidy(
-                hl.filter_intervals(mt, var_keep_locus_intervals),
+                filtered_mt,
                 excluded_intervals,
                 included_intervals,
                 normalization_contig,
@@ -503,6 +535,11 @@ def annotate_sex(
                 {
                     f"{normalization_contig}_mean_dp": f"var_data_{normalization_contig}_mean_dp"
                 }
+            )
+            var_ploidy_ht = var_ploidy_ht.annotate_globals(
+                variants_filter_lcr=variants_filter_lcr,
+                variants_segdup=variants_filter_segdup,
+                variants_snv_only=variants_snv_only,
             )
 
         if ref_keep_contigs:


### PR DESCRIPTION
NOTE: This PR is stacked on the add_gaussian_karyotype PR #478

If helpful for testing:
```
import hail as hl
from gnomad_qc.v4.resources.basics import (
    calling_intervals,
    get_gnomad_v4_vds,
)
from bokeh.plotting import output_notebook, show

hl.init(default_reference='GRCh38')
output_notebook()

vds = get_gnomad_v4_vds(
    remove_hard_filtered_samples=False,
    remove_hard_filtered_samples_no_sex=True,
    test=True,
)
mt = hl.vds.to_merged_sparse_mt(vds)
calling_intervals=calling_intervals(interval_name='intersection', calling_interval_padding=50).ht()
freq_ht = hl.read_table("gs://gnomad/v4.0/sample_qc/exomes/gnomad.exomes.v4.0.f_stat_sites.ht")
sex_ht = annotate_sex(vds, included_intervals=calling_intervals, sites_ht=freq_ht, f_stat_cutoff=-1, aaf_expr="AF", gt_expr="LGT", use_gaussian_mixture_model=True)
sex_ht2 = annotate_sex(mt, included_intervals=calling_intervals, sites_ht=freq_ht, f_stat_cutoff=-1, aaf_expr="AF", gt_expr="LGT", use_gaussian_mixture_model=True)
sex_ht3 = annotate_sex(vds, included_intervals=calling_intervals, sites_ht=freq_ht, f_stat_cutoff=-1, aaf_expr="AF", gt_expr="LGT", use_gaussian_mixture_model=True, variants_only_x_ploidy=True)
sex_ht4 = annotate_sex(mt, included_intervals=calling_intervals, sites_ht=freq_ht, f_stat_cutoff=-1, aaf_expr="AF", gt_expr="LGT", use_gaussian_mixture_model=True, variants_only_x_ploidy=True)

show(hl.plot.scatter(sex_ht.chrX_ploidy, sex_ht.chrY_ploidy, label=sex_ht.sex_karyotype))
show(hl.plot.scatter(sex_ht2.chrX_ploidy, sex_ht2.chrY_ploidy, label=sex_ht2.sex_karyotype))
show(hl.plot.scatter(sex_ht3.chrX_ploidy, sex_ht3.chrY_ploidy, label=sex_ht3.sex_karyotype))
show(hl.plot.scatter(sex_ht4.chrX_ploidy, sex_ht4.chrY_ploidy, label=sex_ht4.sex_karyotype))
```
