### PR TITLE
Add an option for samples that must be kept to `compute_related_samples_to_drop`

### DIFF
--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -824,14 +824,13 @@ def compute_related_samples_to_drop(
             **related_samples_to_drop_ht.node
         )
     else:
-        print("Running new method")
         related_pair_graph = nx.Graph()
         related_pair_graph.add_edges_from(
             list(zip(relatedness_ht.i.collect(), relatedness_ht.j.collect()))
         )
         related_samples_to_drop_ht = hl.Table.parallelize(
             maximal_independent_set_keep_samples(
-                related_pair_graph, keep=keep_samples.collect()[0]
+                related_pair_graph, keep=hl.eval(keep_samples)
             )
         )
     related_samples_to_drop_ht = related_samples_to_drop_ht.key_by("s")

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -777,11 +777,11 @@ def compute_related_samples_to_drop(
         # connected in the graph and share no connections to samples in any other set.
         connected_samples = list(nx.connected_components(pair_graph))
         # For each of the connected components, determine the sample with the largest
-        # degree (number of samples it is related to) that is not in keep.
+        # degree (number of samples it is related to), followed by highest rank, that is not in keep.
         # Add this sample to drop_samples and then compute the subgraph with this
         # sample excluded. Repeat the process on this subgraph. Continue until all
         # connected components contain only a single sample, unless connected samples
-        # are in keep.
+        # are in `keep`.
         for con in connected_samples:
             if len(con) > 1:
                 # Build a list of (degree, rank, sample) sorted by highest degree and

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -662,7 +662,8 @@ def compute_related_samples_to_drop(
     :param rank_ht: Table with a global rank for each sample (smaller is preferred)
     :param filtered_samples: An optional set of samples to exclude (e.g. these samples were hard-filtered)  These samples will then appear in the resulting samples to drop.
     :param min_related_hard_filter: If provided, any sample that is related to more samples than this parameter will be filtered prior to computing the maximal independent set and appear in the results.
-    :param keep_samples: An optional set of samples that must be kept. An error is raised if any two samples in the list are among the related pairs.
+    :param keep_samples: An optional set of samples that must be kept. An error is raised (when `keep_samples_when_related` is False) if any two samples in the list are among the related pairs.
+    :param keep_samples_when_related: Don't raise an error if `keep_samples` contains related samples, and keep related samples. Default is False.
     :return: A Table with the list of the samples to drop along with their rank.
     """
     # Make sure that the key types are valid

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -786,7 +786,7 @@ def compute_related_samples_to_drop(
                     last_s = con_idx[degree_rank_list[last_i][2]]
                 if last_s.s not in keep_samples:
                     drop_samples.append(last_s)
-                    new_con = {con_idx[s[2]] for s in degree_rank_list[:-1]}
+                    new_con = con - {last_s}
                     if len(new_con) > 1:
                         drop_samples.extend(
                             maximal_independent_set_keep_samples(

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -809,8 +809,7 @@ def compute_related_samples_to_drop(
                                 keep=keep,
                             )
                         )
-                else:
-                    print("Must keep", highest_degree_s.s)
+
         return drop_samples
 
     if keep_samples is None:

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -717,10 +717,14 @@ def compute_related_samples_to_drop(
             "Number of samples in the provided list of samples to keep: %f",
             hl.eval(hl.len(keep_samples)),
         )
-        keep_samples_rel = relatedness_ht.filter(
-            keep_samples.contains(relatedness_ht.key[0])
-            & keep_samples.contains(relatedness_ht.key[1])
-        ).key.collect()
+        i = relatedness_ht.key[0]
+        j = relatedness_ht.key[1]
+        keep_samples_rel = relatedness_ht.aggregate(
+            hl.agg.filter(
+                keep_samples.contains(i) & keep_samples.contains(j),
+                hl.agg.collect_as_set(hl.struct(i=i, j=j, kin=relatedness_ht.kin)),
+            )
+        )
         num_keep_samples_rel = len(keep_samples_rel)
         if num_keep_samples_rel > 0:
             logger.warning(

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -777,7 +777,8 @@ def compute_related_samples_to_drop(
         # connected in the graph and share no connections to samples in any other set.
         connected_samples = list(nx.connected_components(pair_graph))
         # For each of the connected components, determine the sample with the largest
-        # degree (number of samples it is related to), followed by highest rank, that is not in keep.
+        # degree (number of samples it is related to), followed by highest rank, that
+        # is not in keep.
         # Add this sample to drop_samples and then compute the subgraph with this
         # sample excluded. Repeat the process on this subgraph. Continue until all
         # connected components contain only a single sample, unless connected samples

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 hail
 hdbscan
 ipywidgets
+networkx
 scikit-learn
 slackclient==2.5.0


### PR DESCRIPTION
For gnomAD v4 we want to prioritize keeping gnomAD v3.1 release samples so that frequency calculations don't need to be recomputed. The option added in this PR will ensure that these samples are kept when determining what related samples to drop.