### PR TITLE
Functions to process, filter, annotate and aggregate variants by transcript expression (get the pext scores per variant)

### DIFF
--- a/gnomad/resources/grch37/reference_data.py
+++ b/gnomad/resources/grch37/reference_data.py
@@ -7,26 +7,9 @@ from gnomad.resources.resource_utils import (
     GnomadPublicTableResource,
     VersionedMatrixTableResource,
     VersionedTableResource,
+    import_gencode,
     import_sites_vcf,
 )
-
-
-def _import_gencode(gtf_path: str, **kwargs) -> hl.Table:
-    """
-    Import GENCODE annotations GTF file as a Hail Table.
-
-    :param gtf_path: Path to GENCODE GTF file.
-    :return: Table with GENCODE annotation information.
-    """
-    ht = hl.experimental.import_gtf(gtf_path, **kwargs)
-
-    # Only get gene and transcript stable IDs (without version numbers if they
-    # exist), early versions of GENCODE have no version numbers but later ones do.
-    ht = ht.annotate(
-        gene_id=ht.gene_id.split("\\.")[0],
-        transcript_id=ht.transcript_id.split("\\.")[0],
-    )
-    return ht
 
 
 def _import_gtex_rsem(gtex_path: str, meta_path: str, **kwargs) -> hl.MatrixTable:
@@ -377,7 +360,7 @@ gencode = VersionedTableResource(
     versions={
         "v19": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch37/gencode/gencode.v19.annotation.ht",
-            import_func=_import_gencode,
+            import_func=import_gencode,
             import_args={
                 "gtf_path": "gs://gcp-public-data--gnomad/resources/grch37/gencode/gencode.v19.annotation.gtf.gz",
                 "reference_genome": "GRCh37",

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -396,7 +396,7 @@ gencode = VersionedTableResource(
                 "gtf_path": "gs://gcp-public-data--gnomad/resources/grch38/gencode/gencode.v39.annotation.gtf.gz",
                 "reference_genome": "GRCh38",
                 "force_bgz": True,
-                "min_partitions": 10,
+                "min_partitions": 100,
             },
         ),
     },

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -10,6 +10,7 @@ from gnomad.resources.resource_utils import (
     GnomadPublicTableResource,
     VersionedMatrixTableResource,
     VersionedTableResource,
+    import_gencode,
     import_sites_vcf,
 )
 from gnomad.utils.vep import vep_or_lookup_vep
@@ -385,30 +386,12 @@ def get_truth_ht() -> Table:
     )
 
 
-def _import_gencode(gtf_path: str, **kwargs) -> hl.Table:
-    """
-    Import GENCODE annotations GTF file as a Hail Table.
-
-    :param gtf_path: Path to GENCODE GTF file.
-    :return: Table with GENCODE annotation information.
-    """
-    ht = hl.experimental.import_gtf(gtf_path, **kwargs)
-
-    # Only get gene and transcript stable IDs (without version numbers if they
-    # exist), early versions of GENCODE have no version numbers but later ones do.
-    ht = ht.annotate(
-        gene_id=ht.gene_id.split("\\.")[0],
-        transcript_id=ht.transcript_id.split("\\.")[0],
-    )
-    return ht
-
-
 gencode = VersionedTableResource(
     default_version="v39",
     versions={
         "v39": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/grch38/gencode/gencode.v39.annotation.ht",
-            import_func=_import_gencode,
+            import_func=import_gencode,
             import_args={
                 "gtf_path": "gs://gcp-public-data--gnomad/resources/grch38/gencode/gencode.v39.annotation.gtf.gz",
                 "reference_genome": "GRCh38",

--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -383,3 +383,38 @@ def get_truth_ht() -> Table:
         .repartition(200, shuffle=False)
         .persist()
     )
+
+
+def _import_gencode(gtf_path: str, **kwargs) -> hl.Table:
+    """
+    Import GENCODE annotations GTF file as a Hail Table.
+
+    :param gtf_path: Path to GENCODE GTF file.
+    :return: Table with GENCODE annotation information.
+    """
+    ht = hl.experimental.import_gtf(gtf_path, **kwargs)
+
+    # Only get gene and transcript stable IDs (without version numbers if they
+    # exist), early versions of GENCODE have no version numbers but later ones do.
+    ht = ht.annotate(
+        gene_id=ht.gene_id.split("\\.")[0],
+        transcript_id=ht.transcript_id.split("\\.")[0],
+    )
+    return ht
+
+
+gencode = VersionedTableResource(
+    default_version="v39",
+    versions={
+        "v39": GnomadPublicTableResource(
+            path="gs://gnomad-public-requester-pays/resources/grch38/gencode/gencode.v39.annotation.ht",
+            import_func=_import_gencode,
+            import_args={
+                "gtf_path": "gs://gcp-public-data--gnomad/resources/grch38/gencode/gencode.v39.annotation.gtf.gz",
+                "reference_genome": "GRCh38",
+                "force_bgz": True,
+                "min_partitions": 10,
+            },
+        ),
+    },
+)

--- a/gnomad/resources/resource_utils.py
+++ b/gnomad/resources/resource_utils.py
@@ -687,3 +687,21 @@ DBSNP_B154_CHR_CONTIG_RECODING = {
 def import_sites_vcf(**kwargs) -> hl.Table:
     """Import site-level data from a VCF into a Hail Table."""
     return hl.import_vcf(**kwargs).rows()
+
+
+def import_gencode(gtf_path: str, **kwargs) -> hl.Table:
+    """
+    Import GENCODE annotations GTF file as a Hail Table.
+
+    :param gtf_path: Path to GENCODE GTF file.
+    :return: Table with GENCODE annotation information.
+    """
+    ht = hl.experimental.import_gtf(gtf_path, **kwargs)
+
+    # Only get gene and transcript stable IDs (without version numbers if they
+    # exist), early versions of GENCODE have no version numbers but later ones do.
+    ht = ht.annotate(
+        gene_id=ht.gene_id.split("\\.")[0],
+        transcript_id=ht.transcript_id.split("\\.")[0],
+    )
+    return ht

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -414,6 +414,8 @@ def filter_to_gencode_cds(
             from gnomad.resources.grch37.reference_data import gencode
         elif build == "GRCh38":
             from gnomad.resources.grch38.reference_data import gencode
+        else:
+            raise ValueError(f"Unsupported reference genome build: {build}")
 
         logger.info(
             "No Gencode Table was supplied, using Gencode version %s",

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -426,6 +426,12 @@ def filter_to_gencode_cds(
     gencode_ht = gencode_ht.filter(
         (gencode_ht.feature == "CDS") & (gencode_ht.transcript_type == "protein_coding")
     )
+    logger.warning(
+        "When filtering to Gencode CDS intervals, it's not filtering by "
+        "transcript, variants that are not in CDS regions but are "
+        "annotated as a coding variants by VEP might be filtered out by "
+        "this."
+    )
     filter_expr = hl.is_defined(gencode_ht[t.locus])
 
     if isinstance(t, hl.MatrixTable):

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -410,7 +410,8 @@ def filter_to_gencode_cds(
         filtering to CDS intervals by transcript, an additional step must be taken.
         For example, when filtering VEP transcript consequences, there may be cases
         where a variant is retained with this filter, but is considered outside the
-        CDS intervals of some of the transcripts in the VEP annotation.
+        CDS intervals of the transcript per the VEP predicted consequence of the
+        variant.
 
     :param t: Input Table/MatrixTable to filter.
     :param gencode_ht: Gencode Table to use for filtering the input Table/MatrixTable

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -383,6 +383,20 @@ def filter_to_clinvar_pathogenic(
     return t
 
 
+def filter_gencode_to_cds(ht: hl.Table) -> hl.Table:
+    """
+    Filter Gencode Table to only CDS regions.
+
+    :param ht: Input Gencode Table that is converted from a GTF file.
+    :return: Table filtered to CDS intervals with necessary fields.
+    """
+    return (
+        ht.filter((ht.feature == "CDS") & (ht.transcript_type == "protein_coding"))
+        .select("gene_id", "transcript_id")
+        .distinct()
+    )
+
+
 def remove_fields_from_constant(
     constant: List[str], fields_to_remove: List[str]
 ) -> List[str]:

--- a/gnomad/utils/filtering.py
+++ b/gnomad/utils/filtering.py
@@ -402,6 +402,16 @@ def filter_to_gencode_cds(
         If no Gencode Table is provided, the default version of the Gencode Table
         resource for the genome build of the input Table/MatrixTable will be used.
 
+    .. warning::
+
+        This Gencode CDS interval filter does not take into account the
+        transcript_id, it filters to any locus that is found in a CDS interval for
+        any protein coding transcript. Therefore, if downstream analyses require
+        filtering to CDS intervals by transcript, an additional step must be taken.
+        For example, when filtering VEP transcript consequences, there may be cases
+        where a variant is retained with this filter, but is considered outside the
+        CDS intervals of some of the transcripts in the VEP annotation.
+
     :param t: Input Table/MatrixTable to filter.
     :param gencode_ht: Gencode Table to use for filtering the input Table/MatrixTable
         to CDS regions. Default is None, which will use the default version of the
@@ -427,10 +437,8 @@ def filter_to_gencode_cds(
         (gencode_ht.feature == "CDS") & (gencode_ht.transcript_type == "protein_coding")
     )
     logger.warning(
-        "When filtering to Gencode CDS intervals, it's not filtering by "
-        "transcript, variants that are not in CDS regions but are "
-        "annotated as a coding variants by VEP might be filtered out by "
-        "this."
+        "This Gencode CDS interval filter does not filter by transcript! Please see the"
+        " documentation for more details to confirm it's being used as intended."
     )
     filter_expr = hl.is_defined(gencode_ht[t.locus])
 

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -175,49 +175,6 @@ def tissue_expression_ht_to_array(
     return ht
 
 
-def get_expression_proportion(
-    transcript_ht: hl.Table,
-    gene_ht: hl.Table,
-    tissues_to_filter: Optional[List[str]] = None,
-) -> hl.Table:
-    """
-    Calculate the proportion of expression of transcript to gene per tissue.
-
-    :param transcript_ht: Table of summarized transcript expression by tissue.
-    :param gene_ht: Table of summarized gene expression by tissue.
-    :param tissues_to_filter: Optional list of tissues to filter out
-    :return: Table with expression proportion of transcript to gene per tissue
-        and mean expression proportion across tissues.
-    """
-    transcript_ht = tissue_expression_ht_to_array(
-        transcript_ht, tissues_to_filter=tissues_to_filter
-    )
-    gene_ht = tissue_expression_ht_to_array(
-        gene_ht, tissues=hl.eval(transcript_ht.tissues)
-    )
-
-    # Join the transcript expression table and gene expression table.
-    transcript_ht = transcript_ht.annotate(
-        gene_expression=gene_ht[transcript_ht.gene_id].tissue_expression
-    )
-
-    # Calculate the proportion of expression of transcript to gene per tissue.
-    transcript_ht = transcript_ht.annotate(
-        exp_prop=hl.or_else(
-            transcript_ht.transcript_expression / transcript_ht.gene_expression,
-            hl.empty_array(hl.tfloat64),
-        ),
-    )
-    # Calculate the mean expression proportion across tissues.
-    transcript_ht = transcript_ht.annotate(
-        exp_prop_mean=hl.mean(
-            hl.filter(lambda e: ~hl.is_nan(e), transcript_ht.exp_prop),
-        )
-    )
-
-    return transcript_ht
-
-
 def tx_annotate_variants(
     ht: hl.Table,
     tx_ht: hl.Table,

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -406,8 +406,5 @@ def process_annotate_aggregate_variants(
 
     tx_ht = tx_aggregate_variants(tx_ht, additional_group_by=additional_group_by)
     tx_ht = tx_ht.collect_by_key("tx_annotation")
-    ht = ht.annotate(**tx_ht[ht.key]).annotate_globals(
-        tissues=tx_ht.index_globals().tissues
-    )
 
-    return ht
+    return tx_ht

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -366,7 +366,7 @@ def tx_aggregate_variants(
     return ht
 
 
-def combined_tx_pipeline(
+def perform_tx_annotation_pipeline(
     ht: hl.Table,
     tx_ht: hl.Table,
     tissues_to_filter: Optional[List[str]] = None,
@@ -409,6 +409,5 @@ def combined_tx_pipeline(
     )
 
     tx_ht = tx_aggregate_variants(tx_ht, additional_group_by=additional_group_by)
-    tx_ht = tx_ht.collect_by_key("tx_annotation")
 
     return tx_ht

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -43,7 +43,7 @@ def summarize_rsem_mt(
     )
 
     if tissue_as_row:
-        rsem_ht = rsem_mt.rename("rsem", "").make_table()
+        rsem_ht = rsem_mt.rename({"rsem": ""}).make_table()
     else:
         rsem_ht = rsem_mt.localize_entries(
             columns_array_field_name="tissues", entries_array_field_name="rsem"

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -18,13 +18,15 @@ def summarize_rsem_mt(
     function to use to summarize the expression by tissue. By default, the median is
     used.
 
-    The output can be returned in one of the following formats (both keyed by
-    "transcript_id" and "gene_id"):
-      - A Table with an 'rsem' field containing an array of summarized expression
-        values by tissue, where the order of tissues in the array is indicated by the
-        "tissues" global annotation (`tissue_as_row` set to False).
-      - A Table with a row annotation for each tissue containing the summarized tissue
-        expression value (`tissue_as_row` set to True).
+    .. note::
+
+        The output can be returned in one of the following formats (both keyed by
+        "transcript_id" and "gene_id"):
+            - A Table with an 'rsem' field containing an array of summarized expression
+              values by tissue, where the order of tissues in the array is indicated by
+              the "tissues" global annotation (`tissue_as_row` set to False).
+            - A Table with a row annotation for each tissue containing the summarized
+              tissue expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -22,11 +22,12 @@ def summarize_rsem_mt(
 
         The output can be returned in one of the following formats (both keyed by
         "transcript_id" and "gene_id"):
-            - A Table with an 'rsem' field containing an array of summarized expression
-              values by tissue, where the order of tissues in the array is indicated by
-              the "tissues" global annotation (`tissue_as_row` set to False).
-            - A Table with a row annotation for each tissue containing the summarized
-              tissue expression value (`tissue_as_row` set to True).
+
+        - A Table with an 'rsem' field containing an array of summarized expression
+          values by tissue, where the order of tissues in the array is indicated by
+          the "tissues" global annotation (`tissue_as_row` set to False).
+        - A Table with a row annotation for each tissue containing the summarized
+          tissue expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -1,0 +1,56 @@
+"""Utils module containing generic functions that are useful for adding transcript expression-aware annotations."""
+from typing import Callable, Optional
+
+import hail as hl
+
+
+def summarize_rsem_mt(
+    rsem_mt: hl.MatrixTable,
+    rsem_expr: hl.expr.NumericExpression,
+    tissue_expr: hl.expr.StringExpression,
+    summary_agg_func: Optional[Callable] = None,
+    tissue_as_row: bool = False,
+) -> hl.Table:
+    """
+    Summarize an RSEM table with ENSTs and ENSGs as rows and samples as columns by tissue.
+
+    The `summary_agg_func` argument allows the user to specify a Hail aggregation
+    function to use to summarize the expression by tissue. By default, the median is
+    used.
+
+    The output can be returned in one of the following formats (both keyed by
+    "transcript_id" and "gene_id"):
+        - A Table with an 'rsem' field containing an array of summarized expression
+          values by tissue, where the order of tissues in the array is indicated by the
+          "tissues" global annotation (`tissue_as_row` set to False).
+        - A Table with a row annotation for each tissue containing the summarized
+          tissue expression value (`tissue_as_row` set to True).
+
+    :param rsem_mt: MatrixTable of RSEM quantifications.
+    :param tissue_expr: Column expression indicating tissue type.
+    :param rsem_expr: Entry expression indicating RSEM quantification.
+    :param summary_agg_func: Optional aggregation function to use to summarize the RSEM
+        values by tissue. Default is None, which will use a median aggregation.
+    :param tissue_as_row: If True, return a Table with a row annotation for each tissue
+        instead of an array of RSEM values. Default is False.
+    :return: Table of summarized transcript expression.
+    """
+    if summary_agg_func is None:
+        summary_agg_func = lambda x: hl.median(hl.agg.collect(x))
+
+    rsem_mt = rsem_mt.group_cols_by(tissue=tissue_expr).aggregate(
+        rsem=summary_agg_func(rsem_expr)
+    )
+
+    if tissue_as_row:
+        rsem_ht = rsem_mt.rename("rsem", "").make_table()
+    else:
+        rsem_ht = rsem_mt.localize_entries(
+            columns_array_field_name="tissues", entries_array_field_name="rsem"
+        )
+        rsem_ht = rsem_ht.annotate(rsem=rsem_ht.rsem.map(lambda x: x.rsem))
+        rsem_ht = rsem_ht.annotate_globals(
+            tissues=rsem_ht.tissues.map(lambda x: x.tissue)
+        )
+
+    return rsem_ht.key_by("transcript_id", "gene_id")

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -20,11 +20,11 @@ def summarize_rsem_mt(
 
     The output can be returned in one of the following formats (both keyed by
     "transcript_id" and "gene_id"):
-        - A Table with an 'rsem' field containing an array of summarized expression
-          values by tissue, where the order of tissues in the array is indicated by the
-          "tissues" global annotation (`tissue_as_row` set to False).
-        - A Table with a row annotation for each tissue containing the summarized
-          tissue expression value (`tissue_as_row` set to True).
+      - A Table with an 'rsem' field containing an array of summarized expression
+        values by tissue, where the order of tissues in the array is indicated by the
+        "tissues" global annotation (`tissue_as_row` set to False).
+      - A Table with a row annotation for each tissue containing the summarized tissue
+        expression value (`tissue_as_row` set to True).
 
     :param rsem_mt: MatrixTable of RSEM quantifications.
     :param tissue_expr: Column expression indicating tissue type.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -163,9 +163,9 @@ def tx_annotate_variants(
         one of the processed consequences: ["transcript_consequences",
         "worst_csq_by_gene", "worst_csq_for_variant",
         "worst_csq_by_gene_canonical", "worst_csq_for_variant_canonical"].
-        For exapmle, if you want to annotate each variant with the worst
-        consequence per gene and the transcript expression, you would use
-        "worst_csq_by_gene". Default is "transcript_consequences".
+        For example, if you want to annotate each variant with the worst
+        consequence in each gene it falls on and the transcript expression,
+        you would use "worst_csq_by_gene". Default is "transcript_consequences".
     :return: Table with transcript expression information annotated
     """
     # GTEx data has transcript IDs without version numbers, so we need to

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -175,30 +175,27 @@ def tissue_expression_ht_to_array(
     return ht
 
 
-def tx_annotate_variants(
+def preprocess_variants_for_tx(
     ht: hl.Table,
-    tx_ht: hl.Table,
+    filter_to_genes: Optional[Union[Tuple[str], List[str]]] = None,
+    filter_to_csqs: Optional[Union[Tuple[str], List[str]]] = None,
+    ignore_splicing: bool = True,
+    filter_to_homs: bool = False,
     filter_to_protein_coding: bool = True,
-    tissues_to_filter: Optional[List[str]] = None,
-    additional_group_by: Optional[Union[Tuple[str], List[str]]] = (
-        "gene_symbol",
-        "most_severe_consequence",
-        "lof",
-        "lof_flags",
-    ),
     vep_annotation: str = "transcript_consequences",
 ) -> hl.Table:
     """
-    Annotate variants with transcript-based expression values or expression proportion from GTEx.
+    Filter variants to those that fall on transcripts of interest.
 
-    :param ht: Table of variants to annotate, it should contain at least the following
-        nested fields: `vep.transcript_consequences`, `freq`.
-    :param tx_ht: Table of transcript expression information.
+    :param ht: Table of variants to filter, it should contain at least the
+        following nested fields: `vep.transcript_consequences`, `freq`.
+    :param filter_to_genes: List of genes to filter to.
+    :param filter_to_csqs: List of consequence terms to filter to.
+    :param ignore_splicing: If True, ignore splice variants. Default is True.
+    :param filter_to_homs: If True, filter to variants with at least one
+        homozygote in `freq` field. Default is False.
     :param filter_to_protein_coding: If True, filter to protein coding
         transcripts. Default is True.
-    :param tissues_to_filter: Optional list of tissues to exclude from the output.
-    :param additional_group_by: Optional list of additional fields to group by before
-        sum aggregation.
     :param vep_annotation: Name of annotation in 'vep' annotation,
         one of the processed consequences: ["transcript_consequences",
         "worst_csq_by_gene", "worst_csq_for_variant",
@@ -206,35 +203,118 @@ def tx_annotate_variants(
         For example, if you want to annotate each variant with the worst
         consequence in each gene it falls on and the transcript expression,
         you would use "worst_csq_by_gene". Default is "transcript_consequences".
+    :return: Table of variants that fall on transcripts of interest.
+    """
+    # TODO: Filter to only CDS regions?
+    ht = ht.select(freq=ht.freq, vep=ht.vep)
+
+    ht = process_consequences(ht)
+    ht = ht.select(freq=ht.freq, vep_processed_csqs=ht.vep[vep_annotation])
+
+    # Explode the processed transcript consequences to be able to key by
+    # transcript ID
+    ht = ht.explode(ht.vep_processed_csqs)
+
+    if filter_to_genes:
+        ht = ht.filter(
+            hl.literal(filter_to_genes).contains(ht.vep_processed_csqs.gene_id)
+        )
+
+    if filter_to_csqs:
+        ht = ht.filter(
+            hl.literal(filter_to_csqs).contains(
+                ht.vep_processed_csqs.most_severe_consequence
+            )
+        )
+
+    # TODO: Need to modify process consequences to ignore splice variants,
+    #  because these can occur on intronic regions?
+    splicing = hl.literal(
+        ["splice_acceptor_variant", "splice_donor_variant", "splice_region_variant"]
+    )
+    if ignore_splicing:
+        ht = ht.filter(
+            ~splicing.contains(ht.vep_processed_csqs.most_severe_consequence)
+        )
+
+    if filter_to_homs:
+        ht = ht.filter(ht.freq[0].homozygote_count > 0)
+
+    if filter_to_protein_coding:
+        ht = ht.filter(ht.vep_processed_csqs.biotype == "protein_coding")
+
+    return ht
+
+
+def tx_annotate_variants(
+    ht: hl.Table,
+    tx_ht: hl.Table,
+    tissues_to_filter: Optional[List[str]] = None,
+    additional_group_by: Optional[Union[Tuple[str], List[str]]] = (
+        "gene_symbol",
+        "most_severe_consequence",
+        "lof",
+        "lof_flags",
+    ),
+) -> hl.Table:
+    """
+    Annotate variants with transcript-based expression values or expression proportion from GTEx.
+
+    :param ht: Table of variants to annotate, it should contain at least the following
+        nested fields: `vep.transcript_consequences`, `freq`.
+    :param tx_ht: Table of transcript expression information.
+    :param tissues_to_filter: Optional list of tissues to exclude from the output.
+    :param additional_group_by: Optional list of additional fields to group by before
+        sum aggregation.
     :return: Input Table with transcript expression information annotated.
     """
     # Filter to tissues of interest and convert to arrays for easy aggregation.
     tx_ht = tissue_expression_ht_to_array(tx_ht, tissues_to_filter=tissues_to_filter)
-    agg_annotations = list(tx_ht.row_value)
-    tissues = hl.eval(tx_ht.tissues)
 
     # Calculate the mean expression proportion across all tissues.
     tx_ht = tx_ht.annotate(exp_prop_mean=hl.mean(tx_ht.expression_proportion))
 
-    ht = process_consequences(ht)
-
-    # Explode the processed transcript consequences to be able to key by
-    # transcript ID
-    ht = ht.explode(ht.vep[vep_annotation])
-
-    if filter_to_protein_coding:
-        ht = ht.filter(ht.vep[vep_annotation].biotype == "protein_coding")
-
     grouping = ["transcript_id", "gene_id"] + list(additional_group_by)
-    ht = ht.select(**{a: ht.vep[vep_annotation][a] for a in grouping})
+    ht = ht.select(**{a: ht.vep_processed_csqs[a] for a in grouping})
+
+    ht = ht.annotate(**tx_ht[ht.transcript_id, ht.gene_id])
+    ht = ht.annotate_globals(tissues=tx_ht.index_globals().tissues)
+
+    return ht
+
+
+def tx_aggregate_variants(
+    ht: hl.Table,
+    agg_annotations: Optional[List[str]] = (
+        "transcript_expression",
+        "expression_proportion",
+    ),
+    additional_group_by: Optional[Union[Tuple[str], List[str]]] = (
+        "gene_symbol",
+        "most_severe_consequence",
+        "lof",
+        "lof_flags",
+    ),
+) -> hl.Table:
+    """
+    Aggregate transcript-based expression values or expression proportion from GTEx.
+
+    :param ht: Table of variants annotated with transcript expression information.
+    :param agg_annotations: Optional list of annotations to aggregate. Default is
+        ['transcript_expression', 'expression_proportion', 'exp_prop_mean'].
+    :param additional_group_by: Optional list of additional fields to group by before
+        sum aggregation.
+    :return: Table of variants with transcript expression information aggregated.
+    """
+    tissues = hl.eval(ht.tissues)
+    # TODO: to key by only locus to get base-level annotation
+    grouping = ["locus", "alleles", "gene_id"] + list(additional_group_by)
 
     # Aggregate the transcript expression information by gene_id and annotation in
     # additional_group_by.
-    variant_to_tx = tx_ht[ht.transcript_id, ht.gene_id]
-    grouping = ["locus", "alleles", "gene_id"] + list(additional_group_by)
     ht = ht.group_by(*grouping).aggregate(
-        **{a: hl.agg.array_sum(variant_to_tx[a]) for a in agg_annotations},
-        exp_prop_mean=hl.agg.sum(variant_to_tx.exp_prop_mean),
+        **{a: hl.agg.array_sum(ht[a]) for a in agg_annotations},
+        exp_prop_mean=hl.agg.sum(ht.exp_prop_mean),
     )
 
     # Reformat the transcript expression information to be a struct per tissue.

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -216,10 +216,9 @@ def tissue_expression_ht_to_array(
     return ht
 
 
-def preprocess_variants_for_tx(
+def tx_filter_variants_by_csqs(
     ht: hl.Table,
     filter_to_cds: bool = True,
-    filter_by_amino_acids: bool = True,
     gencode_ht: Optional[hl.Table] = None,
     filter_to_genes: Optional[List[str]] = None,
     match_by_gene_symbol: bool = False,
@@ -229,18 +228,19 @@ def preprocess_variants_for_tx(
     vep_root: str = "vep",
 ) -> hl.Table:
     """
-    Prepare a Table of variants with vep transcript consequences for annotation.
+    Prepare a Table of variants with VEP transcript consequences for annotation.
 
     :param ht: Table of variants with 'vep' annotations.
     :param gencode_ht: Optional Gencode resource Table containing CDS interval
-        information. Default is None, which will use the default version of the Gencode
-        Table resource for the reference build of the input Table `ht`.
+        information. This is only used when `filter_to_cds` is set to True. Default is
+        None, which will use the default version of the Gencode Table resource for
+        the reference build of the input Table `ht`.
     :param filter_to_cds: Whether to filter to CDS regions. Default is True.
     :param filter_to_genes: Optional list of genes to filter to. Default is None.
     :param match_by_gene_symbol: Whether to match by gene symbol instead of gene ID.
         Default is False.
     :param filter_to_csqs: Optional list of consequences to filter to. Default is None.
-    :param ignore_splicing: If True, ignore splice variants. Default is True.
+    :param ignore_splicing: If True, ignore splice consequences. Default is True.
     :param filter_to_protein_coding: Whether to filter to protein coding transcripts.
         Default is True.
     :param vep_root: Name used for root VEP annotation. Default is 'vep'.
@@ -273,7 +273,9 @@ def preprocess_variants_for_tx(
         keep_csqs=keep_csqs,
         genes=filter_to_genes,
         match_by_gene_symbol=match_by_gene_symbol,
-        amio_acids=filter_by_amino_acids,
+        additional_filtering_criteria=(
+            lambda csq: (csq.amino_acids is not None) & (csq.amino_acids != "*")
+        ),
     )
 
 
@@ -287,18 +289,18 @@ def tx_annotate_variants(
     """
     Annotate variants with transcript-based expression values or expression proportion from GTEx.
 
-    :param ht: Table of variants to annotate, it should contain at least the following
-        nested fields: `vep.transcript_consequences`, `freq`.
+    :param ht: Table of variants to annotate, it should contain the nested fields:
+        `vep.transcript_consequences`.
     :param tx_ht: Table of transcript expression information.
     :param tissues_to_filter: Optional list of tissues to exclude from the output.
     :param vep_root: Name used for root VEP annotation. Default is 'vep'.
-    :param vep_annotation: Name of annotation in 'vep' annotation,
-        one of the processed consequences: ["transcript_consequences",
-        "worst_csq_by_gene", "worst_csq_for_variant",
-        "worst_csq_by_gene_canonical", "worst_csq_for_variant_canonical"].
-        For example, if you want to annotate each variant with the worst
-        consequence in each gene it falls on and the transcript expression,
-        you would use "worst_csq_by_gene". Default is "transcript_consequences".
+    :param vep_annotation: Name of annotation in `vep_root`, one of the processed
+        consequences: ["transcript_consequences", "worst_csq_by_gene",
+        "worst_csq_for_variant", "worst_csq_by_gene_canonical",
+        "worst_csq_for_variant_canonical"]. For example, if you want to annotate
+        each variant with the worst consequence in each gene it falls on and the
+        transcript expression, you would use "worst_csq_by_gene". Default is
+        "transcript_consequences".
     :return: Input Table with transcript expression information annotated.
     """
     # Filter to tissues of interest.
@@ -364,7 +366,7 @@ def tx_aggregate_variants(
     return ht
 
 
-def process_annotate_aggregate_variants(
+def combined_tx_pipeline(
     ht: hl.Table,
     tx_ht: hl.Table,
     tissues_to_filter: Optional[List[str]] = None,
@@ -381,7 +383,7 @@ def process_annotate_aggregate_variants(
     **kwargs,
 ) -> hl.Table:
     """
-    One-stop usage of preprocess_variants_for_tx, tx_annotate_variants and tx_aggregate_variants.
+    One-stop usage of `tx_filter_variants_by_csqs`, `tx_annotate_variants` and `tx_aggregate_variants`.
 
     :param ht: Table of variants to annotate, it should contain at least the
          following nested fields: `vep.transcript_consequences`, `freq`.
@@ -397,7 +399,7 @@ def process_annotate_aggregate_variants(
     :return: Table of variants with transcript expression information aggregated.
     """
     tx_ht = tx_annotate_variants(
-        preprocess_variants_for_tx(
+        tx_filter_variants_by_csqs(
             ht, vep_root=vep_root, filter_to_csqs=filter_to_csqs, **kwargs
         ),
         tx_ht,

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -406,6 +406,8 @@ def process_annotate_aggregate_variants(
 
     tx_ht = tx_aggregate_variants(tx_ht, additional_group_by=additional_group_by)
     tx_ht = tx_ht.collect_by_key("tx_annotation")
-    ht = ht.annotate(**tx_ht[ht.key])
+    ht = ht.annotate(**tx_ht[ht.key]).annotate_globals(
+        tissues=tx_ht.index_globals().tissues
+    )
 
     return ht

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -219,6 +219,7 @@ def tissue_expression_ht_to_array(
 def preprocess_variants_for_tx(
     ht: hl.Table,
     filter_to_cds: bool = True,
+    filter_by_amino_acids: bool = True,
     gencode_ht: Optional[hl.Table] = None,
     filter_to_genes: Optional[List[str]] = None,
     match_by_gene_symbol: bool = False,
@@ -272,6 +273,7 @@ def preprocess_variants_for_tx(
         keep_csqs=keep_csqs,
         genes=filter_to_genes,
         match_by_gene_symbol=match_by_gene_symbol,
+        amio_acids=filter_by_amino_acids,
     )
 
 

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -4,7 +4,7 @@ from typing import Callable, List, Optional, Tuple, Union
 
 import hail as hl
 
-from gnomad.utils.vep import process_consequences
+from gnomad.utils.vep import CSQ_CODING_HIGH_IMPACT, process_consequences
 
 logging.basicConfig(
     format="%(asctime)s (%(name)s %(lineno)s): %(message)s",
@@ -307,7 +307,7 @@ def tx_aggregate_variants(
     :return: Table of variants with transcript expression information aggregated.
     """
     tissues = hl.eval(ht.tissues)
-    # TODO: to key by only locus to get base-level annotation
+    # TODO: group_by and key_by locus to get base-level annotation
     grouping = ["locus", "alleles", "gene_id"] + list(additional_group_by)
 
     # Aggregate the transcript expression information by gene_id and annotation in

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -460,7 +460,8 @@ def filter_vep_to_gene_list(
        all variants that are annotated to the gene, including
        ['upstream_gene_variant', 'downstream_gene_variant'], which will not be the
        same as if you filter to a gene interval. If you only want variants inside
-       certain gene boundaries and a faster filter, you can first filter `t` to an interval list and then apply this filter.
+       certain gene boundaries and a faster filter, you can first filter `t` to an
+       interval list and then apply this filter.
 
     :param t: Input Table or MatrixTable.
     :param genes: Genes of interest to filter VEP transcript consequences to.

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -81,11 +81,19 @@ CSQ_ORDER = (
     + CSQ_NON_CODING
 )
 
-SPLICE_CSQS = [
+CSQ_CODING = CSQ_CODING_HIGH_IMPACT + CSQ_CODING_MEDIUM_IMPACT + CSQ_CODING_LOW_IMPACT
+"""
+Constant containing all coding consequences.
+"""
+
+CSQ_SPLICE = [
     "splice_acceptor_variant",
     "splice_donor_variant",
     "splice_region_variant",
 ]
+"""
+Constant containing all splice consequences.
+"""
 
 POSSIBLE_REFS = ("GRCh37", "GRCh38")
 """

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -711,6 +711,7 @@ def filter_vep_transcript_csqs(
     genes: Optional[List[str]] = None,
     keep_genes: bool = True,
     match_by_gene_symbol: bool = False,
+    amio_acids: bool = False,
 ) -> Union[hl.Table, hl.MatrixTable]:
     """
     Filter VEP transcript consequences based on specified criteria, and optionally filter to variants where transcript consequences is not empty after filtering.
@@ -751,6 +752,8 @@ def filter_vep_transcript_csqs(
         Default is True.
     :param match_by_gene_symbol: Whether to match values in `genes` to VEP transcript
         consequences by 'gene_symbol' instead of 'gene_id'. Default is False.
+    :param amio_acids: Whether to filter to variants whose amic_acids annotation is
+        defined (not None or '*'). Default is False.
     :return: Table or MatrixTable filtered to specified criteria.
     """
     if not synonymous and not (canonical or mane_select) and not filter_empty_csq:
@@ -788,6 +791,11 @@ def filter_vep_transcript_csqs(
             criteria.append(lambda csq: genes.contains(csq[gene_field]))
         else:
             criteria.append(lambda csq: ~genes.contains(csq[gene_field]))
+    if amio_acids:
+        logger.info("Filtering to variants with defined amio_acids annotation...")
+        criteria.append(
+            lambda csq: (csq.amino_acids is not None) & (csq.amino_acids != "*")
+        )
 
     transcript_csqs = transcript_csqs.filter(lambda x: combine_functions(criteria, x))
     is_mt = isinstance(t, hl.MatrixTable)

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -801,7 +801,7 @@ def filter_vep_transcript_csqs(
             criteria.append(lambda csq: ~genes.contains(csq[gene_field]))
     if additional_filtering_criteria is not None:
         logger.info("Filtering to variants with additional criteria...")
-        criteria = criteria.append(additional_filtering_criteria)
+        criteria = criteria + [additional_filtering_criteria]
 
     transcript_csqs = transcript_csqs.filter(lambda x: combine_functions(criteria, x))
     is_mt = isinstance(t, hl.MatrixTable)

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -456,12 +456,11 @@ def filter_vep_to_gene_list(
 
     .. note::
 
-       Filtering to a list of genes by their gene_id or gene_symbol will filter to
+       Filtering to a list of genes by their 'gene_id' or 'gene_symbol' will filter to
        all variants that are annotated to the gene, including
        ['upstream_gene_variant', 'downstream_gene_variant'], which will not be the
        same as if you filter to a gene interval. If you only want variants inside
-       certain gene boundaries and filter faster, you can filter the variant first to an
-       interval list and further filter to specific genes.
+       certain gene boundaries and a faster filter, you can first filter `t` to an interval list and then apply this filter.
 
     :param t: Input Table or MatrixTable.
     :param genes: Genes of interest to filter VEP transcript consequences to.
@@ -720,7 +719,7 @@ def filter_vep_transcript_csqs(
     genes: Optional[List[str]] = None,
     keep_genes: bool = True,
     match_by_gene_symbol: bool = False,
-    additional_filtering_criteria: Optional[Callable] = None,
+    additional_filtering_criteria: Optional[List[Callable]] = None,
 ) -> Union[hl.Table, hl.MatrixTable]:
     """
     Filter VEP transcript consequences based on specified criteria, and optionally filter to variants where transcript consequences is not empty after filtering.
@@ -761,7 +760,7 @@ def filter_vep_transcript_csqs(
         Default is True.
     :param match_by_gene_symbol: Whether to match values in `genes` to VEP transcript
         consequences by 'gene_symbol' instead of 'gene_id'. Default is False.
-    :param additional_filtering_criteria: Optional filtering criteria to apply to.
+    :param additional_filtering_criteria: Optional list of additional filtering criteria to apply to the VEP transcript consequences.
     :return: Table or MatrixTable filtered to specified criteria.
     """
     if not synonymous and not (canonical or mane_select) and not filter_empty_csq:
@@ -801,7 +800,7 @@ def filter_vep_transcript_csqs(
             criteria.append(lambda csq: ~genes.contains(csq[gene_field]))
     if additional_filtering_criteria is not None:
         logger.info("Filtering to variants with additional criteria...")
-        criteria = criteria + [additional_filtering_criteria]
+        criteria = criteria + additional_filtering_criteria
 
     transcript_csqs = transcript_csqs.filter(lambda x: combine_functions(criteria, x))
     is_mt = isinstance(t, hl.MatrixTable)

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -81,6 +81,12 @@ CSQ_ORDER = (
     + CSQ_NON_CODING
 )
 
+SPLICE_CSQS = [
+    "splice_acceptor_variant",
+    "splice_donor_variant",
+    "splice_region_variant",
+]
+
 POSSIBLE_REFS = ("GRCh37", "GRCh38")
 """
 Constant containing supported references
@@ -282,7 +288,7 @@ def process_consequences(
 
     `most_severe_consequence` is the worst consequence for a transcript.
 
-    :param mt: Input MT.
+    :param mt: Input Table or MatrixTable.
     :param vep_root: Root for vep annotation (probably vep).
     :param penalize_flags: Whether to penalize LOFTEE flagged variants, or treat them
         as equal to HC.
@@ -719,7 +725,7 @@ def filter_vep_transcript_csqs(
     :param filter_empty_csq: Whether to filter out rows where 'transcript_consequences'
         is empty, after filtering 'transcript_consequences' to the specified criteria.
         Default is True.
-    :param ensembl_only: Whether to filter to only Ensembl transcipts. This option is
+    :param ensembl_only: Whether to filter to only Ensembl transcripts. This option is
         useful for deduplicating transcripts that are the same between RefSeq and
         Emsembl. Default is True.
     :param protein_coding: Whether to filter to only protein-coding transcripts.

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -292,7 +292,7 @@ def process_consequences(
     def find_worst_transcript_consequence(
         tcl: hl.expr.ArrayExpression,
     ) -> hl.expr.StructExpression:
-        """Get worst transcript_consequence from an array of em."""
+        """Get the worst transcript_consequence from an array of all annotated transcript consequences."""
         flag_score = 500
         no_flag_score = flag_score * (1 + penalize_flags)
 

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -761,7 +761,8 @@ def filter_vep_transcript_csqs(
         Default is True.
     :param match_by_gene_symbol: Whether to match values in `genes` to VEP transcript
         consequences by 'gene_symbol' instead of 'gene_id'. Default is False.
-    :param additional_filtering_criteria: Optional list of additional filtering criteria to apply to the VEP transcript consequences.
+    :param additional_filtering_criteria: Optional list of additional filtering
+        criteria to apply to the VEP transcript consequences.
     :return: Table or MatrixTable filtered to specified criteria.
     """
     if not synonymous and not (canonical or mane_select) and not filter_empty_csq:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("requirements.txt", "r") as requirements_file:
 
 setuptools.setup(
     name="gnomad",
-    version="0.7.0",
+    version="0.7.1",
     author="The Genome Aggregation Database",
     author_email="gnomad@broadinstitute.org",
     description="Hail utilities for the Genome Aggregation Database",


### PR DESCRIPTION
Modifications: 
- change `process_consequences`, `filter_vep_transcript_csqs` and `preprocess_variants_for_tx` to process and filter variants; 
- move `import_gencode` into `resources_utils.py` since it's versatile in any genome build. 

Additions: 
- `filter_vep_to_gene_list`, `import_gencode`,  and `filter_to_gencode_cds` to filter variants; 
- a few more globals concerning variant consequences in `vep.py`; 
- `tx_filter_variants_by_csqs`, `tx_annotate_variants`, `tx_aggregate_variants` and an ensemble function `perform_tx_annotation_pipeline` to combine the first 3 functions; 