### PR TITLE
add function to get max FAF from faf_expr

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -255,7 +255,7 @@ def gen_anc_faf_max_expr(
         `faf_expr` is used, contains fields 'faf95' and 'faf99'.
     :param faf_meta: ArrayExpression of meta dictionaries corresponding to faf (as
         returned by faf_expr)
-    :return: Genetic Ancestry group struct for FAF
+    :return: Genetic ancestry group struct for FAF max
     """
     faf_gen_anc_indices = hl.enumerate(faf_meta).filter(
         lambda i: (hl.set(i[1].keys()) == {"group", "pop"}) & (i[1]["group"] == "adj")
@@ -263,7 +263,7 @@ def gen_anc_faf_max_expr(
     max_fafs_expr = hl.struct()
 
     # Iterate through faf thresholds, generally 'faf95' and 'faf99', and
-    # take the highest faf value, '[0]', and its gen_anc from the sorted faf array
+    # take the maximum faf value, '[0]', and its gen_anc from the sorted faf array
     for threshold in faf[0].keys():
         faf_struct = hl.sorted(
             faf_gen_anc_indices.map(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -262,7 +262,15 @@ def gen_anc_grp_max_faf_exp(
     )
     faf_pop_indices = hl.eval(faf_pop_indices)
 
-    def _calculate_max_faf(faf_expr, indices, faf_item):
+    def _calculate_max_faf(faf_expr, indices, faf_item) -> hl.expr.StructExpression:
+        """
+        Return the max FAF and its genetic ancestry group for the given FAF item (e.g. faf95 or faf99).
+
+        :param faf_expr: ArrayExpression of Structs with fields ['faf95', 'faf99']
+        :param indices: Indices of the populations to consider
+        :param faf_item: FAF item to consider (e.g. faf95 or faf99)
+        :return: Struct containing max FAF and its genetic ancestry group
+        """
         return hl.rbind(
             hl.sorted(
                 hl.array(


### PR DESCRIPTION
Similar to what we do to get a popmax/grpmax from 'freq', we will also get a max on faf95 and faf99 and its corresponding pop from the 'faf' field. 