### PR TITLE
Add RSEM summary function 

### DIFF
--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -18,10 +18,8 @@ def summarize_rsem_mt(
     function to use to summarize the expression by tissue. By default, the median is
     used.
 
-    .. note::
-
-        The output can be returned in one of the following formats (both keyed by
-        "transcript_id" and "gene_id"):
+    The output can be returned in one of the following formats (both keyed by
+    "transcript_id" and "gene_id"):
 
         - A Table with an 'rsem' field containing an array of summarized expression
           values by tissue, where the order of tissues in the array is indicated by

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -14,7 +14,9 @@ logger.setLevel(logging.INFO)
 
 def summarize_transcript_expression(
     mt: hl.MatrixTable,
-    transcript_expression_expr: Union[hl.expr.NumericExpression, str] = "x",
+    transcript_expression_expr: Union[
+        hl.expr.NumericExpression, str
+    ] = "transcript_tpm",
     tissue_expr: Union[hl.expr.StringExpression, str] = "tissue",
     summary_agg_func: Optional[Callable] = None,
 ) -> Tuple[hl.Table, hl.Table]:
@@ -30,9 +32,9 @@ def summarize_transcript_expression(
 
     :param mt: MatrixTable of transcript (rows) expression quantifications (entry) by
         sample (columns).
-    :param tissue_expr: Column expression indicating tissue type. Default is 'tissue'.
     :param transcript_expression_expr: Entry expression indicating transcript expression
-        quantification. Default is 'x'.
+        quantification. Default is 'transcript_tpm'.
+    :param tissue_expr: Column expression indicating tissue type. Default is 'tissue'.
     :param summary_agg_func: Optional aggregation function to use to summarize the
         transcript expression quantification by tissue. Example: `hl.agg.mean`. Default
         is None, which will use a median aggregation.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -43,7 +43,7 @@ def summarize_rsem_mt(
     )
 
     if tissue_as_row:
-        rsem_ht = rsem_mt.rename("rsem", "").make_table()
+        rsem_ht = rsem_mt.rename({"rsem": ""}).make_table()
     else:
         rsem_ht = rsem_mt.localize_entries(
             columns_array_field_name="tissues", entries_array_field_name="rsem"

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -18,13 +18,15 @@ def summarize_rsem_mt(
     function to use to summarize the expression by tissue. By default, the median is
     used.
 
-    The output can be returned in one of the following formats (both keyed by
-    "transcript_id" and "gene_id"):
-      - A Table with an 'rsem' field containing an array of summarized expression
-        values by tissue, where the order of tissues in the array is indicated by the
-        "tissues" global annotation (`tissue_as_row` set to False).
-      - A Table with a row annotation for each tissue containing the summarized tissue
-        expression value (`tissue_as_row` set to True).
+    .. note::
+
+        The output can be returned in one of the following formats (both keyed by
+        "transcript_id" and "gene_id"):
+            - A Table with an 'rsem' field containing an array of summarized expression
+              values by tissue, where the order of tissues in the array is indicated by
+              the "tissues" global annotation (`tissue_as_row` set to False).
+            - A Table with a row annotation for each tissue containing the summarized
+              tissue expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -1,57 +1,92 @@
 """Utils module containing generic functions that are useful for adding transcript expression-aware annotations."""
-from typing import Callable, Optional
+import logging
+from typing import Callable, List, Optional, Tuple, Union
 
 import hail as hl
 
+logging.basicConfig(
+    format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+logger = logging.getLogger("transcript_annotation_utils")
+logger.setLevel(logging.INFO)
 
-def summarize_rsem_mt(
-    rsem_mt: hl.MatrixTable,
-    rsem_expr: hl.expr.NumericExpression,
-    tissue_expr: hl.expr.StringExpression,
+
+def summarize_transcript_expression(
+    mt: hl.MatrixTable,
+    transcript_expression_expr: Union[hl.expr.NumericExpression, str] = "x",
+    tissue_expr: Union[hl.expr.StringExpression, str] = "tissue",
     summary_agg_func: Optional[Callable] = None,
-    tissue_as_row: bool = False,
-) -> hl.Table:
+) -> Tuple[hl.Table, hl.Table]:
     """
-    Summarize an RSEM table with ENSTs and ENSGs as rows and samples as columns by tissue.
+    Summarize a transcript expression MatrixTable by transcript, gene, and tissue.
 
     The `summary_agg_func` argument allows the user to specify a Hail aggregation
     function to use to summarize the expression by tissue. By default, the median is
     used.
 
-    The output can be returned in one of the following formats (both keyed by
-    "transcript_id" and "gene_id"):
+    The returned Table has a row annotation for each tissue containing the summarized
+    tissue expression value.
 
-        - A Table with an 'rsem' field containing an array of summarized expression
-          values by tissue, where the order of tissues in the array is indicated by
-          the "tissues" global annotation (`tissue_as_row` set to False).
-        - A Table with a row annotation for each tissue containing the summarized
-          tissue expression value (`tissue_as_row` set to True).
-
-    :param rsem_mt: MatrixTable of RSEM quantifications.
-    :param tissue_expr: Column expression indicating tissue type.
-    :param rsem_expr: Entry expression indicating RSEM quantification.
-    :param summary_agg_func: Optional aggregation function to use to summarize the RSEM
-        values by tissue. Default is None, which will use a median aggregation.
-    :param tissue_as_row: If True, return a Table with a row annotation for each tissue
-        instead of an array of RSEM values. Default is False.
-    :return: Table of summarized transcript expression.
+    :param mt: MatrixTable of transcript (rows) expression quantifications (entry) by
+        sample (columns).
+    :param tissue_expr: Column expression indicating tissue type. Default is 'tissue'.
+    :param transcript_expression_expr: Entry expression indicating transcript expression
+        quantification. Default is 'x'.
+    :param summary_agg_func: Optional aggregation function to use to summarize the
+        transcript expression quantification by tissue. Example: `hl.agg.mean`. Default
+        is None, which will use a median aggregation.
+    :return: A Table of summarized transcript expression by tissue and a Table of
+        summarized gene expression by tissue.
     """
     if summary_agg_func is None:
         summary_agg_func = lambda x: hl.median(hl.agg.collect(x))
 
-    rsem_mt = rsem_mt.group_cols_by(tissue=tissue_expr).aggregate(
-        rsem=summary_agg_func(rsem_expr)
+    mt = mt.group_cols_by(tissue=tissue_expr).aggregate(
+        tx=summary_agg_func(transcript_expression_expr)
     )
 
-    if tissue_as_row:
-        rsem_ht = rsem_mt.rename({"rsem": ""}).make_table()
-    else:
-        rsem_ht = rsem_mt.localize_entries(
-            columns_array_field_name="tissues", entries_array_field_name="rsem"
-        )
-        rsem_ht = rsem_ht.annotate(rsem=rsem_ht.rsem.map(lambda x: x.rsem))
-        rsem_ht = rsem_ht.annotate_globals(
-            tissues=rsem_ht.tissues.map(lambda x: x.tissue)
-        )
+    transcript_ht = mt.rename({"tx": ""}).make_table()
+    transcript_ht = transcript_ht.key_by("transcript_id", "gene_id")
 
-    return rsem_ht.key_by("transcript_id", "gene_id")
+    gene_ht = transcript_ht.group_by("gene_id").aggregate(
+        **{
+            tissue: hl.agg.sum(transcript_ht[tissue])
+            for tissue in list(transcript_ht.row_value)
+        }
+    )
+
+    return transcript_ht, gene_ht
+
+
+def tissue_expression_ht_to_array(
+    ht: hl.Table,
+    tissues: Optional[List[str]] = None,
+    tissues_to_filter: Optional[List[str]] = None,
+) -> hl.Table:
+    """
+    Convert a Table with a row annotation for each tissue to a Table with tissues as an array.
+
+    The output is a Table with a field 'tissue_expression' containing an array of
+    summarized expression values by tissue, where the order of tissues in the array is
+    indicated by the "tissues" global annotation.
+
+    :param ht: Table with a row annotation for each tissue.
+    :param tissues: Optional list of tissues to keep in the 'tissue_expression' array.
+        Default is all non-key rows in the Table.
+    :param tissues_to_filter: Optional list of tissues to exclude from the tissue
+        expression array.
+    :return: Table with a field 'tissue_expression' containing an array of summarized
+        expression values by tissue.
+    """
+    if tissues is None:
+        tissues = list(ht.row_value)
+
+    if tissues_to_filter is not None:
+        logger.info("Filtering tissues: %s", tissues_to_filter)
+        tissues = [t for t in tissues if t not in tissues_to_filter]
+
+    ht = ht.select_globals(tissues=tissues)
+    ht = ht.select(tissue_expression=ht.tissues.map(lambda x: ht[x]))
+
+    return ht

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -22,11 +22,12 @@ def summarize_rsem_mt(
 
         The output can be returned in one of the following formats (both keyed by
         "transcript_id" and "gene_id"):
-            - A Table with an 'rsem' field containing an array of summarized expression
-              values by tissue, where the order of tissues in the array is indicated by
-              the "tissues" global annotation (`tissue_as_row` set to False).
-            - A Table with a row annotation for each tissue containing the summarized
-              tissue expression value (`tissue_as_row` set to True).
+
+        - A Table with an 'rsem' field containing an array of summarized expression
+          values by tissue, where the order of tissues in the array is indicated by
+          the "tissues" global annotation (`tissue_as_row` set to False).
+        - A Table with a row annotation for each tissue containing the summarized
+          tissue expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -87,6 +87,6 @@ def tissue_expression_ht_to_array(
         tissues = [t for t in tissues if t not in tissues_to_filter]
 
     ht = ht.select_globals(tissues=tissues)
-    ht = ht.select(tissue_expression=ht.tissues.map(lambda x: ht[x]))
+    ht = ht.select(tissue_expression=[ht[t] for t in tissues])
 
     return ht

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -1,0 +1,56 @@
+"""Utils module containing generic functions that are useful for adding transcript expression-aware annotations."""
+from typing import Callable, Optional
+
+import hail as hl
+
+
+def summarize_rsem_mt(
+    rsem_mt: hl.MatrixTable,
+    rsem_expr: hl.expr.NumericExpression,
+    tissue_expr: hl.expr.StringExpression,
+    summary_agg_func: Optional[Callable] = None,
+    tissue_as_row: bool = False,
+) -> hl.Table:
+    """
+    Summarize an RSEM table with ENSTs and ENSGs as rows and samples as columns by tissue.
+
+    The `summary_agg_func` argument allows the user to specify a Hail aggregation
+    function to use to summarize the expression by tissue. By default, the median is
+    used.
+
+    The output can be returned in one of the following formats (both keyed by
+    "transcript_id" and "gene_id"):
+        - A Table with an 'rsem' field containing an array of summarized expression
+          values by tissue, where the order of tissues in the array is indicated by the
+          "tissues" global annotation (`tissue_as_row` set to False).
+        - A Table with a row annotation for each tissue containing the summarized
+          tissue expression value (`tissue_as_row` set to True).
+
+    :param rsem_mt: MatrixTable of RSEM quantifications.
+    :param tissue_expr: Column expression indicating tissue type.
+    :param rsem_expr: Entry expression indicating RSEM quantification.
+    :param summary_agg_func: Optional aggregation function to use to summarize the RSEM
+        values by tissue. Default is None, which will use a median aggregation.
+    :param tissue_as_row: If True, return a Table with a row annotation for each tissue
+        instead of an array of RSEM values. Default is False.
+    :return: Table of summarized transcript expression.
+    """
+    if summary_agg_func is None:
+        summary_agg_func = lambda x: hl.median(hl.agg.collect(x))
+
+    rsem_mt = rsem_mt.group_cols_by(tissue=tissue_expr).aggregate(
+        rsem=summary_agg_func(rsem_expr)
+    )
+
+    if tissue_as_row:
+        rsem_ht = rsem_mt.rename("rsem", "").make_table()
+    else:
+        rsem_ht = rsem_mt.localize_entries(
+            columns_array_field_name="tissues", entries_array_field_name="rsem"
+        )
+        rsem_ht = rsem_ht.annotate(rsem=rsem_ht.rsem.map(lambda x: x.rsem))
+        rsem_ht = rsem_ht.annotate_globals(
+            tissues=rsem_ht.tissues.map(lambda x: x.tissue)
+        )
+
+    return rsem_ht.key_by("transcript_id", "gene_id")

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -20,11 +20,11 @@ def summarize_rsem_mt(
 
     The output can be returned in one of the following formats (both keyed by
     "transcript_id" and "gene_id"):
-        - A Table with an 'rsem' field containing an array of summarized expression
-          values by tissue, where the order of tissues in the array is indicated by the
-          "tissues" global annotation (`tissue_as_row` set to False).
-        - A Table with a row annotation for each tissue containing the summarized
-          tissue expression value (`tissue_as_row` set to True).
+      - A Table with an 'rsem' field containing an array of summarized expression
+        values by tissue, where the order of tissues in the array is indicated by the
+        "tissues" global annotation (`tissue_as_row` set to False).
+      - A Table with a row annotation for each tissue containing the summarized tissue
+        expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -42,6 +42,12 @@ def summarize_transcript_expression(
     if summary_agg_func is None:
         summary_agg_func = lambda x: hl.median(hl.agg.collect(x))
 
+    if isinstance(transcript_expression_expr, str):
+        transcript_expression_expr = mt[transcript_expression_expr]
+
+    if isinstance(tissue_expr, str):
+        tissue_expr = mt[tissue_expr]
+
     mt = mt.group_cols_by(tissue=tissue_expr).aggregate(
         tx=summary_agg_func(transcript_expression_expr)
     )


### PR DESCRIPTION
Starting to move over generic functions from https://github.com/macarthur-lab/tx_annotation/tree/bea56ddf991607f7479358c0c80588f1a2ec9bc1#applying-transcript-expression-aware-annotation-to-your-own-dataset

This function can take in an expression MT and summarize by transcript and tissue, similar to [this](https://github.com/macarthur-lab/tx_annotation/blob/bea56ddf991607f7479358c0c80588f1a2ec9bc1/tx_annotation_resources.py#L125) function after the loading of the resource. 