### PR TITLE
Modify `annotate_mutation_type` to take optional context length as a parameter.

### DIFF
--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -331,9 +331,8 @@ def annotate_mutation_type(
         context_lengths = list(filter(None, set(context_lengths)))
         if len(context_lengths) > 1:
             raise ValueError(
-                "More than one length was found among %s 'context' values. Length of "
-                "'context' should be consistent.",
-                msg,
+                f"More than one length was found among {msg} 'context' values. Length "
+                "of 'context' should be consistent.",
             )
         else:
             context_length = context_lengths[0]

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -337,7 +337,11 @@ def annotate_mutation_type(
             )
         else:
             context_length = context_lengths[0]
-            logger.info("Detected a length of %d for context length", context_length)
+            logger.info(
+                "Detected a length of %d for context length using %s 'context' values.",
+                context_length,
+                msg,
+            )
 
     # Determine the middle index of the context annotation.
     if context_length == 3:


### PR DESCRIPTION
The way context_length is currently determined, there needs to be a full scan through the HT/MT. This allows for a parameter to be passed in instead.

It also throws an error if it finds a 'context' value that is not the expected length. And if no parameter is passed it will detect it using the number of specified values in `num_scan_context_length`.
