### PR TITLE
When merging freq arrays, AF will be missing when AN is 0

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1100,7 +1100,7 @@ def merge_freq_arrays(
     new_freq = freq_meta_idx.map(
         lambda x: hl.bind(
             lambda y: y.annotate(
-                AF=hl.if_else(y.AN > 0, y.AC / y.AN, hl.missing(hl.tfloat64))
+                AF=hl.or_missing(y.AN > 0, y.AC / y.AN)
             ).select(*callstat_ann_af),
             hl.fold(
                 lambda i, j: hl.struct(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1099,9 +1099,9 @@ def merge_freq_arrays(
     callstat_ann_af = ["AC", "AF", "AN", "homozygote_count"]
     new_freq = freq_meta_idx.map(
         lambda x: hl.bind(
-            lambda y: y.annotate(
-                AF=hl.or_missing(y.AN > 0, y.AC / y.AN)
-            ).select(*callstat_ann_af),
+            lambda y: y.annotate(AF=hl.or_missing(y.AN > 0, y.AC / y.AN)).select(
+                *callstat_ann_af
+            ),
             hl.fold(
                 lambda i, j: hl.struct(
                     **{ann: _sum_or_diff_fields(i[ann], j[ann]) for ann in callstat_ann}

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1099,9 +1099,9 @@ def merge_freq_arrays(
     callstat_ann_af = ["AC", "AF", "AN", "homozygote_count"]
     new_freq = freq_meta_idx.map(
         lambda x: hl.bind(
-            lambda y: y.annotate(AF=hl.if_else(y.AN > 0, y.AC / y.AN, 0)).select(
-                *callstat_ann_af
-            ),
+            lambda y: y.annotate(
+                AF=hl.if_else(y.AN > 0, y.AC / y.AN, hl.missing(hl.tfloat64))
+            ).select(*callstat_ann_af),
             hl.fold(
                 lambda i, j: hl.struct(
                     **{ann: _sum_or_diff_fields(i[ann], j[ann]) for ann in callstat_ann}


### PR DESCRIPTION
Previously the merge function set AF to 0 when AN was 0. This was misleading as it implied coverage/information at these sites. 