### PR TITLE
Add gen_anc to SORT_ORDER

### DIFF
--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -17,7 +17,7 @@ SORT_ORDER = [
     "subset",
     "downsampling",
     "popmax",
-    "pop",
+    "gen_anc",
     "subpop",
     "sex",
     "group",

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -17,6 +17,7 @@ SORT_ORDER = [
     "subset",
     "downsampling",
     "popmax",
+    "pop",
     "gen_anc",
     "subpop",
     "sex",


### PR DESCRIPTION
I got warnings when I tried to use `make_freq_index_dict_from_meta`
```
WARNING (gnomad.utils.release 130): Found unexpected frequency metadata groupings: {'gen_anc'}. 
These groupings are not present in the provided sort_order: ['subset', 'downsampling', 'popmax', 'pop', 
'subpop', 'sex', 'group']. These groupings will not be included in the returned dictionary.
```

Should we make it SORT_ORDER for v3 and v4? And also there are multiple lists of SORT_ORDER in this repo. 