### PR TITLE
Add pprint globals and a global/row length comparison, updates monoallelic expr in validity checks

### DIFF
--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -871,7 +871,7 @@ def compare_related_global_and_row_lengths(
     Compare the lengths of global and row annotations.
 
     :param t: Input MatrixTable or Table.
-    :param len_comp_globals_rows: Dictionary with global annotation (key) and list of row annotations (value) to compare.
+    :param len_comp_globals_rows: Dictionary with row annotation (key) and list of associated global annotations (value) to compare.
     :return: None
     """
     t = t.rows() if isinstance(t, hl.MatrixTable) else t

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -882,11 +882,11 @@ def compare_related_global_and_row_lengths(
             outcome = "Failed" if global_len != row_len else "Passed"
             logger.info(
                 f"%s global and row lengths comparison: Length of %s in"
-                f" globals (%d) does %s match length of %s in rows (%d)",
+                f" globals (%d) does %smatch length of %s in rows (%d)",
                 outcome,
                 global_field,
                 global_len,
-                "NOT" if outcome == "Failed" else "",
+                "NOT " if outcome == "Failed" else "",
                 row_field,
                 row_len,
             )

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -891,6 +891,16 @@ def compare_related_global_and_row_lengths(
             )
 
 
+def pprint_global_anns(t: Union[hl.MatrixTable, hl.Table]) -> None:
+    """
+    Pretty print global annotations.
+
+    :param t: Input MatrixTable or Table.
+    """
+    global_pprint = {g: hl.eval(t[g]) for g in t.globals}
+    pprint(global_pprint, sort_dicts=False)
+
+
 def validate_release_t(
     t: Union[hl.MatrixTable, hl.Table],
     subsets: List[str] = [""],
@@ -918,7 +928,7 @@ def validate_release_t(
     samples_sum_check: bool = True,
     sex_chr_check: bool = True,
     missingness_check: bool = True,
-    pprint_globals: bool = True,
+    pprint_globals: bool = False,
     len_comp_globals_rows: Dict[str, List[str]] = None,
 ) -> None:
     """
@@ -963,8 +973,7 @@ def validate_release_t(
     """
     if pprint_globals:
         logger.info("GLOBALS OF INPUT TABLE:")
-        global_pprint = {g: hl.eval(t[g]) for g in t.globals}
-        pprint(global_pprint, sort_dicts=False)
+        pprint_global_anns(t)
 
     if len_comp_globals_rows is not None:
         logger.info("COMPARE GLOBAL ANNOTATIONS' LENGHTS TO ROW ANOTATIONS:")

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -755,8 +755,10 @@ def compute_missingness(
     t = t.rows() if isinstance(t, hl.MatrixTable) else t
 
     logger.info(
-        "Missingness threshold (upper cutoff for what is allowed for missingness"
-        " checks): %.2f",
+        (
+            "Missingness threshold (upper cutoff for what is allowed for missingness"
+            " checks): %.2f"
+        ),
         missingness_threshold,
     )
     metrics_missing = {}
@@ -863,7 +865,7 @@ def vcf_field_check(
     return True
 
 
-def compare_related_global_and_row_lengths(
+def compare_global_and_row_annot_lengths(
     t: Union[hl.MatrixTable, hl.Table],
     len_comp_globals_rows: Dict[str, List[str]] = None,
 ) -> None:
@@ -882,8 +884,10 @@ def compare_related_global_and_row_lengths(
             global_len = hl.eval(hl.len(t[global_field]))
             outcome = "Failed" if global_len != row_len else "Passed"
             logger.info(
-                "%s global and row lengths comparison: Length of %s in"
-                " globals (%d) does %smatch length of %s in rows (%d)",
+                (
+                    "%s global and row lengths comparison: Length of %s in"
+                    " globals (%d) does %smatch length of %s in rows (%d)"
+                ),
                 outcome,
                 global_field,
                 global_len,
@@ -978,8 +982,8 @@ def validate_release_t(
         pprint_global_anns(t)
 
     if len_comp_globals_rows is not None:
-        logger.info("COMPARE GLOBAL ANNOTATIONS' LENGTHS TO ROW ANNOTATIONS:")
-        compare_related_global_and_row_lengths(t, len_comp_globals_rows)
+        logger.info("COMPARE GLOBAL ANNOTATIONS' LENGHTS TO ROW ANOTATIONS:")
+        compare_global_and_row_annot_lengths(t, len_comp_globals_rows)
 
     if summarize_variants_check:
         logger.info("BASIC SUMMARY OF INPUT TABLE:")
@@ -1119,16 +1123,20 @@ def count_vep_annotated_variants_per_interval(
     )
 
     logger.info(
-        "%s gene(s) have no variants annotated as protein-coding in Biotype. It is"
-        " likely these genes are not covered by the variants in 'vep_ht'. These"
-        " genes are: %s",
+        (
+            "%s gene(s) have no variants annotated as protein-coding in Biotype. It is"
+            " likely these genes are not covered by the variants in 'vep_ht'. These"
+            " genes are: %s"
+        ),
         len(gene_sets.na_genes),
         gene_sets.na_genes,
     )
 
     logger.info(
-        "%s gene(s) have a subset of variants annotated as protein-coding biotype"
-        " in their defined intervals",
+        (
+            "%s gene(s) have a subset of variants annotated as protein-coding biotype"
+            " in their defined intervals"
+        ),
         len(gene_sets.partial_pcg_genes),
     )
 

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -881,8 +881,8 @@ def compare_related_global_and_row_lengths(
             global_len = hl.eval(hl.len(t[global_field]))
             outcome = "Failed" if global_len != row_len else "Passed"
             logger.info(
-                f"%s global and row lengths comparison: Length of %s in"
-                f" globals (%d) does %smatch length of %s in rows (%d)",
+                "%s global and row lengths comparison: Length of %s in"
+                " globals (%d) does %smatch length of %s in rows (%d)",
                 outcome,
                 global_field,
                 global_len,

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -868,10 +868,10 @@ def compare_global_and_row_annot_lengths(
     len_comp_globals_rows: Dict[str, List[str]] = None,
 ) -> None:
     """
-    Compare the lengths of global and row annotations.
+    Check that the lengths of row annotations match the lengths of associated global annotations.
 
     :param t: Input MatrixTable or Table.
-    :param len_comp_globals_rows: Dictionary with row annotation (key) and list of associated global annotations (value) to compare.
+    :param len_comp_globals_rows: Dictionary with row annotation (key) and list of associated global annotations (value) to check for consistent lengths.
     :return: None
     """
     t = t.rows() if isinstance(t, hl.MatrixTable) else t
@@ -978,7 +978,7 @@ def validate_release_t(
         pprint_global_anns(t)
 
     if len_comp_globals_rows is not None:
-        logger.info("COMPARE GLOBAL ANNOTATIONS' LENGHTS TO ROW ANOTATIONS:")
+        logger.info("COMPARE GLOBAL ANNOTATIONS' LENGTHS TO ROW ANNOTATIONS:")
         compare_global_and_row_annot_lengths(t, len_comp_globals_rows)
 
     if summarize_variants_check:

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -254,7 +254,7 @@ def summarize_variant_filters(
     :param variant_filter_field: String of variant filtration used in the filters annotation on `ht` (e.g. RF, VQSR, AS_VQSR). Default is "RF".
     :param problematic_regions: List of regions considered problematic to run filter check in. Default is ["lcr", "segdup", "nonpar"].
     :param single_filter_count: If True, explode the Table's filter column and give a supplement total count of each filter. Default is False.
-    :param monoallelic_expr: When passed, either a single boolean expression or dictionary of strings and boolean expressions to log how many monoallelic sites are in the Table. Default is None.
+    :param monoallelic_expr: Optional boolean expression or dictionary of strings and boolean expressions used to log how many monoallelic sites are in the Table.
     :param extra_filter_checks: Optional dictionary containing filter condition name (key) and extra filter expressions (value) to be examined.
     :param n_rows: Number of rows to display only when showing percentages of filtered variants grouped by multiple conditions. Default is 50.
     :param n_cols: Number of columns to display only when showing percentages of filtered variants grouped by multiple conditions. Default is 140.
@@ -948,7 +948,7 @@ def validate_release_t(
     :param subsets: List of subsets to be checked.
     :param pops: List of pops within main callset.
     :param missingness_threshold: Upper cutoff for allowed amount of missingness. Default is 0.5.
-    :param monoallelic_expr: When passed, either a single boolean expression or dictionary of strings and boolean expressions to log how many monoallelic sites are in the Table. Default is None.
+    :param monoallelic_expr: Optional boolean expression or dictionary of strings and boolean expressions used to log how many monoallelic sites are in `t`.
     :param verbose: If True, display top values of relevant annotations being checked, regardless of whether check conditions are violated; if False, display only top values of relevant annotations if check conditions are violated.
     :param show_percent_sites: Show percentage of sites that fail checks. Default is False.
     :param delimiter: String to use as delimiter when making group label combinations. Default is "-".
@@ -969,7 +969,7 @@ def validate_release_t(
     :param sex_chr_check: When True, runs the check_sex_chr_metricss method. Default is True.
     :param missingness_check: When True, runs the compute_missingness method. Default is True.
     :param pprint_globals: When True, Pretty Print the globals of the input Table. Default is True.
-    :param len_comp_globals_rows: When passed, a dictionary of globals (keys) and rows (values) to check that the length of the global key is equal to the length of the row value. Default is None.
+    :param len_comp_globals_rows: Optional dictionary of globals (keys) and rows (values) to be checked. When passed, function checks that the lengths of the global and row annotations are equal.
     :return: None (stdout display of results from the battery of validity checks).
     """
     if pprint_globals:
@@ -977,7 +977,7 @@ def validate_release_t(
         pprint_global_anns(t)
 
     if len_comp_globals_rows is not None:
-        logger.info("COMPARE GLOBAL ANNOTATIONS' LENGHTS TO ROW ANOTATIONS:")
+        logger.info("COMPARE GLOBAL ANNOTATIONS' LENGTHS TO ROW ANNOTATIONS:")
         compare_related_global_and_row_lengths(t, len_comp_globals_rows)
 
     if summarize_variants_check:

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -882,10 +882,11 @@ def compare_related_global_and_row_lengths(
             outcome = "Failed" if global_len != row_len else "Passed"
             logger.info(
                 f"%s global and row lengths comparison: Length of %s in"
-                f" globals (%d) does not match length of %s in rows (%d)",
+                f" globals (%d) does %s match length of %s in rows (%d)",
                 outcome,
                 global_field,
                 global_len,
+                "NOT" if outcome == "Failed" else "",
                 row_field,
                 row_len,
             )

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -875,8 +875,9 @@ def compare_related_global_and_row_lengths(
     :return: None
     """
     t = t.rows() if isinstance(t, hl.MatrixTable) else t
+    t = t.head(1)
     for row_field, global_fields in len_comp_globals_rows.items():
-        row_len = len(t.head(1)[row_field].collect()[0])
+        row_len = len(t[row_field].collect()[0])
         for global_field in global_fields:
             global_len = hl.eval(hl.len(t[global_field]))
             outcome = "Failed" if global_len != row_len else "Passed"


### PR DESCRIPTION
This adds pprint of globals and a comparison of associated row and global annotation's lengths. It also opens up monoallelic_expr to accept a dictionary so we can also pass `only_het`. The comp naming is horrible, suggestions welcome. 

I added the new checks to the validate_release_t as well though we wont use it as currently implemented for v4 because we don't want to write out the  annotations required for the global and row annotation comp. 