### PR TITLE
Fix `annotate_downsamplings` when used with a Table instead of a MatrixTable

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1412,8 +1412,7 @@ def annotate_downsamplings(
         else:
             ht = t
 
-    ht = ht.annotate(r=hl.rand_unif(0, 1))
-    ht = ht.order_by(ht.r)
+    ht = ht.key_by(r=hl.rand_unif(0, 1))
 
     # Add a global index for use in computing frequencies, or other aggregate stats on
     # the downsamplings.


### PR DESCRIPTION
Fix for error `Error summary: AssertionError: assertion failed: Key type struct{r: float64} is not a subset of struct{s: str, global_idx: int64, pop_idx: int64}`