### PR TITLE
Move ga4gh imports to their functions

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -7,6 +7,8 @@ import logging
 from timeit import default_timer as timer
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
+import ga4gh.core as ga4gh_core
+import ga4gh.vrs as ga4gh_vrs
 import hail as hl
 from hail.utils.misc import new_temp_file
 
@@ -2050,9 +2052,6 @@ def gks_compute_seqloc_digest(
         which is then imported as a hail table
     :return: a hail table with the VRS annotation updated with the new SequenceLocations
     """
-    import ga4gh.core as ga4gh_core
-    import ga4gh.vrs.models as ga4gh_vrs
-
     if export_tmpfile is None:
         export_tmpfile = new_temp_file("gks-seqloc-pre.tsv")
     if computed_tmpfile is None:
@@ -2124,9 +2123,6 @@ def add_gks_vrs(
     :param input_vrs: VRS struct (such as from a ht.info.vrs field).
     :return: Python dictionary conforming to GA4GH GKS VRS structure.
     """
-    import ga4gh.core as ga4gh_core
-    import ga4gh.vrs.models as ga4gh_vrs
-
     build_in = input_locus.reference_genome.name
     chr_in = input_locus.contig
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2050,6 +2050,8 @@ def gks_compute_seqloc_digest(
         which is then imported as a hail table
     :return: a hail table with the VRS annotation updated with the new SequenceLocations
     """
+    # NOTE: The pinned ga4gh.vrs module breaks logging when this annotations module is
+    # imported. Importing ga4gh here to avoid this issue.
     import ga4gh.core as ga4gh_core
     import ga4gh.vrs.models as ga4gh_vrs
 
@@ -2124,6 +2126,8 @@ def add_gks_vrs(
     :param input_vrs: VRS struct (such as from a ht.info.vrs field).
     :return: Python dictionary conforming to GA4GH GKS VRS structure.
     """
+    # NOTE: The pinned ga4gh.vrs module breaks logging when this annotations module is
+    # imported. Importing ga4gh here to avoid this issue.
     import ga4gh.core as ga4gh_core
     import ga4gh.vrs.models as ga4gh_vrs
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -7,8 +7,6 @@ import logging
 from timeit import default_timer as timer
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
-import ga4gh.core as ga4gh_core
-import ga4gh.vrs as ga4gh_vrs
 import hail as hl
 from hail.utils.misc import new_temp_file
 
@@ -2052,6 +2050,9 @@ def gks_compute_seqloc_digest(
         which is then imported as a hail table
     :return: a hail table with the VRS annotation updated with the new SequenceLocations
     """
+    import ga4gh.core as ga4gh_core
+    import ga4gh.vrs.models as ga4gh_vrs
+
     if export_tmpfile is None:
         export_tmpfile = new_temp_file("gks-seqloc-pre.tsv")
     if computed_tmpfile is None:
@@ -2123,6 +2124,9 @@ def add_gks_vrs(
     :param input_vrs: VRS struct (such as from a ht.info.vrs field).
     :return: Python dictionary conforming to GA4GH GKS VRS structure.
     """
+    import ga4gh.core as ga4gh_core
+    import ga4gh.vrs.models as ga4gh_vrs
+
     build_in = input_locus.reference_genome.name
     chr_in = input_locus.contig
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2053,7 +2053,7 @@ def gks_compute_seqloc_digest(
     # NOTE: The pinned ga4gh.vrs module breaks logging when this annotations module is
     # imported. Importing ga4gh here to avoid this issue.
     import ga4gh.core as ga4gh_core
-    import ga4gh.vrs.models as ga4gh_vrs
+    import ga4gh.vrs as ga4gh_vrs
 
     if export_tmpfile is None:
         export_tmpfile = new_temp_file("gks-seqloc-pre.tsv")
@@ -2129,7 +2129,7 @@ def add_gks_vrs(
     # NOTE: The pinned ga4gh.vrs module breaks logging when this annotations module is
     # imported. Importing ga4gh here to avoid this issue.
     import ga4gh.core as ga4gh_core
-    import ga4gh.vrs.models as ga4gh_vrs
+    import ga4gh.vrs as ga4gh_vrs
 
     build_in = input_locus.reference_genome.name
     chr_in = input_locus.contig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 annoy
-ga4gh.vrs[extras]==0.8.4
+ga4gh.vrs[extras]
 hail
 hdbscan
 ipywidgets

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 annoy
-ga4gh.vrs[extras]
+ga4gh.vrs[extras]==0.8.4
 hail
 hdbscan
 ipywidgets


### PR DESCRIPTION
The VRS module is breaking our loggers. To keep our versions pinned to 0.8.4 and get logging working, we need to move the imports into the functions that use them. This means loggers will only break when using these functions. 

I think what is happening is their init calls logging.BasicConfig without setting a level which will reset the logging level to warning: https://github.com/ga4gh/vrs-python/blob/593508c6e8229336ca1f53a06f69966020cd68f7/src/ga4gh/vrs/__init__.py


I tested this locally and my logging was restored.

It does look like they removed the logging call in later version so another option is to unpin or use another version of vrs in our requirements file.
