### PR TITLE
v4 VCF export updates

### DIFF
--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -1329,7 +1329,7 @@ def build_vcf_export_reference(
         ],
     }
     if keep_chrM:
-        ref_args["contigs"].append("chrM")
+        ref_args["contigs"].append("M")
         ref_args.update({"mt_contigs": ref.mt_contigs})
 
     export_reference = hl.ReferenceGenome(**ref_args)

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -274,6 +274,12 @@ INFO_DICT = {
             " cohort)"
         )
     },
+    "sibling_singleton": {
+        "Description": (
+            "Variant was a callset-wide doubleton that was present only in two siblings"
+            " (i.e., a singleton amongst unrelated samples in cohort)."
+        )
+    },
     "original_alleles": {"Description": "Alleles before splitting multiallelics"},
     "variant_type": {
         "Description": "Variant type (snv, indel, multi-snv, multi-indel, or mixed)"

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -878,7 +878,7 @@ def make_info_dict(
             },
         }
         info_dict.update(popmax_dict)
-    elif grpmax:
+    if grpmax:
         grpmax_dict = {
             f"{prefix}grpmax{suffix}": {
                 "Number": "A",
@@ -925,6 +925,7 @@ def make_info_dict(
             },
         }
         info_dict.update(grpmax_dict)
+
     if fafmax:
         fafmax_dict = {
             f"{prefix}fafmax{label_delimiter}faf95{label_delimiter}max{suffix}": {

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -956,6 +956,19 @@ def make_info_dict(
                 ),
             },
         }
+        if prefix == "joint" or suffix == "joint":
+            fafmax_dict.update(
+                {
+                    f"{prefix}fafmax{label_delimiter}data_type{suffix}": {
+                        "Number": "A",
+                        "Description": (
+                            "Data type with maximum filtering allele frequency"
+                            f" {description_text}"
+                        ),
+                    },
+                }
+            )
+
         info_dict.update(fafmax_dict)
 
     if callstats or faf:

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -1329,7 +1329,7 @@ def build_vcf_export_reference(
         ],
     }
     if keep_chrM:
-        ref_args["keep_contigs"].append("chrM")
+        ref_args["contigs"].append("chrM")
         ref_args.update({"mt_contigs": ref.mt_contigs})
 
     export_reference = hl.ReferenceGenome(**ref_args)

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -1316,21 +1316,25 @@ def build_vcf_export_reference(
     :return: Reference genome for VCF export containing only contigs in `keep_contigs`.
     """
     ref = hl.get_reference(build)
+    ref_args = {}
 
-    ref_args = {
-        "name": name,
-        "contigs": keep_contigs,
-        "lengths": {contig: ref.lengths[contig] for contig in keep_contigs},
-        "x_contigs": ref.x_contigs,
-        "y_contigs": ref.y_contigs,
-        "par": [
-            (interval.start.contig, interval.start.position, interval.end.position)
-            for interval in ref.par
-        ],
-    }
     if keep_chrM:
-        ref_args["contigs"].append("M")
+        keep_contigs.extend(ref.mt_contigs)
         ref_args.update({"mt_contigs": ref.mt_contigs})
+
+    ref_args.update(
+        {
+            "name": name,
+            "contigs": keep_contigs,
+            "lengths": {contig: ref.lengths[contig] for contig in keep_contigs},
+            "x_contigs": ref.x_contigs,
+            "y_contigs": ref.y_contigs,
+            "par": [
+                (interval.start.contig, interval.start.position, interval.end.position)
+                for interval in ref.par
+            ],
+        }
+    )
 
     export_reference = hl.ReferenceGenome(**ref_args)
 

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -245,7 +245,7 @@ INFO_DICT = {
         "Description": "Variant falls outside of UK Biobank exome capture regions."
     },
     "outside_broad_capture_region": {
-        "Variant falls outside of Broad exome capture regions."
+        "Description": "Variant falls outside of Broad exome capture regions."
     },
     "rf_positive_label": {
         "Description": (
@@ -346,7 +346,7 @@ IN_SILICO_ANNOTATIONS_INFO_DICT = {
     "revel_max": {
         "Number": "1",
         "Description": (
-            "The maximum dbNSFP's Revel score at a site's Mane SELECT or canonical"
+            "The maximum dbNSFP's Revel score at a site's MANE Select or canonical"
             " transcript. Scores ranges from 0 to 1. Variants with higher scores are"
             " predicted to be more likely to be deleterious."
         ),
@@ -769,7 +769,6 @@ def make_info_dict(
     :param popmax: If True, use alternate logic to auto-populate dictionary values associated with popmax annotations.
     :param grpmax: If True, use alternate logic to auto-populate dictionary values associated with grpmax annotations.
     :param fafmax: If True, use alternate logic to auto-populate dictionary values associated with fafmax annotations.
-    :param combined_fields: If True, use alternate logic to auto-populate dictionary values associated with combined annotations.
     :param description_text: Optional text to append to the end of descriptions. Needs to start with a space if specified.
     :param str age_hist_data: Pipe-delimited string of age histograms, from `get_age_distributions`.
     :param sort_order: List containing order to sort label group combinations. Default is SORT_ORDER.

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -732,6 +732,7 @@ def create_label_groups(
 
 def make_info_dict(
     prefix: str = "",
+    suffix: str = "",
     prefix_before_metric: bool = True,
     pop_names: Dict[str, str] = POP_NAMES,
     label_groups: Dict[str, List[str]] = None,
@@ -757,6 +758,7 @@ def make_info_dict(
         - INFO fields for filtering allele frequency (faf) annotations
 
     :param prefix: Prefix string for data, e.g. "gnomAD". Default is empty string.
+    :param suffix: Suffix string for data, e.g. "gnomAD". Default is empty string.
     :param prefix_before_metric: Whether prefix should be added before the metric (AC, AN, AF, nhomalt, faf95, faf99) in INFO field. Default is True.
     :param pop_names: Dict with global population names (keys) and population descriptions (values). Default is POP_NAMES.
     :param label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
@@ -767,7 +769,7 @@ def make_info_dict(
     :param popmax: If True, use alternate logic to auto-populate dictionary values associated with popmax annotations.
     :param grpmax: If True, use alternate logic to auto-populate dictionary values associated with grpmax annotations.
     :param fafmax: If True, use alternate logic to auto-populate dictionary values associated with fafmax annotations.
-    :param combined_fields: If True, use alternate logic to auto-populate dictionary values associated with combined annotations. #TODO: Implement this
+    :param combined_fields: If True, use alternate logic to auto-populate dictionary values associated with combined annotations.
     :param description_text: Optional text to append to the end of descriptions. Needs to start with a space if specified.
     :param str age_hist_data: Pipe-delimited string of age histograms, from `get_age_distributions`.
     :param sort_order: List containing order to sort label group combinations. Default is SORT_ORDER.
@@ -775,12 +777,14 @@ def make_info_dict(
     """
     if prefix != "":
         prefix = f"{prefix}{label_delimiter}"
+    if suffix != "":
+        suffix = f"{label_delimiter}{suffix}"
 
     info_dict = dict()
 
     if age_hist_data:
         age_hist_dict = {
-            f"{prefix}age_hist_het_bin_freq": {
+            f"{prefix}age_hist_het_bin_freq{suffix}": {
                 "Number": "A",
                 "Description": (
                     f"Histogram of ages of heterozygous individuals{description_text};"
@@ -788,21 +792,21 @@ def make_info_dict(
                     f" of any genotype bin: {age_hist_data}"
                 ),
             },
-            f"{prefix}age_hist_het_n_smaller": {
+            f"{prefix}age_hist_het_n_smaller{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Count of age values falling below lowest histogram bin edge for"
                     f" heterozygous individuals{description_text}"
                 ),
             },
-            f"{prefix}age_hist_het_n_larger": {
+            f"{prefix}age_hist_het_n_larger{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Count of age values falling above highest histogram bin edge for"
                     f" heterozygous individuals{description_text}"
                 ),
             },
-            f"{prefix}age_hist_hom_bin_freq": {
+            f"{prefix}age_hist_hom_bin_freq{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Histogram of ages of homozygous alternate"
@@ -811,14 +815,14 @@ def make_info_dict(
                     f" bin: {age_hist_data}"
                 ),
             },
-            f"{prefix}age_hist_hom_n_smaller": {
+            f"{prefix}age_hist_hom_n_smaller{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Count of age values falling below lowest histogram bin edge for"
                     f" homozygous alternate individuals{description_text}"
                 ),
             },
-            f"{prefix}age_hist_hom_n_larger": {
+            f"{prefix}age_hist_hom_n_larger{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Count of age values falling above highest histogram bin edge for"
@@ -830,40 +834,40 @@ def make_info_dict(
 
     if popmax:
         popmax_dict = {
-            f"{prefix}popmax": {
+            f"{prefix}popmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     f"Population with the maximum allele frequency{description_text}"
                 ),
             },
-            f"{prefix}AC{label_delimiter}popmax": {
+            f"{prefix}AC{label_delimiter}popmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Allele count in the population with the maximum allele"
                     f" frequency{description_text}"
                 ),
             },
-            f"{prefix}AN{label_delimiter}popmax": {
+            f"{prefix}AN{label_delimiter}popmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Total number of alleles in the population with the maximum allele"
                     f" frequency{description_text}"
                 ),
             },
-            f"{prefix}AF{label_delimiter}popmax": {
+            f"{prefix}AF{label_delimiter}popmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     f"Maximum allele frequency across populations{description_text}"
                 ),
             },
-            f"{prefix}nhomalt{label_delimiter}popmax": {
+            f"{prefix}nhomalt{label_delimiter}popmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Count of homozygous individuals in the population with the"
                     f" maximum allele frequency{description_text}"
                 ),
             },
-            f"{prefix}faf95{label_delimiter}popmax": {
+            f"{prefix}faf95{label_delimiter}popmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Filtering allele frequency (using Poisson 95% CI) for the"
@@ -872,44 +876,44 @@ def make_info_dict(
             },
         }
         info_dict.update(popmax_dict)
-    if grpmax:
+    elif grpmax:
         grpmax_dict = {
-            f"{prefix}grpmax": {
+            f"{prefix}grpmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Genetic ancestry group with the maximum allele"
                     f" frequency{description_text}"
                 ),
             },
-            f"{prefix}AC{label_delimiter}grpmax": {
+            f"{prefix}AC{label_delimiter}grpmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Allele count in the genetic ancestry group with the maximum allele"
                     f" frequency{description_text}"
                 ),
             },
-            f"{prefix}AN{label_delimiter}grpmax": {
+            f"{prefix}AN{label_delimiter}grpmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Total number of alleles in the genetic ancestry group with the"
                     f" maximum allele frequency{description_text}"
                 ),
             },
-            f"{prefix}AF{label_delimiter}grpmax": {
+            f"{prefix}AF{label_delimiter}grpmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Maximum allele frequency across genetic ancestry"
                     f" groups{description_text}"
                 ),
             },
-            f"{prefix}nhomalt{label_delimiter}grpmax": {
+            f"{prefix}nhomalt{label_delimiter}grpmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Count of homozygous individuals in the genetic ancestry group"
                     f" with the maximum allele frequency{description_text}"
                 ),
             },
-            f"{prefix}faf95{label_delimiter}grpmax": {
+            f"{prefix}faf95{label_delimiter}grpmax{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Filtering allele frequency (using Poisson 95% CI) for the genetic"
@@ -919,30 +923,30 @@ def make_info_dict(
             },
         }
         info_dict.update(grpmax_dict)
-    if fafmax:
+    elif fafmax:
         fafmax_dict = {
-            f"{prefix}fafmax{label_delimiter}faf95{label_delimiter}max": {
+            f"{prefix}fafmax{label_delimiter}faf95{label_delimiter}max{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Maximum filtering allele frequency (using Poisson 95% CI)"
                     f" across genetic_ancestry groups{description_text}"
                 ),
             },
-            f"{prefix}fafmax{label_delimiter}faf95{label_delimiter}max{label_delimiter}gen{label_delimiter}anc": {
+            f"{prefix}fafmax{label_delimiter}faf95{label_delimiter}max{label_delimiter}gen{label_delimiter}anc{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Genetic ancestry group with maximum filtering allele"
                     f" frequency (using Poisson 95% CI){description_text}"
                 ),
             },
-            f"{prefix}fafmax{label_delimiter}faf99{label_delimiter}max": {
+            f"{prefix}fafmax{label_delimiter}faf99{label_delimiter}max{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Maximum filtering allele frequency (using Poisson 99% CI)"
                     f" across genetic_ancestry groups{description_text}"
                 ),
             },
-            f"{prefix}fafmax{label_delimiter}faf99{label_delimiter}max{label_delimiter}gen{label_delimiter}anc": {
+            f"{prefix}fafmax{label_delimiter}faf99{label_delimiter}max{label_delimiter}gen{label_delimiter}anc{suffix}": {
                 "Number": "A",
                 "Description": (
                     "Genetic ancestry group with maximum filtering allele"
@@ -966,12 +970,12 @@ def make_info_dict(
             metrics = ["AC", "AN", "AF", "nhomalt", "faf95", "faf99"]
             if prefix_before_metric:
                 metric_label_dict = {
-                    metric: f"{prefix}{metric}{label_delimiter}{combo}"
+                    metric: f"{prefix}{metric}{label_delimiter}{combo}{suffix}"
                     for metric in metrics
                 }
             else:
                 metric_label_dict = {
-                    metric: f"{metric}{label_delimiter}{prefix}{combo}"
+                    metric: f"{metric}{label_delimiter}{prefix}{combo}{suffix}"
                     for metric in metrics
                 }
 

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -952,7 +952,7 @@ def make_info_dict(
         if prefix == "joint_" or suffix == "_joint":
             fafmax_dict.update(
                 {
-                    f"{prefix}fafmax{label_delimiter}data_type{suffix}": {
+                    f"{prefix}fafmax{label_delimiter}data{label_delimiter}type{suffix}": {
                         "Number": "A",
                         "Description": (
                             "Data type with maximum filtering allele frequency"

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -347,7 +347,7 @@ IN_SILICO_ANNOTATIONS_INFO_DICT = {
         "Number": "1",
         "Description": (
             "The maximum REVEL score at a site's MANE Select or canonical"
-            " transcript.It's an ensemble score for predicting the pathogenicity of"
+            " transcript. It's an ensemble score for predicting the pathogenicity of"
             " missense variants (based on 13 other variant predictors). Scores ranges"
             " from 0 to 1. Variants with higher scores are predicted to be more likely"
             " to be deleterious."

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -319,6 +319,16 @@ INFO_DICT = {
             "Allele-specific forward/reverse read counts for strand bias tests"
         ),
     },
+    "SB": {
+        "Number": "4",
+        "Description": (
+            "Aggregate counts of strand depth across all non-reference sites. The"
+            " values are the of the depth of reference allele on forward strand, depth"
+            " of the reference allele on reverse strand,  depth of all alternate"
+            " alleles on forward strand, depth of all alternate alleles on reverse"
+            " strand."
+        ),
+    },
 }
 """
 Dictionary used during VCF export to export row (variant) annotations.

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -483,8 +483,8 @@ def adjust_vcf_incompatible_types(
     for f, ft in ht.info.dtype.items():
         if ft == hl.dtype("int64"):
             logger.warning(
-                "Coercing field info.%s from int64 to int32 for VCF output. Value will"
-                " be capped at int32 max value.",
+                "Coercing field info.%s from int64 to int32 for VCF output. Value"
+                " will be capped at int32 max value.",
                 f,
             )
             info_type_convert_expr.update(
@@ -996,7 +996,10 @@ def make_hist_bin_edges_expr(
                 f"{prefix}{call_type}": "|".join(
                     map(
                         lambda x: f"{x:.1f}",
-                        ht.head(1)[f"age_hist_{call_type}"].collect()[0].bin_edges,
+                        ht.head(1)
+                        .histograms.age_hists[f"age_hist_{call_type}"]
+                        .collect()[0]
+                        .bin_edges,
                     )
                 )
                 for call_type in ["het", "hom"]
@@ -1013,7 +1016,7 @@ def make_hist_bin_edges_expr(
             edges_dict[hist_name] = "|".join(
                 map(
                     lambda x: f"{x:.2f}" if "ab" in hist else str(int(x)),
-                    ht.head(1)[hist_type][hist].collect()[0].bin_edges,
+                    ht.head(1).histograms[hist_type][hist].collect()[0].bin_edges,
                 )
             )
 

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -915,14 +915,6 @@ def make_info_dict(
                     f" with the maximum allele frequency{description_text}"
                 ),
             },
-            f"{prefix}faf95{label_delimiter}grpmax{suffix}": {
-                "Number": "A",
-                "Description": (
-                    "Filtering allele frequency (using Poisson 95% CI) for the genetic"
-                    " ancestry group with the maximum allele"
-                    f" frequency{description_text}"
-                ),
-            },
         }
         info_dict.update(grpmax_dict)
 

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -346,11 +346,11 @@ IN_SILICO_ANNOTATIONS_INFO_DICT = {
     "revel_max": {
         "Number": "1",
         "Description": (
-            "The maximum REVEL score at a site's MANE Select or canonical transcript."
-             "It's an ensemble score for predicting the pathogenicity of missense "
-             "variants (based on 13 other variant predictors). Scores ranges from 0 to 1. "
-             "Variants with higher scores are predicted to be more likely to be "
-             "deleterious."
+            "The maximum REVEL score at a site's MANE Select or canonical"
+            " transcript.It's an ensemble score for predicting the pathogenicity of"
+            " missense variants (based on 13 other variant predictors). Scores ranges"
+            " from 0 to 1. Variants with higher scores are predicted to be more likely"
+            " to be deleterious."
         ),
     },
     "spliceai_ds_max": {
@@ -744,6 +744,7 @@ def make_info_dict(
     popmax: bool = False,
     grpmax: bool = False,
     fafmax: bool = False,
+    callstats: bool = False,
     description_text: str = "",
     age_hist_data: str = None,
     sort_order: List[str] = SORT_ORDER,
@@ -924,7 +925,7 @@ def make_info_dict(
             },
         }
         info_dict.update(grpmax_dict)
-    elif fafmax:
+    if fafmax:
         fafmax_dict = {
             f"{prefix}fafmax{label_delimiter}faf95{label_delimiter}max{suffix}": {
                 "Number": "A",
@@ -957,7 +958,7 @@ def make_info_dict(
         }
         info_dict.update(fafmax_dict)
 
-    else:
+    if callstats or faf:
         group_types = sorted(label_groups.keys(), key=lambda x: sort_order.index(x))
         combos = make_label_combos(label_groups, label_delimiter=label_delimiter)
 

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -746,7 +746,7 @@ def make_info_dict(
     fafmax: bool = False,
     callstats: bool = False,
     description_text: str = "",
-    age_hist_data: str = None,
+    age_hist_distribution: str = None,
     sort_order: List[str] = SORT_ORDER,
 ) -> Dict[str, Dict[str, str]]:
     """
@@ -773,7 +773,7 @@ def make_info_dict(
     :param grpmax: If True, use alternate logic to auto-populate dictionary values associated with grpmax annotations.
     :param fafmax: If True, use alternate logic to auto-populate dictionary values associated with fafmax annotations.
     :param description_text: Optional text to append to the end of descriptions. Needs to start with a space if specified.
-    :param str age_hist_data: Pipe-delimited string of age histograms, from `get_age_distributions`.
+    :param str age_hist_distribution: Pipe-delimited string of overall age distribution.
     :param sort_order: List containing order to sort label group combinations. Default is SORT_ORDER.
     :return: Dictionary keyed by VCF INFO annotations, where values are dictionaries of Number and Description attributes.
     """
@@ -784,14 +784,14 @@ def make_info_dict(
 
     info_dict = dict()
 
-    if age_hist_data:
+    if age_hist_distribution:
         age_hist_dict = {
             f"{prefix}age_hist_het_bin_freq{suffix}": {
                 "Number": "A",
                 "Description": (
                     f"Histogram of ages of heterozygous individuals{description_text};"
                     f" bin edges are: {bin_edges['het']}; total number of individuals"
-                    f" of any genotype bin: {age_hist_data}"
+                    f" of any genotype bin: {age_hist_distribution}"
                 ),
             },
             f"{prefix}age_hist_het_n_smaller{suffix}": {
@@ -814,7 +814,7 @@ def make_info_dict(
                     "Histogram of ages of homozygous alternate"
                     f" individuals{description_text}; bin edges are:"
                     f" {bin_edges['hom']}; total number of individuals of any genotype"
-                    f" bin: {age_hist_data}"
+                    f" bin: {age_hist_distribution}"
                 ),
             },
             f"{prefix}age_hist_hom_n_smaller{suffix}": {

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -1232,7 +1232,7 @@ def make_hist_dict(
             },
         }
         # These annotations are frequently zero and are dropped from gnomad
-        # releases for most histograms
+        # releases for most histograms.
         if not drop_n_smaller_larger:
             hist_dict.update(
                 {
@@ -1252,7 +1252,7 @@ def make_hist_dict(
                     },
                 }
             )
-        # Only add n_larger for dp qual histograms
+        # Only add n_larger for dp qual histograms.
         if "dp" in hist:
             hist_dict.update(
                 {

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -319,16 +319,6 @@ INFO_DICT = {
             "Allele-specific forward/reverse read counts for strand bias tests"
         ),
     },
-    "SB": {
-        "Number": "4",
-        "Description": (
-            "Aggregate counts of strand depth across all non-reference sites. The"
-            " values are the of the depth of reference allele on forward strand, depth"
-            " of the reference allele on reverse strand,  depth of all alternate"
-            " alleles on forward strand, depth of all alternate alleles on reverse"
-            " strand."
-        ),
-    },
 }
 """
 Dictionary used during VCF export to export row (variant) annotations.

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -237,7 +237,7 @@ INFO_DICT = {
     "fail_interval_qc": {
         "Description": (
             "Less than 85 percent of samples meet 20X coverage if variant is in"
-            " autosomal or PAR region or 10X coverage for non-PAR regions of"
+            " autosomal or PAR regions or 10X coverage for non-PAR regions of"
             " chromosomes X and Y."
         )
     },
@@ -346,9 +346,11 @@ IN_SILICO_ANNOTATIONS_INFO_DICT = {
     "revel_max": {
         "Number": "1",
         "Description": (
-            "The maximum dbNSFP's Revel score at a site's MANE Select or canonical"
-            " transcript. Scores ranges from 0 to 1. Variants with higher scores are"
-            " predicted to be more likely to be deleterious."
+            "The maximum REVEL score at a site's MANE Select or canonical transcript."
+             "It's an ensemble score for predicting the pathogenicity of missense "
+             "variants (based on 13 other variant predictors). Scores ranges from 0 to 1. "
+             "Variants with higher scores are predicted to be more likely to be "
+             "deleterious."
         ),
     },
     "spliceai_ds_max": {

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -957,7 +957,7 @@ def make_info_dict(
                 ),
             },
         }
-        if prefix == "joint" or suffix == "joint":
+        if prefix == "joint_" or suffix == "_joint":
             fafmax_dict.update(
                 {
                     f"{prefix}fafmax{label_delimiter}data_type{suffix}": {


### PR DESCRIPTION
This adds v4 export functionality through a number of fields like `inbreeding_coeff`, new annotations like `grpmax` and `fafmax`, and a `suffix` arg to the info dictionary construction. I tried my best to avoid any breaking change here but the histogram access is one. This is a minor function IMO so I think it is alright and  have assign eda change log ignore label.
