### PR TITLE
Update variant QC evaluation `score_bin_agg` to include clinvar pathogenic count and use 'fail_hard_filters' instead of 'info'

### DIFF
--- a/gnomad/variant_qc/evaluation.py
+++ b/gnomad/variant_qc/evaluation.py
@@ -85,7 +85,7 @@ def compute_ranked_bin(
         "Sorting the HT by score_expr followed by a random float between 0 and 1. "
         "Then adding a row index per grouping defined by bin_expr..."
     )
-    bin_ht = bin_ht.order_by("_score", "_rand")
+    bin_ht = bin_ht.key_by("_score", "_rand")
     bin_ht = bin_ht.annotate(
         **{
             f"{bin_id}_rank": hl.or_missing(

--- a/gnomad/variant_qc/pipeline.py
+++ b/gnomad/variant_qc/pipeline.py
@@ -14,7 +14,7 @@ from gnomad.sample_qc.relatedness import (
     generate_trio_stats_expr,
 )
 from gnomad.utils.annotations import annotate_adj, bi_allelic_expr
-from gnomad.utils.filtering import filter_to_autosomes
+from gnomad.utils.filtering import filter_to_autosomes, filter_to_clinvar_pathogenic
 from gnomad.utils.reference_genome import get_reference_genome
 from gnomad.variant_qc.evaluation import compute_ranked_bin
 from gnomad.variant_qc.random_forest import (
@@ -197,11 +197,14 @@ def score_bin_agg(
     indel_length = hl.abs(ht.alleles[0].length() - ht.alleles[1].length())
     # Load external evaluation data
     build = get_reference_genome(ht.locus).name
-    clinvar = (
+    clinvar_ht = (
         grch37_resources.reference_data.clinvar
         if build == "GRCh37"
         else grch38_resources.reference_data.clinvar
-    ).ht()[ht.key]
+    ).ht()
+    # Filter to ClinVar pathogenic data.
+    clinvar_path = filter_to_clinvar_pathogenic(clinvar_ht)[ht.key]
+    clinvar = clinvar_ht[ht.key]
     truth_data = (
         grch37_resources.reference_data.get_truth_ht()
         if build == "GRCh37"


### PR DESCRIPTION
- Also fixes issue with binning using `order_by`