### PR TITLE
VRS_States header number from R to .

### DIFF
--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -426,7 +426,7 @@ VRS_FIELDS_DICT = {
         ),
     },
     "VRS_States": {
-        "Number": "R",
+        "Number": ".",
         "Description": (
             "The literal sequence states used for the GA4GH VRS Alleles corresponding"
             " to the values in the REF and ALT fields"


### PR DESCRIPTION
VCFtools vcf-validator is flagging the VRS_States field. Given the "R", in the header, it expects two entries per field, one for reference, one for alternate. 
```
INFO field at chr1:55064734 .. INFO tag [VRS_States=CA,] expected different number of values (expected 2, found 1)
```
In the release HT, this annotation is ["CA",""] but in the VCF, the empty string is not considered a value. Changing the VCF header to be Number="." allows the number of entries to be variable and pass the vcf-validator.

VCF 4.3 specs
```
• A: The field has one value per alternate allele. The values must be in the same order as listed in the ALT
column (described in section 1.6).
• R: The field has one value for each possible allele, including the reference. The order of the values must be the
reference allele first, then the alternate alleles as listed in the ALT column.
• G: The field has one value for each possible genotype. The values must be in the same order as prescribed in
section 1.6.2 (see Genotype Ordering).
• . (dot): The number of possible values varies, is unknown or unbounded.
```
