### PR TITLE
Add additional strata to freq dict labels

### DIFF
--- a/gnomad/utils/release.py
+++ b/gnomad/utils/release.py
@@ -103,7 +103,9 @@ def make_freq_index_dict(
                 # Note: Tack the new strata onto the end of the sort order so the labels
                 # can be made
                 if k not in sort_order:
-                    sort_order.append(k)
+                    sort_order.append(
+                        k
+                    )  # TODO: Should we add the additional strata before group, aka adj? sort_order.insert(-1,k)
             index_dict.update({**_get_index(dict(group=groups, **strata))})
 
     return index_dict

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -446,8 +446,8 @@ def adjust_vcf_incompatible_types(
     for f, ft in ht.info.dtype.items():
         if ft == hl.dtype("int64"):
             logger.warning(
-                "Coercing field info.%s from int64 to int32 for VCF output. Value will"
-                " be capped at int32 max value.",
+                "Coercing field info.%s from int64 to int32 for VCF output. Value"
+                " will be capped at int32 max value.",
                 f,
             )
             info_type_convert_expr.update(
@@ -517,7 +517,7 @@ def make_label_combos(
     combos = []
     for x, y in itertools.product(
         anchor_val,
-        make_label_combos(copy_label_groups, label_delimiter=label_delimiter),
+        make_label_combos(copy_label_groups, sort_order, label_delimiter),
     ):
         combos.append(f"{x}{label_delimiter}{y}")
     return combos
@@ -527,6 +527,7 @@ def index_globals(
     globals_array: List[Dict[str, str]],
     label_groups: Dict[str, List[str]],
     label_delimiter: str = "_",
+    sort_order: List[str] = SORT_ORDER,
 ) -> Dict[str, int]:
     """
     Create a dictionary keyed by the specified label groupings with values describing the corresponding index of each grouping entry in the meta_array annotation.
@@ -536,10 +537,11 @@ def index_globals(
     :param label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
         e.g. "sex" or "pop", and value is a list of all possible values for that grouping (e.g. ["male", "female"] or ["afr", "nfe", "amr"])
     :param label_delimiter: String used as delimiter when making group label combinations.
+    :param sort_order: List of strings specifying the order to sort subgroupings in labels.
     :return: Dictionary keyed by specified label grouping combinations, with values describing the corresponding index
         of each grouping entry in the globals
     """
-    combos = make_label_combos(label_groups, label_delimiter=label_delimiter)
+    combos = make_label_combos(label_groups, sort_order, label_delimiter)
     index_dict = {}
 
     for combo in combos:


### PR DESCRIPTION
We built functionality to add additional strata to the freq array but did not include the ability to build those strata into the freq index dictionary. This seemed like the simplest way to do this. Additional strata are simply added to the end of the label `amr_xx_adj_4.1.0.1`. We historicaly have liked to see adj last so I did put a note that we could insert before the last elemnt in sort order. We could also add the functionality to insert the strata into the SORT_ORDER list at a certain index but this requires knowledge of the order and the order could change based on other groupings. For these reasons, I felt it was best (and easiest) to tack it onto the end of the order or before the last element.