### PR TITLE
add optional ab_expr to qual_hists

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -281,12 +281,15 @@ def qual_hist_expr(
                 for qual_hist_name, qual_hist_expr in qual_hists.items()
             },
         }
+        ab_hist_msg = "Using the %s to compute allele balance histogram..."
         if ab_expr is not None:
-            qual_hists["ab_hist_all"] = hl.agg.filter(
+            logger.info(ab_hist_msg, "ab_expr")
+            qual_hists["ab_hist_alt"] = hl.agg.filter(
                 gt_expr.is_het(), hl.agg.hist(ab_expr, 0, 1, 20)
             )
         elif ad_expr is not None:
-            qual_hists["ab_hist_all"] = hl.agg.filter(
+            logger.info(ab_hist_msg, "ad_expr")
+            qual_hists["ab_hist_alt"] = hl.agg.filter(
                 gt_expr.is_het(), hl.agg.hist(ad_expr[1] / hl.sum(ad_expr), 0, 1, 20)
             )
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1156,7 +1156,7 @@ def region_flag_expr(
     :return: `region_flag` struct row annotation
     """
     prob_flags_expr = (
-        {"non_par": t.locus.in_x_nonpar() | t.locus.in_y_nonpar()} if non_par else {}
+        {"non_par": (t.locus.in_x_nonpar() | t.locus.in_y_nonpar())} if non_par else {}
     )
 
     if prob_regions is not None:


### PR DESCRIPTION
This adds an `ab_expr` to  the qual_hists_expr. Currenlt the ab hists rely on AD which is expensive to densify as an array expression of ints. This would allow us to pass a single float expr while maintaining the original AD functionality. 
