### PR TITLE
Add optional filter to freq meta sample counts

### DIFF
--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -600,12 +600,15 @@ def filter_freq_by_meta(
         ),
     )
     freq_expr = freq_meta_expr.map(lambda x: freq_expr[x[0]])
-    freq_meta_expr = freq_meta_expr.map(lambda x: x[1])
 
     if freq_meta_sample_count_expr is not None:
         freq_meta_sample_count_expr = freq_meta_expr.map(
             lambda x: freq_meta_sample_count_expr[x[0]]
         )
+
+    freq_meta_expr = freq_meta_expr.map(lambda x: x[1])
+
+    if freq_meta_sample_count_expr is not None:
         return freq_expr, freq_meta_expr, freq_meta_sample_count_expr
     else:
         return freq_expr, freq_meta_expr

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -539,6 +539,7 @@ def filter_freq_by_meta(
     items_to_filter: Union[Dict[str, List[str]], List[str]],
     keep: bool = True,
     combine_operator: str = "and",
+    freq_meta_sample_count_expr: Optional[hl.ArrayExpression] = None,
 ) -> Tuple[hl.expr.ArrayExpression, hl.expr.ArrayExpression]:
     """
     Filter frequency and frequency meta expressions specified by `items_to_filter`.
@@ -564,6 +565,7 @@ def filter_freq_by_meta(
     :param keep: Whether to keep or remove the items specified by `items_to_filter`.
     :param combine_operator: Whether to use "and" or "or" to combine the items
         specified by `items_to_filter`.
+    :param freq_meta_sample_count: Optional frequency meta sample count expression to be filtered.
     :return: Tuple of the filtered frequency and frequency meta expressions.
     """
     freq_meta_expr = freq_meta_expr.collect(_localize=False)[0]
@@ -600,4 +602,10 @@ def filter_freq_by_meta(
     freq_expr = freq_meta_expr.map(lambda x: freq_expr[x[0]])
     freq_meta_expr = freq_meta_expr.map(lambda x: x[1])
 
-    return freq_expr, freq_meta_expr
+    if freq_meta_sample_count_expr is not None:
+        freq_meta_sample_count_expr = freq_meta_expr.map(
+            lambda x: freq_meta_sample_count_expr[x[0]]
+        )
+        return freq_expr, freq_meta_expr, freq_meta_sample_count_expr
+    else:
+        return freq_expr, freq_meta_expr

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -552,7 +552,7 @@ def filter_arrays_by_meta(
 
     The items can be kept or removed from `meta_indexed_expr` and `meta_expr` based on
     the value of `keep`. For example if `meta_indexed_exprs` is {'freq': ht.freq,
-    'freq_meta_sample_count`: ht.index_globals().freq_meta_sample_count} and `meta_expr`
+'freq_meta_sample_count': ht.index_globals().freq_meta_sample_count} and `meta_expr`
     is ht.freq_meta then if `keep` is True, the items specified by `items_to_filter`
     such as  'pop' = 'han' will be kept and all other items will be removed from the
     ht.freq, ht.freq_meta_sample_count, and ht.freq_meta.
@@ -570,7 +570,6 @@ def filter_arrays_by_meta(
     :param keep: Whether to keep or remove the items specified by `items_to_filter`.
     :param combine_operator: Whether to use "and" or "or" to combine the items
         specified by `items_to_filter`.
-    :param meta_based_array_expr: Optional array based on freq meta expression to be filtered.
     :return: Tuple of the filtered metadata expression and a dictionary of metadata indexed expressions.
     """
     meta_expr = meta_expr.collect(_localize=False)[0]

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -541,7 +541,7 @@ def filter_arrays_by_meta(
     items_to_filter: Union[Dict[str, List[str]], List[str]],
     keep: bool = True,
     combine_operator: str = "and",
-) -> Tuple[hl.expr.ArrayExpression, Dict[str, hl.expr.ArrayExpression]]:
+) -> Tuple[hl.expr.ArrayExpression, Union[Dict[str, hl.expr.ArrayExpression], hl.expr.ArrayExpression]]:
     """
     Filter both metadata array expression and meta data indexed expression by `items_to_filter`.
 

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -605,9 +605,9 @@ def filter_arrays_by_meta(
         ),
     )
 
-    meta_indexed_exprs = meta_indexed_exprs.map_values(
-        lambda x: meta_expr.map(lambda y: x[y[0]])
-    )
+    meta_indexed_exprs = {
+        k: meta_expr.map(lambda x: v[x[0]]) for k, v in meta_indexed_exprs.items()
+    }
     meta_expr = meta_expr.map(lambda x: x[1])
 
     return meta_expr, meta_indexed_exprs

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -552,7 +552,7 @@ def filter_arrays_by_meta(
 
     The items can be kept or removed from `meta_indexed_expr` and `meta_expr` based on
     the value of `keep`. For example if `meta_indexed_exprs` is {'freq': ht.freq,
-'freq_meta_sample_count': ht.index_globals().freq_meta_sample_count} and `meta_expr`
+    'freq_meta_sample_count': ht.index_globals().freq_meta_sample_count} and `meta_expr`
     is ht.freq_meta then if `keep` is True, the items specified by `items_to_filter`
     such as  'pop' = 'han' will be kept and all other items will be removed from the
     ht.freq, ht.freq_meta_sample_count, and ht.freq_meta.

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -541,7 +541,10 @@ def filter_arrays_by_meta(
     items_to_filter: Union[Dict[str, List[str]], List[str]],
     keep: bool = True,
     combine_operator: str = "and",
-) -> Tuple[hl.expr.ArrayExpression, Union[Dict[str, hl.expr.ArrayExpression], hl.expr.ArrayExpression]]:
+) -> Tuple[
+    hl.expr.ArrayExpression,
+    Union[Dict[str, hl.expr.ArrayExpression], hl.expr.ArrayExpression],
+]:
     """
     Filter both metadata array expression and meta data indexed expression by `items_to_filter`.
 

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -539,7 +539,7 @@ def filter_freq_by_meta(
     items_to_filter: Union[Dict[str, List[str]], List[str]],
     keep: bool = True,
     combine_operator: str = "and",
-    freq_meta_sample_count_expr: Optional[hl.ArrayExpression] = None,
+    freq_meta_based_array_expr: Optional[hl.ArrayExpression] = None,
 ) -> Tuple[hl.expr.ArrayExpression, hl.expr.ArrayExpression]:
     """
     Filter frequency and frequency meta expressions specified by `items_to_filter`.
@@ -565,7 +565,7 @@ def filter_freq_by_meta(
     :param keep: Whether to keep or remove the items specified by `items_to_filter`.
     :param combine_operator: Whether to use "and" or "or" to combine the items
         specified by `items_to_filter`.
-    :param freq_meta_sample_count: Optional frequency meta sample count expression to be filtered.
+    :param freq_meta_based_array_expr: Optional array based on freq meta expression to be filtered.
     :return: Tuple of the filtered frequency and frequency meta expressions.
     """
     freq_meta_expr = freq_meta_expr.collect(_localize=False)[0]
@@ -601,14 +601,14 @@ def filter_freq_by_meta(
     )
     freq_expr = freq_meta_expr.map(lambda x: freq_expr[x[0]])
 
-    if freq_meta_sample_count_expr is not None:
-        freq_meta_sample_count_expr = freq_meta_expr.map(
-            lambda x: freq_meta_sample_count_expr[x[0]]
+    if freq_meta_based_array_expr is not None:
+        freq_meta_based_array_expr = freq_meta_expr.map(
+            lambda x: freq_meta_based_array_expr[x[0]]
         )
 
     freq_meta_expr = freq_meta_expr.map(lambda x: x[1])
 
-    if freq_meta_sample_count_expr is not None:
-        return freq_expr, freq_meta_expr, freq_meta_sample_count_expr
+    if freq_meta_based_array_expr is not None:
+        return freq_expr, freq_meta_expr, freq_meta_based_array_expr
     else:
         return freq_expr, freq_meta_expr


### PR DESCRIPTION
This adds in an optional filtering of another array that is based on freq_meta (filtering freq_meta_sample_counts is how I will use it)  but I think we could generalize this more since its just adding an optional step with the same exact filtering that happens on freq. Maybe make the function `filter_array_by_meta` or something and pass a dictionary of strings and array expressions that all get filtered the same.....all that said I didnt want to change too much without your inputs since this just went in. 
