### PR TITLE
add `.he` to file extensions list in `file_exists()`

### DIFF
--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -116,9 +116,10 @@ def file_exists(fname: str) -> bool:
     fext = os.path.splitext(fname)[1]
     if fext in {".ht", ".mt", ".bm", ".parquet", ".he"}:
         paths = [f"{fname}/_SUCCESS"]
-
-    if fext == ".vds":
+    elif fext == ".vds":
         paths = [f"{fname}/reference_data/_SUCCESS", f"{fname}/variant_data/_SUCCESS"]
+    else:
+        paths = [fname]
 
     if fname.startswith("gs://"):
         exists_func = hl.hadoop_exists

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -114,7 +114,7 @@ def file_exists(fname: str) -> bool:
     :return: Whether the file exists.
     """
     fext = os.path.splitext(fname)[1]
-    if fext in {".ht", ".mt", ".bm", ".parquet", "he"}:
+    if fext in {".ht", ".mt", ".bm", ".parquet", ".he"}:
         paths = [f"{fname}/_SUCCESS"]
 
     if fext == ".vds":

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -108,7 +108,7 @@ def file_exists(fname: str) -> bool:
     Check whether a file exists.
 
     Supports either local or Google cloud (gs://) paths.
-    If the file is a Hail file (.ht, .mt, .bm, .parquet, .he, and .vds extensions), it 
+    If the file is a Hail file (.ht, .mt, .bm, .parquet, .he, and .vds extensions), it
     checks that _SUCCESS is present.
 
     :param fname: File name.

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -114,7 +114,7 @@ def file_exists(fname: str) -> bool:
     :return: Whether the file exists.
     """
     fext = os.path.splitext(fname)[1]
-    if fext in {".ht", ".mt", ".bm", ".parquet"}:
+    if fext in {".ht", ".mt", ".bm", ".parquet", "he"}:
         paths = [f"{fname}/_SUCCESS"]
 
     if fext == ".vds":

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -108,7 +108,8 @@ def file_exists(fname: str) -> bool:
     Check whether a file exists.
 
     Supports either local or Google cloud (gs://) paths.
-    If the file is a Hail file (.ht, .mt, .bm, .parquet, and .vds extensions), it checks that _SUCCESS is present.
+    If the file is a Hail file (.ht, .mt, .bm, .parquet, .he, and .vds extensions), it 
+    checks that _SUCCESS is present.
 
     :param fname: File name.
     :return: Whether the file exists.


### PR DESCRIPTION
`file_exists()` will crash if it's used on files whose extension is not in `".ht", ".mt", ".bm", ".parquet", ".vds"`, because `paths` isn't assigned. I added `".he"` to the list. Please let me know if you want to add a `else` case dealing with `paths`! 