### PR TITLE
make in silico predictors a public resource

### DIFF
--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -441,7 +441,7 @@ revel = VersionedTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/revel.v1.3.ht",
             import_func=hl.import_table,
             import_args={
-                "path": "gs://gnomad-insilico/revel/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz",
+                "path": "gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz",
                 "delimiter": ",",
                 "types": {"grch38_pos": hl.tstr, "REVEL": hl.tfloat64},
                 "force_bgz": True,

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -458,7 +458,7 @@ pangolin = VersionedTableResource(
     versions={
         "v1.0": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/pangolin.v1.0.ht",
-            import_func=hl.import_sites_vcf,
+            import_func=import_sites_vcf,
             import_args={
                 "path": "gs://gnomad-insilico/pangolin/gnomad.v4.0.genomes.pangolin.vcf.bgz/*",
                 "force_bgz": True,

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -375,7 +375,7 @@ def get_truth_ht() -> Table:
     )
 
 
-def _load_cadd_raw(cadd_tsv) -> hl.Table:
+def _load_cadd_raw(path) -> hl.Table:
     """Functions to load CADD raw data in TSV format to Hail Table."""
     column_names = {
         "f0": "chr",
@@ -387,7 +387,7 @@ def _load_cadd_raw(cadd_tsv) -> hl.Table:
     }
     types = {"f0": hl.tstr, "f1": hl.tint32, "f4": hl.tfloat32, "f5": hl.tfloat32}
     ht = hl.import_table(
-        cadd_tsv,
+        path,
         types=types,
         no_header=True,
         force_bgz=True,
@@ -436,18 +436,32 @@ cadd = VersionedTableResource(
     },
 )
 
+
+def _import_revel_csv(path: str) -> hl.Table:
+    """
+    Import REVEL scores from CSV file.
+
+    :param path: Path to CSV file containing REVEL scores.
+    :return: Table with REVEL scores.
+    """
+    ht = hl.import_table(
+        path,
+        delimiter=",",
+        min_partitions=1000,
+        types={"grch38_pos": hl.tstr, "REVEL": hl.tfloat64},
+        force_bgz=True,
+    )
+    return ht
+
+
 revel = VersionedTableResource(
     default_version="v1.3",
     versions={
         "v1.3": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/revel.v1.3.ht",
-            import_func=hl.import_table,
+            import_func=_import_revel_csv,
             import_args={
                 "path": "gs://gnomad-insilico/revel/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz",
-                "delimiter": ",",
-                "types": {"grch38_pos": hl.tstr, "REVEL": hl.tfloat64},
-                "force_bgz": True,
-                "min_partitions": 1000,
             },
         ),
     },

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -408,7 +408,7 @@ def _load_cadd_raw(cadd_tsv) -> hl.Table:
 cadd = VersionedTableResource(
     versions={
         "snvs": GnomadPublicTableResource(
-            path="gs://gcp-public-data--gnomad/resources/grch38/in_silico_predictors/CADD_v1.6_SNVs.ht"
+            path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/CADD_v1.6_SNVs.ht"
         ),
         "indels3.0": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/cadd.v1.6.gnomad.genomes.v3.0.indel.ht",
@@ -441,7 +441,7 @@ revel = VersionedTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/revel.v1.3.ht",
             import_func=hl.import_table,
             import_args={
-                "path": "gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz",
+                "path": "gs://gnomad-insilico/revel/revel-v1.3_all_chromosomes_with_transcript_ids.csv.bgz",
                 "delimiter": ",",
                 "types": {"grch38_pos": hl.tstr, "REVEL": hl.tfloat64},
                 "force_bgz": True,

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -406,6 +406,7 @@ def _load_cadd_raw(cadd_tsv) -> hl.Table:
 
 
 cadd = VersionedTableResource(
+    default_version="indels4.0",
     versions={
         "snvs": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/CADD_v1.6_SNVs.ht"
@@ -432,10 +433,11 @@ cadd = VersionedTableResource(
                 )
             },
         ),
-    }
+    },
 )
 
 revel = VersionedTableResource(
+    default_version="v1.3",
     versions={
         "v1.3": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/revel.v1.3.ht",
@@ -448,10 +450,11 @@ revel = VersionedTableResource(
                 "min_partitions": 1000,
             },
         ),
-    }
+    },
 )
 
 pangolin = VersionedTableResource(
+    default_version="v1.0",
     versions={
         "v1.0": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/in_silico_predictors/pangolin.v1.0.ht",
@@ -464,5 +467,5 @@ pangolin = VersionedTableResource(
                 "skip_invalid_loci": True,
             },
         ),
-    }
+    },
 )


### PR DESCRIPTION
I'm making REVEL, Pangolin, and CADD (only for indels) as public resources. 
But I have troubling writing into the public bucket even though KC granted me temporary access, I could copy something into it, but not create. Since Mike's been on my other PR, but KC told me that only her, Julia and Steve has right. 
Error as in this [job](https://console.cloud.google.com/dataproc/jobs/81cb64fcf1ef4fc9ac41ed4c92453706/monitoring?project=broad-mpg-gnomad&region=us-central1). 
