### PR TITLE
Allow any frequency groupings

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -397,8 +397,8 @@ def annotate_freq(
 
     If the `additional_strata_expr` parameter is used, frequencies will be computed for each of the strata dictionaries across all
     values. For example, if `additional_strata_expr` is set to `[{'platform': mt.platform}, {'platform':mt.platform, 'pop': mt.pop},
-     {'age_bin': mt.age_bin}]`, then frequencies will be computed for each of the values of `mt.platform`, each of the combined values
-     of `mt.platform` and `mt.pop`, and each of the values of `mt.age_bin`.
+    {'age_bin': mt.age_bin}]`, then frequencies will be computed for each of the values of `mt.platform`, each of the combined values
+    of `mt.platform` and `mt.pop`, and each of the values of `mt.age_bin`.
 
     :param mt: Input MatrixTable
     :param sex_expr: When specified, frequencies are stratified by sex. If `pop_expr` is also specified, then a pop/sex stratifiction is added.

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1118,7 +1118,7 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
+        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())} if non_par else {}
     )
 
     if prob_regions is not None:


### PR DESCRIPTION
This PR expands on the utility of `additional_strata_expr` by allowing the user to pass a list of dictionaries where each dictionary will be grouped together. This relies on the user to define the specific groupings for freq calculations, e.g. [{'pop': pop_expr}, {'platform': platform_expr, 'pop': pop_expr}, {'sample_age_bin': sample_age_bin_expr}]. I think this could eventually be used for all aggregations and clean this function up quite a bit.  I kept the ability to pass a single dictionary but have removed the additonal_strata_groupings_expr as this is a cleaner and more flexible implementation. 