### PR TITLE
Add more file types to `file_exists` for checking '_SUCCESS'

### DIFF
--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -135,6 +135,31 @@ def file_exists(fname: str, overwrite: Optional[bool] = None) -> bool:
     return exists
 
 
+def file_list_exists(
+    fname_list: List[str],
+    overwrite: bool = None,
+) -> bool:
+    """
+    Check whether all files in the list exist and raise an exception if any of them exist and overwrite is False.
+
+    :param fname_list: List of file paths to check the existence of.
+    :param overwrite: Optional boolean that will raise an exception if set to False and any of the resources exist.
+    :return: Boolean indicating if all files in `fname_list` exist.
+    """
+    exists = []
+    exceptions_raised = []
+    for fname in fname_list:
+        try:
+            exists.append(file_exists(fname, overwrite))
+        except DataException as e:
+            exceptions_raised.append(str(e))
+
+    if exceptions_raised:
+        raise DataException("\n".join(exceptions_raised))
+
+    return all(exists)
+
+
 def write_temp_gcs(
     t: Union[hl.MatrixTable, hl.Table],
     gcs_path: str,

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -133,13 +133,13 @@ def check_file_exists_raise_error(
     fname: Union[str, List[str]],
     error_if_exists: bool = False,
     error_if_not_exists: bool = False,
-    error_if_exists_msg: str = "The following files already exist and the overwrite option was not used: ",
+    error_if_exists_msg: str = "The following files already exist: ",
     error_if_not_exists_msg: str = "The following files do not exist: ",
 ) -> bool:
     """
     Check whether the file or all files in a list of files exist and optionally raise an exception.
 
-    This can be useful when writing out to files at the end of a pipeline, but want to check if the file already
+    This can be useful when writing out to files at the end of a pipeline to first check if the file already
     exists and therefore requires the file to be removed or overwrite specified so the pipeline doesn't fail.
 
     :param fname: File path, or list of file paths to check the existence of.


### PR DESCRIPTION
Add `check_file_exists_raise_error` to use `file_exists` to check the existence of all files in a list of file paths with options to raise an error.