### PR TITLE
Add additional groupings to optional stratified allele frequencies

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -391,12 +391,19 @@ def annotate_freq(
     :param pop_expr: When specified, frequencies are stratified by population. If `sex_expr` is also specified, then a pop/sex stratifiction is added.
     :param subpop_expr: When specified, frequencies are stratified by sub-continental population. Note that `pop_expr` is required as well when using this option.
     :param additional_strata_expr: When specified, frequencies are stratified by the given additional strata found in the dict. This can e.g. be used to stratify by platform.
+    :param additional_strata_grouping_expr: When specified, frequencies are further stratified by groups within the additional_strata_expr. This can e.g. be used to stratify by platform-population.
     :param downsamplings: When specified, frequencies are computed by downsampling the data to the number of samples given in the list. Note that if `pop_expr` is specified, downsamplings by population is also computed.
     :return: MatrixTable with `freq` annotation
     """
     if subpop_expr is not None and pop_expr is None:
         raise NotImplementedError(
             "annotate_freq requires pop_expr when using subpop_expr"
+        )
+
+    if additional_strata_grouping_expr is not None and additional_strata_expr is None:
+        raise NotImplementedError(
+            "annotate_freq requires additional_strata_expr when using"
+            " additional_strata_grouping_expr"
         )
 
     if additional_strata_expr is None:
@@ -517,7 +524,7 @@ def annotate_freq(
         + sample_group_filters
     )
 
-    # Add additional groupings to strata, e.g. strata-pop, strata-sex
+    # Add additional groupings to strata, e.g. strata-pop, strata-sex, strata-pop-sex
     if additional_strata_grouping_expr is not None:
         for strata in additional_strata_grouping_expr:
             if strata not in cut_data.keys():

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -403,6 +403,8 @@ def annotate_freq(
         additional_strata_expr = {}
 
     _freq_meta_expr = hl.struct(**additional_strata_expr)
+    if additional_strata_grouping_expr is not None:
+        _freq_meta_expr = _freq_meta_expr.annotate(**additional_strata_grouping_expr)
     if sex_expr is not None:
         _freq_meta_expr = _freq_meta_expr.annotate(sex=sex_expr)
     if pop_expr is not None:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -410,7 +410,9 @@ def annotate_freq(
         additional_strata_expr = {}
 
     _freq_meta_expr = hl.struct(**additional_strata_expr)
-    if additional_strata_grouping_expr is not None:
+    if additional_strata_grouping_expr is None:
+        additional_strata_grouping_expr = {}
+    else:
         _freq_meta_expr = _freq_meta_expr.annotate(**additional_strata_grouping_expr)
     if sex_expr is not None:
         _freq_meta_expr = _freq_meta_expr.annotate(sex=sex_expr)
@@ -421,9 +423,6 @@ def annotate_freq(
 
     # Annotate cols with provided cuts
     mt = mt.annotate_cols(_freq_meta=_freq_meta_expr)
-
-    if additional_strata_grouping_expr is None:
-        additional_strata_grouping_expr = {}
 
     # Get counters for sex, pop and if set subpop and additional strata
     cut_dict = {
@@ -526,12 +525,6 @@ def annotate_freq(
 
     # Add additional groupings to strata, e.g. strata-pop, strata-sex, strata-pop-sex
     if additional_strata_grouping_expr is not None:
-        for strata in additional_strata_grouping_expr:
-            if strata not in cut_data.keys():
-                raise KeyError(
-                    "%s is not an existing annotation and thus cannot be combined with"
-                    " additional strata"
-                )
         sample_group_filters.extend(
             [
                 (


### PR DESCRIPTION
Add additional groupings to optional stratified allele frequencies to allow stratified frequencies by multiple annotations: e.g. platform and population, or GATK version and population. 
