### PR TITLE
Added utility function to repartition HTs prior to join

### DIFF
--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -296,7 +296,7 @@ def repartition_for_join(
     :param ht_path: Path to Table to repartition.
     :param new_partition_percent: Percent of initial dataset partitions to use.
         Value should be greater than 1 so that input HT will have more
-        partitions for the join.
+        partitions for the join. Defaults to 1.1.
     :return: List of IntervalExpressions calculated over new set of partitions
         (number of partitions in HT * desired percent increase).
     """

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -284,9 +284,8 @@ def read_list_data(input_file_path: str) -> List[str]:
 
 def repartition_for_join(
     ht_path: str,
-    new_partition_percent: Optional[float] = None,
-    n_partitions: Optional[int] = None,
-) -> hl.Table:
+    new_partition_percent: float,
+) -> List[hl.expr.IntervalExpression]:
     """
     Repartition a Table prior to joining with another Table(s).
 
@@ -294,30 +293,15 @@ def repartition_for_join(
 
     :param ht_path: Path to Table to repartition.
     :param new_partition_percent: Percent of initial dataset partitions to use.
-        Value should be greater than 1.
-        Default is None.
-        Should not be specified if `n_partitions` is not None.
-    :param n_partitions: Number of partitions desired after repartition.
-        Default is None.
-        Should not be specified if `new_partition_percent` is not None.
-    :return: hl.Table
+        Value should be greater than 1 so that input HT will have more
+        partitions for the join.
+    :return: List of IntervalExpressions calculated over new set of partitions
+        (number of partitions in HT * desired percent increase).
     """
-    if not new_partition_percent and not n_partitions:
-        raise DataException(
-            "Must specify either new_partition_percent or n_partitions!"
-        )
-
     ht = hl.read_table(ht_path)
-    if new_partition_percent:
-        if new_partition_percent < 1:
-            logger.warning(
-                "new_partition_percent value is less than 1! The new HT will have fewer"
-                " partitions than the original HT!"
-            )
-        partition_intervals = ht._calculate_new_partitions(
-            ht.n_partitions() * new_partition_percent
+    if new_partition_percent < 1:
+        logger.warning(
+            "new_partition_percent value is less than 1! The new HT will have fewer"
+            " partitions than the original HT!"
         )
-    if n_partitions:
-        partition_intervals = ht._calculate_new_partitions(n_partitions)
-
-    return hl.read_table(ht_path, _intervals=partition_intervals)
+    return ht._calculate_new_partitions(ht.n_partitions() * new_partition_percent)

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -14,7 +14,8 @@ import hail as hl
 from hailtop.aiogoogle import GoogleStorageAsyncFS
 from hailtop.aiotools import AsyncFS, LocalAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.utils import bounded_gather, tqdm
+from hailtop.utils import bounded_gather
+from hailtop.utils.rich_progress_bar import SimpleRichProgressBar
 
 from gnomad.resources.resource_utils import DataException
 
@@ -55,8 +56,8 @@ async def parallel_file_exists_async(
         else:
             return True
 
-    with tqdm(
-        total=len(fpaths), desc="check files for existence", disable=False
+    with SimpleRichProgressBar(
+        total=len(fpaths), description="check files for existence", disable=False
     ) as pbar:
         with ThreadPoolExecutor() as thread_pool:
             async with RouterAsyncFS(

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -287,14 +287,14 @@ def repartition_for_join(
     new_partition_percent: float = 1.1,
 ) -> List[hl.expr.IntervalExpression]:
     """
-    Calculate  partitions' intervals using the passed Table. 
+    Calculate new partition intervals using input Table.
 
-    Reading in all Tables using these partition intervals using  `_intervals` 
-    before they are joined, makes the join(s) much more efficient.
+    Reading in all Tables using the same partition intervals (via
+    `_intervals`) before they are joined makes the joins much more efficient.
     For more information, see:
     https://discuss.hail.is/t/room-for-improvement-when-joining-multiple-hts/2278/8
 
-    :param ht_path: Path to Table to use for interval partition calculation. 
+    :param ht_path: Path to Table to use for interval partition calculation.
     :param new_partition_percent: Percent of initial dataset partitions to use.
         Value should be greater than 1 so that input Table will have more
         partitions for the join. Defaults to 1.1.

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -284,7 +284,7 @@ def read_list_data(input_file_path: str) -> List[str]:
 
 def repartition_for_join(
     ht_path: str,
-    new_partition_percent: float,
+    new_partition_percent: float = 1.1,
 ) -> List[hl.expr.IntervalExpression]:
     """
     Repartition a Table prior to joining with another Table(s).

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -293,7 +293,7 @@ def repartition_for_join(
     For more information, see:
     https://discuss.hail.is/t/room-for-improvement-when-joining-multiple-hts/2278/8
 
-    :param ht_path: Path to Table to repartition.
+    :param ht_path: Path to Table to use for interval partition calculation. 
     :param new_partition_percent: Percent of initial dataset partitions to use.
         Value should be greater than 1 so that input HT will have more
         partitions for the join. Defaults to 1.1.

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -295,7 +295,7 @@ def repartition_for_join(
 
     :param ht_path: Path to Table to use for interval partition calculation. 
     :param new_partition_percent: Percent of initial dataset partitions to use.
-        Value should be greater than 1 so that input HT will have more
+        Value should be greater than 1 so that input Table will have more
         partitions for the join. Defaults to 1.1.
     :return: List of IntervalExpressions calculated over new set of partitions
         (number of partitions in HT * desired percent increase).

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -290,6 +290,8 @@ def repartition_for_join(
     Repartition a Table prior to joining with another Table(s).
 
     This repartitioning makes the join(s) much more efficient.
+    For more information, see:
+    https://discuss.hail.is/t/room-for-improvement-when-joining-multiple-hts/2278/8
 
     :param ht_path: Path to Table to repartition.
     :param new_partition_percent: Percent of initial dataset partitions to use.

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -287,9 +287,10 @@ def repartition_for_join(
     new_partition_percent: float = 1.1,
 ) -> List[hl.expr.IntervalExpression]:
     """
-    Repartition a Table prior to joining with another Table(s).
+    Calculate  partitions' intervals using the passed Table. 
 
-    This repartitioning makes the join(s) much more efficient.
+    Reading in all Tables using these partition intervals using  `_intervals` 
+    before they are joined, makes the join(s) much more efficient.
     For more information, see:
     https://discuss.hail.is/t/room-for-improvement-when-joining-multiple-hts/2278/8
 

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -14,8 +14,7 @@ import hail as hl
 from hailtop.aiogoogle import GoogleStorageAsyncFS
 from hailtop.aiotools import AsyncFS, LocalAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
-from hailtop.utils import bounded_gather
-from hailtop.utils.rich_progress_bar import SimpleRichProgressBar
+from hailtop.utils import bounded_gather, tqdm
 
 from gnomad.resources.resource_utils import DataException
 
@@ -56,8 +55,8 @@ async def parallel_file_exists_async(
         else:
             return True
 
-    with SimpleRichProgressBar(
-        total=len(fpaths), description="check files for existence", disable=False
+    with tqdm(
+        total=len(fpaths), desc="check files for existence", disable=False
     ) as pbar:
         with ThreadPoolExecutor() as thread_pool:
             async with RouterAsyncFS(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.

To make sure that this change is included in release notes, please:
- Use a descriptive title for the pull request.
- Apply one of the "Changelog" labels (if applicable).

-->
This PR adds a small utility function (`repartition_for_join`) that repartitions a Table to make a downstream join more efficient
