### PR TITLE
Merge freq array function and new frequency dictionary builder

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -126,7 +126,7 @@ def project_max_expr(
                     > 0
                 ),
                 # order the callstats computed by AF in decreasing order
-                lambda x: -x[1].AF[ai],
+                lambda x: -x[1].AF[ai]
                 # take the n_projects projects with largest AF
             )[:n_projects].map(
                 # add the project in the callstats struct

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1202,6 +1202,7 @@ def merge_freq_arrays(
     Merge frequency arrays on the same HT.
 
     .. note::
+
         Arrays do not have to contain the same groupings or order of groupings but
         the array indices for a freq array in farrays must be the same as its associated
         frequency metadata index in fmeta i.e., farrays = [freq1, freq2] then fmeta

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1231,18 +1231,22 @@ def merge_freq_arrays(
     set_negatives_to_zero: bool = True,
 ) -> Tuple[hl.expr.ArrayExpression, Dict[str, int]]:
     """
-    Merge frequency arrays from multiple datasets.
+    Merge frequency arrays on the same HT.
 
-    Farrays and fmeta do not need to be the same or in the same order. They will be
-    merged based on the join type and operation. Missing values are dependent on the
-    join type and operation.
-    :param farrays: List of frequency arrays to merge. First entry in the list is the
-     primary array to which other arrays will be added or subtracted. Array must be on
-     the same HT.
+    .. note::
+        Arrays do not have to contain the same groupings or order of groupings but
+        the array indices for a freq array in farrays must be the same as its associated
+        frequency metadata index in fmeta i.e., farrays = [freq1, freq2] then fmeta
+        must equal [fmeta1, fmeta2] where fmeta1 contains the metadata information
+        for freq1. If th merge operation is set to "sum", groups in the merged array
+        will be the union of groupings found within the arrays' metadata and all arrays
+        with be summed by grouping. If the operation is set to "diff", the merged array
+        will contain groups only found in the first array of fmeta. Any array containing
+        any of these groups will have thier values subtracted from the values of the first array.
+
+    :param farrays: List of frequency arrays to merge. First entry in the list is the primary array to which other arrays will be added or subtracted. Array must be on the same HT.
     :param fmeta: List of frequency metadata for arrays being merged.
-    :param operation: Merge operation to perform. Options are "sum" and "diff". If
-    "diff" is passed, the first array in the list will have the other arrays subtracted
-    from it.
+    :param operation: Merge operation to perform. Options are "sum" and "diff". If "diff" is passed, the first freq array in the list will have the other arrays subtracted from it.
     :param set_negatives_to_zero: If True, set negative array values to 0 for AC, AN,
     AF, and homozygote_count. If False, raise a ValueError. Default is True.
     :return: Tuple of merged frequency array and its freq index dictionary.

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1196,7 +1196,7 @@ def merge_freq_arrays(
     farrays: List[hl.expr.ArrayExpression],
     fmeta: List[List[Dict[str, str]]],
     operation: str = "sum",
-    set_negatives_to_zero: bool = True,
+    set_negatives_to_zero: bool = False,
 ) -> Tuple[hl.expr.ArrayExpression, List[Dict[str, int]]]:
     """
     Merge a list of frequency arrays based on the supplied `operation`.

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1108,7 +1108,8 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
+        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())
+         } if non_par else {}  # fmt: skip
     )
 
     if prob_regions is not None:
@@ -1210,8 +1211,8 @@ def merge_freq_arrays(
         the array indices for a freq array in `farrays` must be the same as its associated
         frequency metadata index in `fmeta` i.e., `farrays = [freq1, freq2]` then `fmeta`
         must equal `[fmeta1, fmeta2]` where fmeta1 contains the metadata information
-        for freq1. 
-        
+        for freq1.
+
         If `operation` is set to "sum", groups in the merged array
         will be the union of groupings found within the arrays' metadata and all arrays
         with be summed by grouping. If `operation` is set to "diff", the merged array
@@ -1222,7 +1223,7 @@ def merge_freq_arrays(
     :param fmeta: List of frequency metadata for arrays being merged.
     :param operation: Merge operation to perform. Options are "sum" and "diff". If "diff" is passed, the first freq array in the list will have the other arrays subtracted from it.
     :param set_negatives_to_zero: If True, set negative array values to 0 for AC, AN, AF, and homozygote_count. If False, raise a ValueError. Default is True.
-    :return: Tuple of merged frequency array and its freq index dictionary.
+    :return: Tuple of merged frequency array and its frequency metadata list.
     """
     if len(farrays) < 2:
         raise ValueError("Must provide at least two frequency arrays to merge!")

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1109,7 +1109,7 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
+        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())} if non_par else {}
     )
 
     if prob_regions is not None:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -125,7 +125,7 @@ def project_max_expr(
                     > 0
                 ),
                 # order the callstats computed by AF in decreasing order
-                lambda x: -x[1].AF[ai]
+                lambda x: -x[1].AF[ai],
                 # take the n_projects projects with largest AF
             )[:n_projects].map(
                 # add the project in the callstats struct
@@ -1108,7 +1108,7 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())} if non_par else {}
+        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
     )
 
     if prob_regions is not None:
@@ -1216,8 +1216,7 @@ def merge_freq_arrays(
     :param farrays: List of frequency arrays to merge. First entry in the list is the primary array to which other arrays will be added or subtracted. Array must be on the same HT.
     :param fmeta: List of frequency metadata for arrays being merged.
     :param operation: Merge operation to perform. Options are "sum" and "diff". If "diff" is passed, the first freq array in the list will have the other arrays subtracted from it.
-    :param set_negatives_to_zero: If True, set negative array values to 0 for AC, AN,
-    AF, and homozygote_count. If False, raise a ValueError. Default is True.
+    :param set_negatives_to_zero: If True, set negative array values to 0 for AC, AN, AF, and homozygote_count. If False, raise a ValueError. Default is True.
     :return: Tuple of merged frequency array and its freq index dictionary.
     """
     if len(farrays) < 2:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1210,7 +1210,9 @@ def merge_freq_arrays(
         the array indices for a freq array in `farrays` must be the same as its associated
         frequency metadata index in `fmeta` i.e., `farrays = [freq1, freq2]` then `fmeta`
         must equal `[fmeta1, fmeta2]` where fmeta1 contains the metadata information
-        for freq1. If `operation` is set to "sum", groups in the merged array
+        for freq1. 
+        
+        If `operation` is set to "sum", groups in the merged array
         will be the union of groupings found within the arrays' metadata and all arrays
         with be summed by grouping. If `operation` is set to "diff", the merged array
         will contain groups only found in the first array of `fmeta`. Any array containing

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1270,9 +1270,7 @@ def merge_freq_arrays(
     fmeta = hl.fold(
         lambda i, j: hl.dict(
             (
-                hl.if_else(
-                    operation == "sum", (i.key_set() | j.key_set()), i.key_set()
-                )  # TODO: confirms this works on freq meta arrays with more than two entires
+                hl.if_else(operation == "sum", (i.key_set() | j.key_set()), i.key_set())
             ).map(
                 lambda k: (
                     k,

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 import hail as hl
 
 from gnomad.utils.gen_stats import to_phred
-from gnomad.utils.vcf import SORT_ORDER
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -126,7 +125,7 @@ def project_max_expr(
                     > 0
                 ),
                 # order the callstats computed by AF in decreasing order
-                lambda x: -x[1].AF[ai]
+                lambda x: -x[1].AF[ai],
                 # take the n_projects projects with largest AF
             )[:n_projects].map(
                 # add the project in the callstats struct
@@ -1109,7 +1108,7 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())} if non_par else {}
+        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
     )
 
     if prob_regions is not None:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -125,7 +125,7 @@ def project_max_expr(
                     > 0
                 ),
                 # order the callstats computed by AF in decreasing order
-                lambda x: -x[1].AF[ai],
+                lambda x: -x[1].AF[ai]
                 # take the n_projects projects with largest AF
             )[:n_projects].map(
                 # add the project in the callstats struct
@@ -1108,7 +1108,7 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
+        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())} if non_par else {}
     )
 
     if prob_regions is not None:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1193,37 +1193,6 @@ def hemi_expr(
     )
 
 
-def make_freq_index_dict_from_meta(
-    freq_meta: List[Dict[str, str]],
-    label_delimiter: str = "_",
-    sort_order: Optional[List[str]] = SORT_ORDER,
-) -> Dict[str, int]:
-    """
-    Create a dictionary for accessing frequency array.
-
-    :param freq_meta: List of dictionaries containing frequency metadata.
-    :param label_delimiter: Delimiter to use when joining frequency metadata labels.
-    :param sort_order: List of frequency metadata labels to use when sorting the dictionary.
-    :return: Dictionary of frequency metadata.
-    """
-    index_dict = {}
-    for i, f in enumerate(hl.eval(freq_meta)):
-        if sort_order and len(set(f.keys()) - set(sort_order)) < 1:
-            index_dict[
-                label_delimiter.join(
-                    [
-                        f[g]
-                        for g in sorted(
-                            f.keys(),
-                            key=(lambda x: sort_order.index(x)) if sort_order else None,
-                        )
-                    ]
-                )
-            ] = i
-
-    return index_dict
-
-
 def merge_freq_arrays(
     farrays: List[hl.expr.ArrayExpression],
     fmeta: List[List[Dict[str, str]]],

--- a/gnomad/utils/release.py
+++ b/gnomad/utils/release.py
@@ -124,15 +124,16 @@ def make_freq_index_dict_from_meta(
     :return: Dictionary of frequency metadata.
     """
     # Confirm all groups in freq_meta are in sort_order. Warn user if not.
-    diff = hl.eval(hl.set(freq_meta.flatmap(lambda i: i.keys()))) - set(sort_order)
-    if diff:
-        logger.warning(
-            "Found unexpected frequency metadata groupings: %s. These groupings are"
-            " not present in the provided sort_order: %s. These groupings will not"
-            " be included in the returned dictionary.",
-            diff,
-            sort_order,
-        )
+    if sort_order is not None:
+        diff = hl.eval(hl.set(freq_meta.flatmap(lambda i: i.keys()))) - set(sort_order)
+        if diff:
+            logger.warning(
+                "Found unexpected frequency metadata groupings: %s. These groupings"
+                " are not present in the provided sort_order: %s. These groupings"
+                " will not be included in the returned dictionary.",
+                diff,
+                sort_order,
+            )
 
     index_dict = {}
     for i, f in enumerate(hl.eval(freq_meta)):

--- a/gnomad/utils/release.py
+++ b/gnomad/utils/release.py
@@ -107,7 +107,7 @@ def make_freq_index_dict(
 def make_freq_index_dict_from_meta(
     freq_meta: List[Dict[str, str]],
     label_delimiter: str = "_",
-    sort_order: List[str] = SORT_ORDER,
+    sort_order: Optional[List[str]] = SORT_ORDER,
 ) -> Dict[str, int]:
     """
     Create a dictionary for accessing frequency array.
@@ -136,7 +136,7 @@ def make_freq_index_dict_from_meta(
 
     index_dict = {}
     for i, f in enumerate(hl.eval(freq_meta)):
-        if sort_order and len(set(f.keys()) - set(sort_order)) < 1:
+        if sort_order is None or len(set(f.keys()) - set(sort_order)) < 1:
             index_dict[
                 label_delimiter.join(
                     [

--- a/gnomad/utils/release.py
+++ b/gnomad/utils/release.py
@@ -114,9 +114,9 @@ def make_freq_index_dict_from_meta(
 
     The dictionary is keyed by the grouping combinations found in the frequency metadata
     array, where values are the corresponding 0-based indices for the groupings in the
-    frequency array. For example, if the freq_meta entry [{'pop': 'nfe'}, {'sex': 'XX'}]
+    frequency array. For example, if the `freq_meta` entry [{'pop': 'nfe'}, {'sex': 'XX'}]
     corresponds to the 5th entry in the frequency array, the returned dictionary entry
-    would be {`nfe_XX`: 4}.
+    would be {'nfe_XX': 4}.
 
     :param freq_meta: List of dictionaries containing frequency metadata.
     :param label_delimiter: Delimiter to use when joining frequency metadata labels.
@@ -124,7 +124,7 @@ def make_freq_index_dict_from_meta(
     :return: Dictionary of frequency metadata.
     """
     # Confirm all groups in freq_meta are in sort_order. Warn user if not.
-    diff = hl.eval(hl.set(freq_meta.flatmap(lambda i: i.keys()))) - set(SORT_ORDER)
+    diff = hl.eval(hl.set(freq_meta.flatmap(lambda i: i.keys()))) - set(sort_order)
     if diff:
         logger.warning(
             "Found unexpected frequency metadata groupings: %s. These groupings are"

--- a/gnomad/utils/release.py
+++ b/gnomad/utils/release.py
@@ -2,6 +2,8 @@
 
 from typing import Dict, List, Optional
 
+import hail as hl
+
 from gnomad.resources.grch38.gnomad import (
     CURRENT_MAJOR_RELEASE,
     GROUPS,
@@ -9,7 +11,7 @@ from gnomad.resources.grch38.gnomad import (
     SEXES,
     SUBSETS,
 )
-from gnomad.utils.vcf import index_globals
+from gnomad.utils.vcf import SORT_ORDER, index_globals
 
 
 def make_faf_index_dict(

--- a/gnomad/utils/release.py
+++ b/gnomad/utils/release.py
@@ -92,3 +92,34 @@ def make_freq_index_dict(
         )
 
     return index_dict
+
+
+def make_freq_index_dict_from_meta(
+    freq_meta: List[Dict[str, str]],
+    label_delimiter: str = "_",
+    sort_order: Optional[List[str]] = SORT_ORDER,
+) -> Dict[str, int]:
+    """
+    Create a dictionary for accessing frequency array.
+
+    :param freq_meta: List of dictionaries containing frequency metadata.
+    :param label_delimiter: Delimiter to use when joining frequency metadata labels.
+    :param sort_order: List of frequency metadata labels to use when sorting the dictionary.
+    :return: Dictionary of frequency metadata.
+    """
+    index_dict = {}
+    for i, f in enumerate(hl.eval(freq_meta)):
+        if sort_order and len(set(f.keys()) - set(sort_order)) < 1:
+            index_dict[
+                label_delimiter.join(
+                    [
+                        f[g]
+                        for g in sorted(
+                            f.keys(),
+                            key=(lambda x: sort_order.index(x)) if sort_order else None,
+                        )
+                    ]
+                )
+            ] = i
+
+    return index_dict


### PR DESCRIPTION
This adds the ability to merge multiple frequency arrays that are on the same table. The merge supports addition or subtraction of arrays. For subtraction, all freq arrays are subtracted from the first freq array in the list. This also adds a new function to build frequency array dictionaries from the frequency metadata.
