### PR TITLE
Add "remaining" to pops to remove for popmax for v4

### DIFF
--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -200,7 +200,7 @@ TGP_POP_NAMES = {
 """
 
 POPS_STORED_AS_SUBPOPS = TGP_POPS + HGDP_POPS
-POPS_TO_REMOVE_FOR_POPMAX = {"asj", "fin", "oth", "ami", "mid"}
+POPS_TO_REMOVE_FOR_POPMAX = {"asj", "fin", "oth", "ami", "mid", "remaining"}
 """
 Populations that are removed before popmax calculations.
 """


### PR DESCRIPTION
"oth" was changed to "remaining" in v4. This adds "remaining" to the groups to remove from popmax.