### PR TITLE
Split vds change from list to dict

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1339,7 +1339,7 @@ def annotate_freq(
         ds_ht = annotate_downsamplings(mt, downsamplings, pop_expr=pop_expr).cols()
         downsamplings = hl.eval(ds_ht.downsamplings)
         ds_pop_counts = hl.eval(ds_ht.ds_pop_counts)
-        downsampling_expr = ds_ht[mt.col_key]
+        downsampling_expr = ds_ht[mt.col_key].downsampling
 
     # Build list of all stratification groups to be used in the frequency calculation.
     strata_expr = build_freq_stratification_list(

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -528,4 +528,6 @@ def split_vds_by_strata(
         hl.agg.group_by(strata_expr, hl.agg.collect_as_set(vmt.s))
     )
 
-    return [hl.vds.filter_samples(vds, list(s)) for strata, s in s_by_strata.items()]
+    return {
+        strata: hl.vds.filter_samples(vds, list(s)) for strata, s in s_by_strata.items()
+    }

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -515,13 +515,13 @@ def filter_for_mu(
 
 def split_vds_by_strata(
     vds: hl.vds.VariantDataset, strata_expr: hl.expr.Expression
-) -> List[hl.vds.VariantDataset]:
+) -> Dict[str, hl.vds.VariantDataset]:
     """
-    Split a VDS into a list of VDSs based on `strata_expr`.
+    Split a VDS into multiple VDSs based on `strata_expr`.
 
     :param vds: Input VDS.
     :param strata_expr: Expression on VDS variant_data MT to split on.
-    :return: List of VDSs.
+    :return: Dictionary where strata value is key and VDS is value.
     """
     vmt = vds.variant_data
     s_by_strata = vmt.aggregate_cols(


### PR DESCRIPTION
This changes the split_vds_by_strata's return to a dictionary instead of a list of VDSs. This gives more utility in seeing which VDS belongs to which strata. This also fixes a bug in the annotate_freq function.