### PR TITLE
Update annotate_freq and qual_hists, add split_vds and compute_freq_by_strata

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -379,7 +379,7 @@ def annotate_freq(
 
     .. rubric:: `freq` row annotation
 
-    The `freq` row annotation is an Array of Struct, with each Struct containing the
+    The `freq` row annotation is an Array of Structs, with each Struct containing the
     following fields:
 
         - AC: int32
@@ -1377,7 +1377,11 @@ def compute_freq_by_strata(
     entry_agg_funcs: Optional[Dict[str, Tuple[Callable, Callable]]] = None,
 ) -> hl.Table:
     """
-    Compute allele frequencies by strata.
+    Compute allele frequencies by strata and downsamplings, when provided.
+
+    .. note::
+        This function is primarily used through annotate_freq but can be used
+        independently if desired.
 
     :param mt: Input MatrixTable.
     :param strata_expr: List of dicts of strata expressions.
@@ -1456,6 +1460,7 @@ def compute_freq_by_strata(
     freq_meta_expr = [
         dict(**sample_group[0], group="adj") for sample_group in sample_group_filters
     ]
+    # Add the "raw" group, representing all samples, to the freq_meta_expr list.
     freq_meta_expr.insert(1, {"group": "raw"})
     freq_sample_count.insert(1, freq_sample_count[0])
     mt = mt.annotate_globals(
@@ -1484,6 +1489,7 @@ def compute_freq_by_strata(
             )
         )
         raw_agg_expr = agg_expr.aggregate(lambda x: agg_func(x, *args))
+        # Add the "raw" group, representing all samples, to the adj_agg_expr list.
         return adj_agg_expr[:1].append(raw_agg_expr).extend(adj_agg_expr[1:])
 
     freq_expr = _agg_by_group(ht, hl.agg.call_stats, ht.gt_array, ht.alleles)

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1504,7 +1504,8 @@ def compute_freq_by_strata(
             )
         )
         raw_agg_expr = agg_expr.aggregate(lambda x: agg_func(x, *args))
-        # Add the "raw" group, representing all samples, to the adj_agg_expr list.
+        # Create final agg list by inserting the "raw" group, representing all samples,
+        # into the adj_agg_list.
         return adj_agg_expr[:1].append(raw_agg_expr).extend(adj_agg_expr[1:])
 
     freq_expr = _agg_by_group(ht, hl.agg.call_stats, ht.gt_array, ht.alleles)

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1383,7 +1383,11 @@ def compute_freq_by_strata(
     entry_agg_funcs: Optional[Dict[str, Tuple[Callable, Callable]]] = None,
 ) -> hl.Table:
     """
-    Compute allele frequencies by strata and downsamplings, when provided.
+    Compute call statistics and, when passed, entry aggregation function(s) by strata.
+
+    The computed call statistics are AC, AF, AN, and homozygote_count. Downsamplings are
+    added to the strata when downsamplings when passed. The entry aggregation functions
+    are applied to the MatrixTable entries and aggregated by strata.
 
     .. note::
         This function is primarily used through annotate_freq but can be used
@@ -1393,7 +1397,12 @@ def compute_freq_by_strata(
     :param strata_expr: List of dicts of strata expressions.
     :param downsamplings: Optional list of downsampling groups.
     :param ds_pop_counts: Optional dict of population counts for downsampling groups.
-    :param entry_agg_funcs: Optional dict of entry aggregation functions.
+    :param entry_agg_funcs: Optional dict of entry aggregation functions. When
+        specified, additional annotations are added to the output Table/MatrixTable.
+        The keys of the dict are the names of the annotations and the values are tuples
+        of functions. The first function is used to transform the `mt` entries in some
+        way, and the second function is used to aggregate the output from the first
+        function.
     :return: Table or MatrixTable with allele frequencies by strata.
     """
     n_samples = mt.count_cols()

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1451,11 +1451,6 @@ def compute_freq_by_strata(
             "Strata must contain a downsampling expression when downsamplings"
             "are provided."
         )
-    if downsamplings is not None and not ds_in_strata:
-        errors.append(
-            "Strata must contain a downsampling expression when downsamplings"
-            "are provided."
-        )
     if downsamplings is not None and not global_idx_in_ds_expr:
         errors.append(
             "Strata must contain a downsampling expression with 'global_idx' when "
@@ -1494,7 +1489,7 @@ def compute_freq_by_strata(
         downsampling_expr = strata.get("downsampling")
         strata_values = []
         # Add to all downsampling groups, both global and population-specific, to
-        # strata
+        # strata.
         for s in strata:
             if s == "downsampling":
                 v = [("downsampling", d) for d in downsamplings]
@@ -1573,7 +1568,18 @@ def compute_freq_by_strata(
         gt_array=ht.entries.map(lambda e: e.GT),
     )
 
-    def _agg_by_group(ht, agg_func, agg_expr, *args):
+    def _agg_by_group(
+        ht: hl.Table, agg_func: Callable, agg_expr: Callable, *args
+    ) -> hl.expr.ArrayExpression:
+        """
+        Run a passed function on entries and aggregate the results by group.
+
+        :param ht: Input Hail Table.
+        :param agg_func: Function to apply to the entries.
+        :param agg_expr: Aggregation to run on the result of `agg_func`.
+        :param args: Additional arguments to pass to the `agg_func`.
+        :return: Aggregated array expression.
+        """
         adj_agg_expr = ht.indices_by_group.map(
             lambda s_indices: s_indices.aggregate(
                 lambda i: hl.agg.filter(ht.adj_array[i], agg_func(agg_expr[i], *args))

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1572,11 +1572,11 @@ def compute_freq_by_strata(
         ht: hl.Table, agg_func: Callable, agg_expr: Callable, *args
     ) -> hl.expr.ArrayExpression:
         """
-        Run a passed function on entries and aggregate the results by group.
+        Aggregate `agg_expr` by group using the `agg_func` function.
 
         :param ht: Input Hail Table.
-        :param agg_func: Function to apply to the entries.
-        :param agg_expr: Aggregation to run on the result of `agg_func`.
+        :param agg_func: Aggregation function to apply to `agg_expr`.
+        :param agg_expr: Expression to aggregate by group.
         :param args: Additional arguments to pass to the `agg_func`.
         :return: Aggregated array expression.
         """

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1456,6 +1456,11 @@ def compute_freq_by_strata(
             "Strata must contain a downsampling expression when downsamplings"
             "are provided."
         )
+    if downsamplings is not None and not global_idx_in_ds_expr:
+        errors.append(
+            "Strata must contain a downsampling expression with 'global_idx' when "
+            "downsamplings are provided."
+        )
     if ds_pop_counts is not None and not pop_in_strata:
         errors.append(
             "Strata must contain a population expression 'pop' when ds_pop_counts "

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -255,13 +255,14 @@ def qual_hist_expr(
         - If `ab_expr` is provided, the allele-balance histogram is computed using this expression instead of the ad_expr.
         - If `adj_expr` is provided, additional histograms are computed using only adj samples.
 
-    :param gt_expr: Entry expression containing genotype
-    :param gq_expr: Entry expression containing genotype quality
-    :param dp_expr: Entry expression containing depth
-    :param ad_expr: Entry expression containing allelic depth (bi-allelic here)
-    :param adj_expr: Entry expression containing adj (high quality) genotype status
-    :param ab_expr: Entry expression containing allele balance (bi-allelic here)
-    :return: Genotype quality histograms expression
+    :param gt_expr: Entry expression containing genotype.
+    :param gq_expr: Entry expression containing genotype quality.
+    :param dp_expr: Entry expression containing depth.
+    :param ad_expr: Entry expression containing allelic depth (bi-allelic here).
+    :param adj_expr: Entry expression containing adj (high quality) genotype status.
+    :param ab_expr: Entry expression containing allele balance (bi-allelic here).
+    :param split_adj_and_raw: Whether to split the adj and raw histograms into separate fields in the returned struct expr.
+    :return: Genotype quality histograms expression.
     """
     qual_hists = {}
     if gq_expr is not None:

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -511,3 +511,21 @@ def filter_for_mu(
     )
 
     return ht
+
+
+def split_vds_by_strata(
+    vds: hl.vds.VariantDataset, strata_expr: hl.expr.Expression
+) -> List[hl.vds.VariantDataset]:
+    """
+    Split a VDS into a list of VDSs based on `strata_expr`.
+
+    :param vds: Input VDS.
+    :param strata_expr: Expression on VDS variant_data MT to split on.
+    :return: List of VDSs.
+    """
+    vmt = vds.variant_data
+    s_by_strata = vmt.aggregate_cols(
+        hl.agg.group_by(strata_expr, hl.agg.collect_as_set(vmt.s))
+    )
+
+    return [hl.vds.filter_samples(vds, list(s)) for strata, s in s_by_strata.items()]


### PR DESCRIPTION
This updates annotate_freq to use the added array aggregation functionality in hail, originally added by Tim in #537, adds the ability to add entry aggregation annotations, and generally cleans up the function by splitting the existing annotate_freq into two functions: annotate_freq which calls compute_freq_by_strata. 

This also adds split_vds_by_strata which returns a lists of VDSs with as many VDSs as there are unique values for the passed expression. 

We also add the ability to return a single struct of qual histograms, containing separate structs of raw and adj qual histograms.