### PR TITLE
Add option to also merge an array of counts/ints in the freq array merge

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1354,17 +1354,16 @@ def merge_freq_arrays(
             ),
         )
     )
-    # Iterate through each group in the freq_meta_idx
+    # Iterate through each group in the high_ab_meta_idx
     # access the entry in the high_ab_hets_by_group_membership annotation
-    # and add the values for each group to make a
-    # new high_ab_het counts annotation. Probably add in diff?
+    # and add the values for each group to make a new count array annotation.
     if count_arrays:
-        high_ab_meta_idx = fmeta.map(
+        count_array_meta_idx = fmeta.map(
             lambda x: hl.zip(count_arrays, x[1]).map(lambda i: i[0][i[1]])
         )
-        new_counts_array = high_ab_meta_idx.map(
+        new_counts_array = count_array_meta_idx.map(
             lambda x: hl.fold(
-                lambda i, j: _sum_or_diff_fields(x[i], x[j]),
+                lambda i, j: _sum_or_diff_fields(i, j),
                 x[0],
                 x[1:],
             ),

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1275,7 +1275,7 @@ def merge_freq_arrays(
     :param fmeta: List of frequency metadata for arrays being merged.
     :param operation: Merge operation to perform. Options are "sum" and "diff". If "diff" is passed, the first freq array in the list will have the other arrays subtracted from it.
     :param set_negatives_to_zero: If True, set negative array values to 0 for AC, AN, AF, and homozygote_count. If False, raise a ValueError. Default is True.
-    :param count_arrays: List of arrays containing counts to merge using the passed operation. Default is None.
+    :param count_arrays: List of arrays containing counts to merge using the passed operation. Must use the same group indexing as fmeta. Default is None.
     :return: Tuple of merged frequency array and its frequency metadata list.
     """
     if len(farrays) < 2:
@@ -1284,6 +1284,9 @@ def merge_freq_arrays(
         raise ValueError("Length of farrays and fmeta must be equal!")
     if operation not in ["sum", "diff"]:
         raise ValueError("Operation must be either 'sum' or 'diff'!")
+    if count_arrays is not None:
+        if len(count_arrays) != len(fmeta):
+            raise ValueError("Length of count_arrays and fmeta must be equal!")
 
     # Create a list where each entry is a dictionary whose key is an aggregation
     # group and the value is the corresponding index in the freq array.


### PR DESCRIPTION
This adds functionality to merge arrays of counts. This is used when merging the array of high AB hets in gnomad_qc's frequency script. 