### PR TITLE
Change `get_downsampling_freq_indices` and `downsampling_counts_expr` to support both 'pop' and 'gen_anc' keys in metadata

### DIFF
--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -229,7 +229,7 @@ def count_variants_by_group(
 
 def get_downsampling_freq_indices(
     freq_meta_expr: hl.expr.ArrayExpression,
-    gen_anc: str = "global",
+    pop: str = "global",
     variant_quality: str = "adj",
     genetic_ancestry_label: Optional[str] = None,
     subset: Optional[str] = "None",
@@ -241,7 +241,7 @@ def get_downsampling_freq_indices(
     :param freq_meta_expr: ArrayExpression containing the set of groupings for each
         element of the `freq_expr` array (e.g., [{'group': 'adj'}, {'group': 'adj',
         'pop': 'nfe'}, {'downsampling': '5000', 'group': 'adj', 'pop': 'global'}]).
-    :param gen_anc: Genetic ancestry group to use for filtering by the `genetic_ancestry_label` key in
+    :param pop: Population to use for filtering by the `genetic_ancestry_label` key in
         `freq_meta_expr`. Default is 'global'.
     :param variant_quality: Variant quality to use for filtering by the 'group' key in
         `freq_meta_expr`. Default is 'adj'.
@@ -261,7 +261,7 @@ def get_downsampling_freq_indices(
         gen_anc = [genetic_ancestry_label]
     indices = hl.enumerate(freq_meta_expr).filter(
         lambda f: (f[1].get("group") == variant_quality)
-        & (hl.any([f[1].get(l, "") == gen_anc for l in gen_anc]))
+        & (hl.any([f[1].get(l, "") == pop for l in gen_anc]))
         & f[1].contains("downsampling")
         & hl.literal(downsamplings).contains(hl.int(f[1].get("downsampling", "0")))
         & (f[1].get("subset", "None") == subset)
@@ -273,7 +273,7 @@ def get_downsampling_freq_indices(
 def downsampling_counts_expr(
     freq_expr: hl.expr.ArrayExpression,
     freq_meta_expr: hl.expr.ArrayExpression,
-    gen_anc: str = "global",
+    pop: str = "global",
     variant_quality: str = "adj",
     singleton: bool = False,
     max_af: Optional[float] = None,
@@ -293,7 +293,7 @@ def downsampling_counts_expr(
     :param freq_meta_expr: ArrayExpression containing the set of groupings for each
         element of the `freq_expr` array (e.g., [{'group': 'adj'}, {'group': 'adj',
         'pop': 'nfe'}, {'downsampling': '5000', 'group': 'adj', 'pop': 'global'}]).
-    :param gen_anc: Genetic ancestry group to use for filtering by the `genetic_ancestry_label` key in
+    :param pop: Population to use for filtering by the `genetic_ancestry_label` key in
         `freq_meta_expr`. Default is 'global'.
     :param variant_quality: Variant quality to use for filtering by the 'group' key in
         `freq_meta_expr`. Default is 'adj'.
@@ -313,7 +313,7 @@ def downsampling_counts_expr(
     # Get an array of indices sorted by "downsampling" key.
     sorted_indices = get_downsampling_freq_indices(
         freq_meta_expr,
-        gen_anc,
+        pop,
         variant_quality,
         genetic_ancestry_label,
         subset,
@@ -337,7 +337,7 @@ def downsampling_counts_expr(
 
     # Map `_get_criteria` function to each downsampling indexed by `sorted_indices` to
     # generate a list of 1's and 0's for each variant, where the length of the array is
-    # the total number of downsamplings for the specified genetic ancestry group and each element
+    # the total number of downsamplings for the specified population and each element
     # in the array indicates if the variant in the downsampling indexed by
     # `sorted_indices` meets the specified criteria.
     # Return an array sum aggregation that aggregates arrays generated from mapping.

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -1012,15 +1012,6 @@ def compute_expected_variants(
         intercept = plateau_model[0]
         agg_func = hl.agg.sum
         ann_to_sum = ["observed_variants", "possible_variants"]
-    # If genetic ancestry group is "global", use the overall plateau model,
-    # but sum across array of downsampling counts.
-    elif pop == "global":
-        plateau_model = hl.literal(plateau_models_expr.total)[cpg_expr]
-        slope = plateau_model[1]
-        intercept = plateau_model[0]
-        agg_func = hl.agg.array_sum
-        pop = f"_{pop}"
-        ann_to_sum = [f"downsampling_counts{pop}"]
     else:
         plateau_model = hl.literal(plateau_models_expr[pop])
         slope = hl.map(lambda f: f[cpg_expr][1], plateau_model)

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -205,7 +205,11 @@ def count_variants_by_group(
             pop,
         )
         agg[f"downsampling_counts_{pop}"] = downsampling_counts_expr(
-            freq_expr, freq_meta_expr, pop, max_af=max_af
+            freq_expr,
+            freq_meta_expr,
+            pop,
+            max_af=max_af,
+            downsamplings=DOWNSAMPLINGS["v4"],
         )
         if count_singletons:
             logger.info(
@@ -215,7 +219,12 @@ def count_variants_by_group(
                 pop,
             )
             agg[f"singleton_downsampling_counts_{pop}"] = downsampling_counts_expr(
-                freq_expr, freq_meta_expr, pop, max_af=max_af, singleton=True
+                freq_expr,
+                freq_meta_expr,
+                pop,
+                max_af=max_af,
+                downsamplings=DOWNSAMPLINGS["v4"],
+                singleton=True,
             )
     # Apply each variant count aggregation in `agg` to get counts for all
     # combinations of `grouping`.

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -232,7 +232,7 @@ def get_downsampling_freq_indices(
     pop: str = "global",
     variant_quality: str = "adj",
     genetic_ancestry_label: Optional[str] = None,
-    subset: Optional[str] = "None",
+    subset: Optional[str] = None,
     downsamplings: Optional[List[int]] = None,
 ) -> hl.expr.ArrayExpression:
     """

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -233,7 +233,7 @@ def get_downsampling_freq_indices(
     variant_quality: str = "adj",
     genetic_ancestry_label: Optional[str] = None,
     subset: Optional[str] = "None",
-    downsamplings: list = DOWNSAMPLINGS["v4"],
+    downsamplings: Optional[List[int]] = None,
 ) -> hl.expr.ArrayExpression:
     """
     Get indices of dictionaries in meta dictionaries that only have the "downsampling" key with specified `genetic_ancestry_label` and "variant_quality" values.
@@ -250,7 +250,8 @@ def get_downsampling_freq_indices(
         None.
     :param subset: Subset to use for filtering by the 'subset' key in
         `freq_meta_expr`. Default is "None".
-    :param downsamplings: List of strings specifying what levels of downsamplings to obtain.
+    :param downsamplings: Optional List of integers specifying what downsampling 
+        indices to obtain. Default is None, which will return all downsampling indices.
     :return: ArrayExpression of indices of dictionaries in `freq_meta_expr` that only
         have the "downsampling" key with specified `genetic_ancestry_label` and
         "variant_quality" values.
@@ -278,8 +279,8 @@ def downsampling_counts_expr(
     singleton: bool = False,
     max_af: Optional[float] = None,
     genetic_ancestry_label: Optional[str] = None,
-    subset: Optional[str] = "None",
-    downsamplings: list = DOWNSAMPLINGS["v4"],
+    subset: Optional[str] = None,
+    downsamplings: Optional[List[int]] = None,
 ) -> hl.expr.ArrayExpression:
     """
     Return an aggregation expression to compute an array of counts of all downsamplings found in `freq_expr` where specified criteria is met.

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -1001,7 +1001,8 @@ def compute_expected_variants(
         intercept = plateau_model[0]
         agg_func = hl.agg.sum
         ann_to_sum = ["observed_variants", "possible_variants"]
-    # If genetic ancestry group is "global", use the overall plateau model, but sum across array of downsampling counts.
+    # If genetic ancestry group is "global", use the overall plateau model,
+    # but sum across array of downsampling counts.
     elif pop == "global":
         plateau_model = hl.literal(plateau_models_expr.total)[cpg_expr]
         slope = plateau_model[1]

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import hail as hl
 from hail.utils.misc import divide_null, new_temp_file
 
-from gnomad.resources.grch38.gnomad import DOWNSAMPLINGS
 from gnomad.utils.vep import explode_by_vep_annotation, process_consequences
 
 logging.basicConfig(
@@ -56,6 +55,7 @@ def count_variants_by_group(
     freq_meta_expr: Optional[hl.expr.ArrayExpression] = None,
     count_singletons: bool = False,
     count_downsamplings: Tuple[str] = (),
+    downsamplings: Optional[List[int]] = None,
     additional_grouping: Tuple[str] = (),
     partition_hint: int = 100,
     omit_methylation: bool = False,
@@ -130,6 +130,8 @@ def count_variants_by_group(
         Default is False.
     :param count_downsamplings: Tuple of populations to use for downsampling counts.
         Default is ().
+    :param downsamplings: Optional List of integers specifying what downsampling
+        indices to obtain. Default is None, which will return all downsampling counts.
     :param additional_grouping: Additional features to group by. e.g. 'exome_coverage'.
         Default is ().
     :param partition_hint: Target number of partitions for aggregation. Default is 100.
@@ -209,7 +211,7 @@ def count_variants_by_group(
             freq_meta_expr,
             pop,
             max_af=max_af,
-            downsamplings=DOWNSAMPLINGS["v4"],
+            downsamplings=downsamplings,
         )
         if count_singletons:
             logger.info(
@@ -223,7 +225,7 @@ def count_variants_by_group(
                 freq_meta_expr,
                 pop,
                 max_af=max_af,
-                downsamplings=DOWNSAMPLINGS["v4"],
+                downsamplings=downsamplings,
                 singleton=True,
             )
     # Apply each variant count aggregation in `agg` to get counts for all

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -248,8 +248,9 @@ def get_downsampling_freq_indices(
     :param genetic_ancestry_label: Label defining the genetic ancestry groups. If None,
         "gen_anc" or "pop" is used (in that order of preference) if present. Default is
         None.
-    :param subset: Subset to use for filtering by the 'subset' key in
-        `freq_meta_expr`. Default is "None".
+    :param subset: Subset to use for filtering by the 'subset' key in `freq_meta_expr`.
+        Default is None, which will return all downsampling indices without a 'subset'
+        key in `freq_meta_expr`.
     :param downsamplings: Optional List of integers specifying what downsampling
         indices to obtain. Default is None, which will return all downsampling indices.
     :return: ArrayExpression of indices of dictionaries in `freq_meta_expr` that only

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -250,7 +250,7 @@ def get_downsampling_freq_indices(
         None.
     :param subset: Subset to use for filtering by the 'subset' key in
         `freq_meta_expr`. Default is "None".
-    :param downsamplings: Optional List of integers specifying what downsampling 
+    :param downsamplings: Optional List of integers specifying what downsampling
         indices to obtain. Default is None, which will return all downsampling indices.
     :return: ArrayExpression of indices of dictionaries in `freq_meta_expr` that only
         have the "downsampling" key with specified `genetic_ancestry_label` and
@@ -985,6 +985,14 @@ def compute_expected_variants(
         intercept = plateau_model[0]
         agg_func = hl.agg.sum
         ann_to_sum = ["observed_variants", "possible_variants"]
+    # If genetic ancestry group is "global", use the overall plateau model, but sum across array of downsampling counts.
+    elif pop == "global":
+        plateau_model = hl.literal(plateau_models_expr.total)[cpg_expr]
+        slope = plateau_model[1]
+        intercept = plateau_model[0]
+        agg_func = hl.agg.array_sum
+        pop = f"_{pop}"
+        ann_to_sum = [f"downsampling_counts{pop}"]
     else:
         plateau_model = hl.literal(plateau_models_expr[pop])
         slope = hl.map(lambda f: f[cpg_expr][1], plateau_model)

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -317,9 +317,12 @@ def downsampling_counts_expr(
     :param genetic_ancestry_label: Label defining the genetic ancestry groups. If None,
         "gen_anc" or "pop" is used (in that order of preference) if present. Default is
         None.
-    :param subset: Subset to use for filtering by the 'subset' key in
-        `freq_meta_expr`. Default is "None".
-    :param downsamplings: List of strings specifying what levels of downsamplings to obtain.
+    :param subset: Subset to use for filtering by the 'subset' key in `freq_meta_expr`.
+        Default is None, which will return all downsampling counts without a 'subset'
+        key in `freq_meta_expr`. If specified, only downsamplings with the specified
+        subset will be included.
+    :param downsamplings: Optional List of integers specifying what downsampling
+        indices to obtain. Default is None, which will return all downsampling counts.
     :return: Aggregation Expression for an array of the variant counts in downsamplings
         for specified population.
     """

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -215,7 +215,7 @@ def count_variants_by_group(
                 pop,
             )
             agg[f"singleton_downsampling_counts_{pop}"] = downsampling_counts_expr(
-                freq_expr, freq_meta_expr, pop, singleton=True
+                freq_expr, freq_meta_expr, pop, max_af=max_af, singleton=True
             )
     # Apply each variant count aggregation in `agg` to get counts for all
     # combinations of `grouping`.

--- a/gnomad/utils/constraint.py
+++ b/gnomad/utils/constraint.py
@@ -229,7 +229,7 @@ def count_variants_by_group(
 
 def get_downsampling_freq_indices(
     freq_meta_expr: hl.expr.ArrayExpression,
-    pop: str = "global",
+    gen_anc: str = "global",
     variant_quality: str = "adj",
     genetic_ancestry_label: Optional[str] = None,
     subset: Optional[str] = "None",
@@ -241,7 +241,7 @@ def get_downsampling_freq_indices(
     :param freq_meta_expr: ArrayExpression containing the set of groupings for each
         element of the `freq_expr` array (e.g., [{'group': 'adj'}, {'group': 'adj',
         'pop': 'nfe'}, {'downsampling': '5000', 'group': 'adj', 'pop': 'global'}]).
-    :param pop: Population to use for filtering by the `genetic_ancestry_label` key in
+    :param gen_anc: Genetic ancestry group to use for filtering by the `genetic_ancestry_label` key in
         `freq_meta_expr`. Default is 'global'.
     :param variant_quality: Variant quality to use for filtering by the 'group' key in
         `freq_meta_expr`. Default is 'adj'.
@@ -261,7 +261,7 @@ def get_downsampling_freq_indices(
         gen_anc = [genetic_ancestry_label]
     indices = hl.enumerate(freq_meta_expr).filter(
         lambda f: (f[1].get("group") == variant_quality)
-        & (hl.any([f[1].get(l, "") == pop for l in gen_anc]))
+        & (hl.any([f[1].get(l, "") == gen_anc for l in gen_anc]))
         & f[1].contains("downsampling")
         & hl.literal(downsamplings).contains(hl.int(f[1].get("downsampling", "0")))
         & (f[1].get("subset", "None") == subset)
@@ -273,7 +273,7 @@ def get_downsampling_freq_indices(
 def downsampling_counts_expr(
     freq_expr: hl.expr.ArrayExpression,
     freq_meta_expr: hl.expr.ArrayExpression,
-    pop: str = "global",
+    gen_anc: str = "global",
     variant_quality: str = "adj",
     singleton: bool = False,
     max_af: Optional[float] = None,
@@ -293,7 +293,7 @@ def downsampling_counts_expr(
     :param freq_meta_expr: ArrayExpression containing the set of groupings for each
         element of the `freq_expr` array (e.g., [{'group': 'adj'}, {'group': 'adj',
         'pop': 'nfe'}, {'downsampling': '5000', 'group': 'adj', 'pop': 'global'}]).
-    :param pop: Population to use for filtering by the `genetic_ancestry_label` key in
+    :param gen_anc: Genetic ancestry group to use for filtering by the `genetic_ancestry_label` key in
         `freq_meta_expr`. Default is 'global'.
     :param variant_quality: Variant quality to use for filtering by the 'group' key in
         `freq_meta_expr`. Default is 'adj'.
@@ -313,7 +313,7 @@ def downsampling_counts_expr(
     # Get an array of indices sorted by "downsampling" key.
     sorted_indices = get_downsampling_freq_indices(
         freq_meta_expr,
-        pop,
+        gen_anc,
         variant_quality,
         genetic_ancestry_label,
         subset,
@@ -337,7 +337,7 @@ def downsampling_counts_expr(
 
     # Map `_get_criteria` function to each downsampling indexed by `sorted_indices` to
     # generate a list of 1's and 0's for each variant, where the length of the array is
-    # the total number of downsamplings for the specified population and each element
+    # the total number of downsamplings for the specified genetic ancestry group and each element
     # in the array indicates if the variant in the downsampling indexed by
     # `sorted_indices` meets the specified criteria.
     # Return an array sum aggregation that aggregates arrays generated from mapping.


### PR DESCRIPTION
Needed for some plots I am creating that use these two functions on the v4 data