### PR TITLE
Avoid DeprecationWarnings from superseded hail function and import [minor] 

### DIFF
--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -1097,7 +1097,7 @@ def generate_trio_stats_expr(
                 locus.in_autosome(),
                 proband_gt.is_het() & father_gt.is_hom_ref() & mother_gt.is_hom_ref(),
             )
-        return hl.cond(
+        return hl.if_else(
             locus.in_autosome_or_par() | (proband_is_female & locus.in_x_nonpar()),
             proband_gt.is_het() & father_gt.is_hom_ref() & mother_gt.is_hom_ref(),
             hl.or_missing(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -601,7 +601,7 @@ def get_lowqual_expr(
 
     if isinstance(qual_approx_expr, hl.expr.ArrayNumericExpression):
         return hl.range(1, hl.len(alleles)).map(
-            lambda ai: hl.cond(
+            lambda ai: hl.if_else(
                 hl.is_snp(alleles[0], alleles[ai]),
                 qual_approx_expr[ai - 1] < min_snv_qual,
                 qual_approx_expr[ai - 1] < min_indel_qual,
@@ -728,7 +728,7 @@ def get_adj_expr(
     """
     return (
         (gq_expr >= adj_gq)
-        & hl.cond(gt_expr.is_haploid(), dp_expr >= haploid_adj_dp, dp_expr >= adj_dp)
+        & hl.if_else(gt_expr.is_haploid(), dp_expr >= haploid_adj_dp, dp_expr >= adj_dp)
         & (
             hl.case()
             .when(~gt_expr.is_het(), True)
@@ -778,12 +778,12 @@ def add_variant_type(alt_alleles: hl.expr.ArrayExpression) -> hl.expr.StructExpr
     alts = alt_alleles[1:]
     non_star_alleles = hl.filter(lambda a: a != "*", alts)
     return hl.struct(
-        variant_type=hl.cond(
+        variant_type=hl.if_else(
             hl.all(lambda a: hl.is_snp(ref, a), non_star_alleles),
-            hl.cond(hl.len(non_star_alleles) > 1, "multi-snv", "snv"),
-            hl.cond(
+            hl.if_else(hl.len(non_star_alleles) > 1, "multi-snv", "snv"),
+            hl.if_else(
                 hl.all(lambda a: hl.is_indel(ref, a), non_star_alleles),
-                hl.cond(hl.len(non_star_alleles) > 1, "multi-indel", "indel"),
+                hl.if_else(hl.len(non_star_alleles) > 1, "multi-indel", "indel"),
                 "mixed",
             ),
         ),
@@ -971,7 +971,7 @@ def fs_from_sb(
     # Normalize table if counts get too large
     if normalize:
         fs_expr = hl.bind(
-            lambda sb, sb_sum: hl.cond(
+            lambda sb, sb_sum: hl.if_else(
                 sb_sum <= 2 * min_cell_count,
                 sb,
                 sb.map(lambda x: hl.int(x / (sb_sum / min_cell_count))),

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import hail as hl
-from hailtop.aiogoogle import GoogleStorageAsyncFS
+from hailtop.aiocloud.aiogoogle import GoogleStorageAsyncFS
 from hailtop.aiotools import AsyncFS, LocalAsyncFS
 from hailtop.aiotools.router_fs import RouterAsyncFS
 from hailtop.utils import bounded_gather

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -237,7 +237,7 @@ def add_filters_expr(
         lambda x, y: x.union(y),
         current_filters,
         [
-            hl.cond(filter_condition, hl.set([filter_name]), hl.empty_set(hl.tstr))
+            hl.if_else(filter_condition, hl.set([filter_name]), hl.empty_set(hl.tstr))
             for filter_name, filter_condition in filters.items()
         ],
     )

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -976,7 +976,7 @@ def compute_coverage_stats(
 
     # Annotate rows now
     return mt.select_rows(
-        mean=hl.cond(hl.is_nan(mean_expr), 0, mean_expr),
+        mean=hl.if_else(hl.is_nan(mean_expr), 0, mean_expr),
         median_approx=hl.or_else(hl.agg.approx_median(hl.or_else(mt.DP, 0)), 0),
         total_DP=hl.agg.sum(mt.DP),
         **{

--- a/gnomad/variant_qc/random_forest.py
+++ b/gnomad/variant_qc/random_forest.py
@@ -45,7 +45,7 @@ def run_rf_test(
     )
 
     mt = mt.annotate_rows(
-        label=hl.cond(mt["feature1"] & (mt["feature2"] > 0), "TP", "FP")
+        label=hl.if_else(mt["feature1"] & (mt["feature2"] > 0), "TP", "FP")
     )
     ht = mt.rows()
 


### PR DESCRIPTION
Rewrite remaining invocations of `hl.cond()` to `hl.if_else()`. There are already numerous instances of `hl.if_else()` in gnomad_methods, so this has no compatibility considerations.

Also (in _gnomad/utils/file_utils.py_) import `GoogleStorageAsyncFS` from its modern location. This has been `hailtop.aiocloud.aiogoogle` since hail 2.0.78 (see hail-is/hail#10898 and hail-is/hail#10974). If gnomad_methods needs to be compatible with versions of hail prior to 2.0.78, this part of the change should be omitted.

Very minor, but a few of these appear in our test logs which makes for noise when tracking down other problems via the logs.



<!-- Thank you for submitting a pull request.

To make sure that this change is included in release notes, please:
- Use a descriptive title for the pull request.
- Apply one of the "Changelog" labels (if applicable).

-->
