### PR TITLE
Optimize a couple collect calls and add option to disable checkpointing

### DIFF
--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -497,6 +497,7 @@ def gnomad_gks(
             coverage_ht = hl.read_table(
                 coverage("genomes").versions[coverage_version].path
             )
+        ht = ht.annotate(mean_cov=coverage_ht[ht.locus].mean)
 
     # Retrieve ancestry groups from the imported POPS dictionary.
     pops_list = list(POPS[high_level_version]) if by_ancestry_group else None
@@ -517,8 +518,11 @@ def gnomad_gks(
 
     # Select relevant fields, checkpoint, and filter to interval before adding
     # annotations
-    ht = ht.select(ht.freq, ht.info.vrs, ht.popmax)
-    ht = ht.checkpoint(hl.utils.new_temp_file("vrs_checkpoint", extension="ht"))
+    if not skip_coverage:
+        ht = ht.select(ht.freq, ht.info.vrs, ht.popmax, ht.mean_cov)
+    else:
+        ht = ht.select(ht.freq, ht.info.vrs, ht.popmax)
+    # ht = ht.checkpoint(hl.utils.new_temp_file("vrs_checkpoint", extension="ht"))
     ht = hl.filter_intervals(ht, [locus_interval])
 
     # Collect all variants as structs, so all dictionary construction can be
@@ -547,7 +551,6 @@ def gnomad_gks(
                 input_struct=variant,
                 label_name="gnomAD",
                 label_version=version,
-                coverage_ht=coverage_ht,
                 ancestry_groups=pops_list,
                 ancestry_groups_dict=POP_NAMES,
                 by_sex=by_sex,

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -524,6 +524,7 @@ def gnomad_gks(
     # Collect all variants as structs, so all dictionary construction can be
     # done in native Python
     variant_list = ht.collect()
+    ht_freq_index_dict = ht.freq_index_dict.collect()[0]
 
     # Assemble output dicts with VRS and optionally frequency, append to list,
     # then return list
@@ -550,7 +551,7 @@ def gnomad_gks(
                 ancestry_groups=pops_list,
                 ancestry_groups_dict=POP_NAMES,
                 by_sex=by_sex,
-                freq_index_dict=ht.freq_index_dict.collect()[0],
+                freq_index_dict=ht_freq_index_dict,
             )
 
             # Assign existing VRS information to "focusAllele" key

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -452,6 +452,7 @@ def gnomad_gks(
     by_sex: bool = False,
     vrs_only: bool = False,
     custom_ht: hl.Table = None,
+    skip_checkpoint: bool = False,
     skip_coverage: bool = False,
     custom_coverage_ht: hl.Table = None,
 ) -> list:
@@ -467,6 +468,8 @@ def gnomad_gks(
     :param vrs_only: Boolean to pass for only VRS info to be returned
         (will not include allele frequency information).
     :param custom_ht: Table to use instead of what public_release() method would return for the version.
+    :param skip_checkpoint: Bool to pass to skip checkpointing selected columns
+        (checkpointing may be desirable for large datasets by reducing data copies across the cluster).
     :param skip_coverage: Bool to pass to skip adding coverage statistics.
     :param custom_coverage_ht: Custom table to use for coverage statistics instead of the release coverage table.
     :return: List of dictionaries containing VRS information
@@ -522,7 +525,10 @@ def gnomad_gks(
         ht = ht.select(ht.freq, ht.info.vrs, ht.popmax, ht.mean_cov)
     else:
         ht = ht.select(ht.freq, ht.info.vrs, ht.popmax)
-    # ht = ht.checkpoint(hl.utils.new_temp_file("vrs_checkpoint", extension="ht"))
+
+    # Checkpoint narrower set of columns if not skipped.
+    if not skip_checkpoint:
+        ht = ht.checkpoint(hl.utils.new_temp_file("vrs_checkpoint", extension="ht"))
     ht = hl.filter_intervals(ht, [locus_interval])
 
     # Collect all variants as structs, so all dictionary construction can be

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -468,7 +468,7 @@ def gnomad_gks(
     :param vrs_only: Boolean to pass for only VRS info to be returned
         (will not include allele frequency information).
     :param custom_ht: Table to use instead of what public_release() method would return for the version.
-    :param skip_checkpoint: Bool to pass to skip checkpointing selected columns
+    :param skip_checkpoint: Bool to pass to skip checkpointing selected fields
         (checkpointing may be desirable for large datasets by reducing data copies across the cluster).
     :param skip_coverage: Bool to pass to skip adding coverage statistics.
     :param custom_coverage_ht: Custom table to use for coverage statistics instead of the release coverage table.
@@ -500,7 +500,7 @@ def gnomad_gks(
             coverage_ht = hl.read_table(
                 coverage("genomes").versions[coverage_version].path
             )
-        ht = ht.annotate(mean_cov=coverage_ht[ht.locus].mean)
+        ht = ht.annotate(mean_depth=coverage_ht[ht.locus].mean)
 
     # Retrieve ancestry groups from the imported POPS dictionary.
     pops_list = list(POPS[high_level_version]) if by_ancestry_group else None
@@ -521,10 +521,11 @@ def gnomad_gks(
 
     # Select relevant fields, checkpoint, and filter to interval before adding
     # annotations
+    keep_fields = [ht.freq, ht.info.vrs, ht.popmax]
     if not skip_coverage:
-        ht = ht.select(ht.freq, ht.info.vrs, ht.popmax, ht.mean_cov)
-    else:
-        ht = ht.select(ht.freq, ht.info.vrs, ht.popmax)
+        keep_fields.append(ht.mean_cov)
+
+    ht = ht.select(*keep_fields)
 
     # Checkpoint narrower set of columns if not skipped.
     if not skip_checkpoint:

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -523,7 +523,7 @@ def gnomad_gks(
     # annotations
     keep_fields = [ht.freq, ht.info.vrs, ht.popmax]
     if not skip_coverage:
-        keep_fields.append(ht.mean_cov)
+        keep_fields.append(ht.mean_depth)
 
     ht = ht.select(*keep_fields)
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2045,7 +2045,6 @@ def add_gks_va(
     input_struct: hl.struct,
     label_name: str = "gnomAD",
     label_version: str = "3.1.2",
-    coverage_ht: hl.Table = None,
     ancestry_groups: list = None,
     ancestry_groups_dict: dict = None,
     by_sex: bool = False,
@@ -2056,14 +2055,13 @@ def add_gks_va(
 
     Populate the dictionary with frequency information conforming to the GKS VA frequency schema.
     If ancestry_groups or by_sex is provided, also include subcohort schemas for each cohort.
+    If input_struct has mean_cov, it is added to ancillaryResults.
     This annotation is added under the gks_va_freq_dict field of the table.
     The focusAllele field is not populated, and must be filled in by the caller.
 
     :param input_struct: Hail struct for a desired variant (such as result of running .collect()[0] on a Table).
     :param label_name: Label name to use within the returned dictionary. Example: "gnomAD".
     :param label_version: String listing the version of the table being used. Example: "3.1.2".
-    :param coverage_ht: Table containing coverage stats, with mean depth in "mean" annotation.
-        If None, omit coverage in return.
     :param ancestry_groups: List of strings of shortened names of cohorts to return results for.
         Example: ['afr','fin','nfe']. Default is None.
     :param ancestry_groups_dict: Dict mapping shortened genetic ancestry group names to full names.
@@ -2199,11 +2197,9 @@ def add_gks_va(
             "popFreqId": f"{gnomad_id}.{input_struct.popmax.pop.upper()}",
         }
 
-    # Add mean coverage statistics if a coverage Table is provided
-    if coverage_ht is not None:
-        ancillaryResults["meanDepth"] = coverage_ht.filter(
-            coverage_ht.locus == input_struct.locus
-        ).mean.collect()[0]
+    # Add mean coverage statistics if the input was annotated with coverage information
+    if "mean_cov" in input_struct:
+        ancillaryResults["meanDepth"] = input_struct.mean_cov
 
     final_freq_dict["ancillaryResults"] = ancillaryResults
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2055,7 +2055,7 @@ def add_gks_va(
 
     Populate the dictionary with frequency information conforming to the GKS VA frequency schema.
     If ancestry_groups or by_sex is provided, also include subcohort schemas for each cohort.
-    If input_struct has mean_cov, it is added to ancillaryResults.
+    If input_struct has mean_depth, it is added to ancillaryResults.
     This annotation is added under the gks_va_freq_dict field of the table.
     The focusAllele field is not populated, and must be filled in by the caller.
 
@@ -2197,9 +2197,10 @@ def add_gks_va(
             "popFreqId": f"{gnomad_id}.{input_struct.popmax.pop.upper()}",
         }
 
-    # Add mean coverage statistics if the input was annotated with coverage information
-    if "mean_cov" in input_struct:
-        ancillaryResults["meanDepth"] = input_struct.mean_cov
+    # Add mean coverage depth statistics if the input was annotated
+    # with coverage information.
+    if "mean_depth" in input_struct:
+        ancillaryResults["meanDepth"] = input_struct.mean_depth
 
     final_freq_dict["ancillaryResults"] = ancillaryResults
 


### PR DESCRIPTION
- VA freq code needs values from global `ht.freq_index_dict`, but since it's a global and same for every row, it only needs to be read once
- The coverage table only has one row per variant, so it can be joined with the gnomad variant table using a `.join` which is indexed and faster than `.filter`, and makes it so the coverage stats for all the variants in the locus interval can be retrieved in one `.collect` call
- For small-ish tables of tens of thousands of variants or fewer (opposed to millions or more), checkpointing is a significant time overhead to add to what is otherwise relatively fast. So leaving it enabled but having an option to disable it is helpful