### PR TITLE
Add an option `compute_x_frac_variants_hom_alt` to `annotate_sex` that computes the fraction of variants on chromosome X that are homozygous alternate per sample

### DIFF
--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -503,12 +503,9 @@ def annotate_sex(
             "Filtering variants for variant only sex chromosome ploidy imputation and/or computation of the fraction "
             "of homozygous alternate variants on chromosome X",
         )
-        if variants_only_x_ploidy:
-            filtered_mt = hl.filter_intervals(mt, var_keep_locus_intervals)
-        else:
-            filtered_mt = hl.filter_intervals(
-                mt, var_keep_locus_intervals + x_locus_intervals
-            )
+        filtered_mt = hl.filter_intervals(
+            mt, var_keep_locus_intervals + x_locus_intervals
+        )
         if variants_filter_lcr or variants_filter_segdup or variants_filter_decoy:
             logger.info(
                 "Filtering out variants in: %s",


### PR DESCRIPTION
NOTE: This PR is stacked on the annotate_sex_variant_filters PR #479

If helpful for testing:
```
import hail as hl
from gnomad_qc.v4.resources.basics import (
    calling_intervals,
    get_gnomad_v4_vds,
)
from bokeh.plotting import output_notebook, show

hl.init(default_reference='GRCh38')
output_notebook()

vds = get_gnomad_v4_vds(
    remove_hard_filtered_samples=False,
    remove_hard_filtered_samples_no_sex=True,
    test=True,
)
calling_intervals=calling_intervals(interval_name='intersection', calling_interval_padding=50).ht()
freq_ht = hl.read_table("gs://gnomad/v4.0/sample_qc/exomes/gnomad.exomes.v4.0.f_stat_sites.ht")

sex_ht = annotate_sex(vds, included_intervals=calling_intervals, sites_ht=freq_ht, aaf_expr="AF", gt_expr="LGT", use_gaussian_mixture_model=True, variants_only_x_ploidy=True, compute_x_frac_variants_hom_alt=True)

show(hl.plot.histogram(sex_ht.chrx_frac_hom_alt_adj))
show(hl.plot.scatter(sex_ht.chrX_ploidy, sex_ht.chrx_frac_hom_alt_adj, label=sex_ht.sex_karyotype))
```

