### PR TITLE
Remove inadvertent tuple in popMaxFAF95 field in add_gks_va function

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2308,9 +2308,9 @@ def add_gks_va(
     }
 
     if input_struct.faf95.popmax_population is not None:
-        ancillaryResults["popMaxFAF95"]["popFreqID"] = (
-            f"{gnomad_id}.{input_struct.faf95.popmax_population.upper()}",
-        )
+        ancillaryResults["popMaxFAF95"][
+            "popFreqID"
+        ] = f"{gnomad_id}.{input_struct.faf95.popmax_population.upper()}"
     else:
         ancillaryResults["popMaxFAF95"]["popFreqID"] = None
 


### PR DESCRIPTION
Currently the `popFreqID` field returned by `add_gks_va` is a tuple instead of a string due to an extra comma. This PR removes the comma, ensuring a string is returned.