### PR TITLE
Function to get expression proportion

### DIFF
--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -90,3 +90,46 @@ def tissue_expression_ht_to_array(
     ht = ht.select(tissue_expression=[ht[t] for t in tissues])
 
     return ht
+
+
+def get_expression_proportion(
+    transcript_ht: hl.Table,
+    gene_ht: hl.Table,
+    tissues_to_filter: Optional[List[str]] = None,
+) -> hl.Table:
+    """
+    Calculate the proportion of expression of transcript to gene per tissue.
+
+    :param transcript_ht: Table of summarized transcript expression by tissue.
+    :param gene_ht: Table of summarized gene expression by tissue.
+    :param tissues_to_filter: Optional list of tissues to filter out
+    :return: Table with expression proportion of transcript to gene per tissue
+        and mean expression proportion across tissues.
+    """
+    transcript_ht = tissue_expression_ht_to_array(
+        transcript_ht, tissues_to_filter=tissues_to_filter
+    )
+    gene_ht = tissue_expression_ht_to_array(
+        gene_ht, tissues=hl.eval(transcript_ht.tissues)
+    )
+
+    # Join the transcript expression table and gene expression table.
+    transcript_ht = transcript_ht.annotate(
+        gene_expression=gene_ht[transcript_ht.gene_id].tissue_expression
+    )
+
+    # Calculate the proportion of expression of transcript to gene per tissue.
+    transcript_ht = transcript_ht.annotate(
+        exp_prop=hl.or_else(
+            transcript_ht.transcript_expression / transcript_ht.gene_expression,
+            hl.empty_array(hl.tfloat64),
+        ),
+    )
+    # Calculate the mean expression proportion across tissues.
+    transcript_ht = transcript_ht.annotate(
+        exp_prop_mean=hl.mean(
+            hl.filter(lambda e: ~hl.is_nan(e), transcript_ht.exp_prop),
+        )
+    )
+
+    return transcript_ht

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -1,6 +1,6 @@
 """Utils module containing generic functions that are useful for adding transcript expression-aware annotations."""
 import logging
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Union
 
 import hail as hl
 

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -18,13 +18,15 @@ def summarize_rsem_mt(
     function to use to summarize the expression by tissue. By default, the median is
     used.
 
-    The output can be returned in one of the following formats (both keyed by
-    "transcript_id" and "gene_id"):
-      - A Table with an 'rsem' field containing an array of summarized expression
-        values by tissue, where the order of tissues in the array is indicated by the
-        "tissues" global annotation (`tissue_as_row` set to False).
-      - A Table with a row annotation for each tissue containing the summarized tissue
-        expression value (`tissue_as_row` set to True).
+    .. note::
+
+        The output can be returned in one of the following formats (both keyed by
+        "transcript_id" and "gene_id"):
+            - A Table with an 'rsem' field containing an array of summarized expression
+              values by tissue, where the order of tissues in the array is indicated by
+              the "tissues" global annotation (`tissue_as_row` set to False).
+            - A Table with a row annotation for each tissue containing the summarized
+              tissue expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -22,11 +22,12 @@ def summarize_rsem_mt(
 
         The output can be returned in one of the following formats (both keyed by
         "transcript_id" and "gene_id"):
-            - A Table with an 'rsem' field containing an array of summarized expression
-              values by tissue, where the order of tissues in the array is indicated by
-              the "tissues" global annotation (`tissue_as_row` set to False).
-            - A Table with a row annotation for each tissue containing the summarized
-              tissue expression value (`tissue_as_row` set to True).
+
+        - A Table with an 'rsem' field containing an array of summarized expression
+          values by tissue, where the order of tissues in the array is indicated by
+          the "tissues" global annotation (`tissue_as_row` set to False).
+        - A Table with a row annotation for each tissue containing the summarized
+          tissue expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -23,12 +23,12 @@ def summarize_transcript_expression(
     """
     Summarize a transcript expression MatrixTable by transcript, gene, and tissue.
 
-    The `summary_agg_func` argument allows the user to specify a Hail aggregation
-    function to use to summarize the expression by tissue. By default, the median is
-    used.
+    The `summary_agg_func` argument allows the user to specify a Hail
+    aggregation function to use to summarize the expression by tissue. By
+    default, the median is used.
 
-    The returned Table has a row annotation for each tissue containing the summarized
-    tissue expression value.
+    The returned Table has a row annotation for each tissue containing the
+    summarized tissue expression value.
 
     :param mt: MatrixTable of transcript (rows) expression quantifications (entry) by
         sample (columns).
@@ -36,8 +36,8 @@ def summarize_transcript_expression(
         quantification. Default is 'transcript_tpm'.
     :param tissue_expr: Column expression indicating tissue type. Default is 'tissue'.
     :param summary_agg_func: Optional aggregation function to use to summarize the
-        transcript expression quantification by tissue. Example: `hl.mean`. Default
-        is None, which will use a median aggregation.
+        transcript expression quantification by tissue. Example: `hl.agg.mean`.
+        Default is None, which will use a median aggregation.
     :return: A Table of summarized transcript expression by tissue
     """
     if summary_agg_func is None:
@@ -54,7 +54,9 @@ def summarize_transcript_expression(
     )
     ht = mt.rename({"tx": ""}).make_table().key_by("transcript_id", "gene_id")
 
-    # Annotate with the proportion of expression of transcript to gene per tissue.
+    # Annotate with the proportion of expression of transcript to gene per tissue. The
+    # returned Table has a row annotation for each tissue containing the summarized
+    # tissue expression value.
     ht = ht.annotate(expression_proportion=get_expression_proportion(ht))
     ht = ht.select(
         **{
@@ -74,8 +76,8 @@ def get_expression_proportion(ht: hl.Table) -> hl.expr.StructExpression:
     Calculate the proportion of expression of transcript to gene per tissue.
 
     :param ht: Table of summarized transcript expression by tissue.
-    :return: Table with expression proportion of transcript to gene per tissue
-        and mean expression proportion across tissues.
+    :return: StructExpression containing the proportion of expression of transcript to
+        gene per tissue.
     """
     tissues = list(ht.row_value)
 
@@ -138,16 +140,27 @@ def tissue_expression_ht_to_array(
     """
     Convert a Table with a row annotation for each tissue to a Table with tissues as an array.
 
-    The output is a Table with fields in `annotations_to_extract`,
-    each containing an array of summarized expression values or proportion
-    by tissue, where the order of tissues in the array is indicated by
-    the "tissues" global annotation.
+    The output is a Table with one of the two formats: either an annotation of
+    'tissue_expression' containing an array of structs by tissue, where each element of
+    the array is the Table's row value for a given tissue, like this:
+    tissue_expression': array<struct {
+        transcript_expression: float64,
+        expression_proportion: float64
+    }>
+
+    or a Table with one array annotation for each field defined in the
+    'annotations_to_extract' argument, where each array is an array of the given field
+    values by tissue, like this:
+    'transcript_expression': array<float64>
+    'expression_proportion': array<float64>
+
+    The order of tissues in the array is indicated by the "tissues" global annotation.
 
     :param ht: Table with a row annotation for each tissue.
-    :param tissues_to_keep: Optional list of tissues to keep in the 'tissue_expression'
+    :param tissues_to_keep: Optional list of tissues to keep in the tissue expression
         array. Default is all non-key rows in the Table.
-    :param tissues_to_filter: Optional list of tissues to exclude from the tissue
-        expression array.
+    :param tissues_to_filter: Optional list of tissues to exclude from the
+        tissue expression array.
     :param annotations_to_extract: Optional list of tissue struct fields to extract
         into top level array annotations. If None, the returned Table will contain a
         single top level annotation 'tissue_expression' that contains an array of

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -77,67 +77,36 @@ def get_expression_proportion(
     transcript_ht: hl.Table,
     gene_ht: hl.Table,
     tissues_to_filter: Optional[List[str]] = None,
-    tissue_as_row: bool = False,
 ) -> hl.Table:
     """
     Calculate the proportion of expression of transcript to gene per tissue.
 
-    :param transcript_ht: Table of summarized transcript expression by tissue
-    :param gene_ht: Table of summarized gene expression by tissue
+    :param transcript_ht: Table of summarized transcript expression by tissue.
+    :param gene_ht: Table of summarized gene expression by tissue.
     :param tissues_to_filter: Optional list of tissues to filter out
-    :param tissue_as_row: If True, the input Table is with a row annotation for each
-        tissue instead of an array of values. Default is False.
     :return: Table with expression proportion of transcript to gene per tissue
-        and mean expression proportion across tissues
+        and mean expression proportion across tissues.
     """
-    if tissue_as_row:
-        tissues1 = list(gene_ht.row)
-        tissues1.remove("gene_id")
-        gene_ht = gene_ht.select(
-            gene_expression=hl.array([gene_ht[tissue] for tissue in tissues1])
-        ).annotate_globals(tissues=tissues1)
-
-        tissues2 = list(transcript_ht.row)
-        tissues2.remove("transcript_id")
-        tissues2.remove("gene_id")
-        transcript_ht = transcript_ht.select(
-            transcript_expression=hl.array(
-                [transcript_ht[tissue] for tissue in tissues2]
-            )
-        ).annotate_globals(tissues=tissues2)
-
-    # Join the transcript expression table and gene expression table
-    transcript_ht = transcript_ht.annotate(
-        gene_expression=gene_ht[transcript_ht.gene_id].gene_expression
+    transcript_ht = tissue_expression_ht_to_array(
+        transcript_ht, tissues_to_filter=tissues_to_filter
+    )
+    gene_ht = tissue_expression_ht_to_array(
+        gene_ht, tissues=hl.eval(transcript_ht.tissues)
     )
 
-    if tissues_to_filter is not None:
-        tissues_indices = []
-        for i, t in enumerate(hl.eval(transcript_ht.tissues)):
-            if t not in tissues_to_filter:
-                tissues_indices.append(i)
+    # Join the transcript expression table and gene expression table.
+    transcript_ht = transcript_ht.annotate(
+        gene_expression=gene_ht[transcript_ht.gene_id].tissue_expression
+    )
 
-        transcript_ht = transcript_ht.annotate(
-            transcript_expression=hl.array(
-                [transcript_ht.transcript_expression[i] for i in tissues_indices]
-            ),
-            gene_expression=hl.array(
-                [transcript_ht.gene_expression[i] for i in tissues_indices]
-            ),
-        )
-
-        transcript_ht = transcript_ht.select_globals(
-            tissues=hl.array([transcript_ht.tissues[i] for i in tissues_indices])
-        )
-
-    # Calculate the proportion of expression of transcript to gene per tissue
+    # Calculate the proportion of expression of transcript to gene per tissue.
     transcript_ht = transcript_ht.annotate(
         exp_prop=hl.or_else(
             transcript_ht.transcript_expression / transcript_ht.gene_expression,
             hl.empty_array(hl.tfloat64),
         ),
     )
-    # Calculate the mean expression proportion across tissues
+    # Calculate the mean expression proportion across tissues.
     transcript_ht = transcript_ht.annotate(
         exp_prop_mean=hl.mean(
             hl.filter(lambda e: ~hl.is_nan(e), transcript_ht.exp_prop),

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -143,16 +143,16 @@ def tissue_expression_ht_to_array(
     The output is a Table with one of the two formats: either an annotation of
     'tissue_expression' containing an array of structs by tissue, where each element of
     the array is the Table's row value for a given tissue, like this:
-    tissue_expression': array<struct {
-        transcript_expression: float64,
-        expression_proportion: float64
-    }>
+    # tissue_expression': array<struct {
+    #     transcript_expression: float64,
+    #     expression_proportion: float64
+    # }>
 
     or a Table with one array annotation for each field defined in the
     'annotations_to_extract' argument, where each array is an array of the given field
     values by tissue, like this:
-    'transcript_expression': array<float64>
-    'expression_proportion': array<float64>
+    # 'transcript_expression': array<float64>
+    # 'expression_proportion': array<float64>
 
     The order of tissues in the array is indicated by the "tissues" global annotation.
 


### PR DESCRIPTION
This function is similar to [this](https://github.com/macarthur-lab/tx_annotation/blob/bea56ddf991607f7479358c0c80588f1a2ec9bc1/tx_annotation.py#L211C5-L211C30), by taking the proportions of transcript expression to gene expression per tissue, and a mean proportion. It's extended to use both array-format expression data and tissue-as-row expression data as input. 
