### PR TITLE
Add callstats option to inbreeding coeff

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -898,9 +898,7 @@ def bi_allelic_site_inbreeding_expr(
         The computation is run based on the counts of alternate alleles and thus should only be run on bi-allelic sites.
 
     :param call: Expression giving the calls in the MT
-    :param callstats_expr: StructExpression containing only alternate allele AC, AN,
-    and homozygote_count as integers. If passed, used to create expression in place of GT calls.
-
+    :param callstats_expr: StructExpression containing only alternate allele AC, AN, and homozygote_count as integers. If passed, used to create expression in place of GT calls.
     :return: Site inbreeding coefficient expression
     """
     if call is None and callstats_expr is None:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -914,23 +914,12 @@ def bi_allelic_site_inbreeding_expr(
         return 1 - (gt_counts.get(1, 0) / (2 * p * q * n))
 
     if callstats_expr is not None:
-        # Compute the counts of alternate alleles by individual from the callstats
-        gt_counts = hl.dict(
-            {
-                0: (
-                    callstats_expr.AN
-                    - callstats_expr.AC
-                    - (callstats_expr.AC - (2 * callstats_expr.homozygote_count))
-                )
-                / 2,
-                1: callstats_expr.AC - (2 * callstats_expr.homozygote_count),
-                2: callstats_expr.homozygote_count,
-            }
-        )
+        n = callstats_expr.AN / 2
+        q = callstats_expr.AC / callstats_expr.AN
+        p = 1 - q
+        return 1 - (callstats_expr.AC - (2 * callstats_expr.hom)) / (2 * p * q * n)
     else:
-        gt_counts = hl.agg.counter(call.n_alt_alleles())
-
-    return hl.bind(inbreeding_coeff, gt_counts)
+        return hl.bind(inbreeding_coeff, hl.agg.counter(call.n_alt_alleles()))
 
 
 def fs_from_sb(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1139,7 +1139,7 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
+        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())} if non_par else {}
     )
 
     if prob_regions is not None:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -125,7 +125,7 @@ def project_max_expr(
                     > 0
                 ),
                 # order the callstats computed by AF in decreasing order
-                lambda x: -x[1].AF[ai],
+                lambda x: -x[1].AF[ai]
                 # take the n_projects projects with largest AF
             )[:n_projects].map(
                 # add the project in the callstats struct

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -899,7 +899,7 @@ def bi_allelic_site_inbreeding_expr(
 
     :param call: Expression giving the calls in the MT
     :param callstats_expr: StructExpression containing only alternate allele AC, AN,
-    and hom (homozygote_count). If passed, used to create expression in place of GT calls.
+    and homozygote_count as integers. If passed, used to create expression in place of GT calls.
 
     :return: Site inbreeding coefficient expression
     """

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -929,8 +929,8 @@ def bi_allelic_site_inbreeding_expr(
             )
         ):
             raise ValueError(
-                "callstats_expr must be a StructExpression containing int32 fields AC,"
-                " AN, and homozygote_count."
+                "callstats_expr must be a StructExpression containing fields 'AC',"
+                " 'AN', and 'homozygote_count' of types int32 or int64."
             )
         n = callstats_expr.AN / 2
         q = callstats_expr.AC / callstats_expr.AN


### PR DESCRIPTION
Adds the option to pass a callstats struct expression with AC, AN, and the number of homozygote alternates to the inbreeding coefficient expr, allowing someone without access to the GT calls to still calculate inbreeding coefficient. 