### PR TITLE
Suggestions to get_expression_proportion PR

### DIFF
--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -1,6 +1,6 @@
 """Utils module containing generic functions that are useful for adding transcript expression-aware annotations."""
 import logging
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import hail as hl
 
@@ -52,17 +52,63 @@ def summarize_transcript_expression(
     mt = mt.group_cols_by(tissue=tissue_expr).aggregate(
         tx=summary_agg_func(transcript_expression_expr)
     )
+    ht = mt.rename({"tx": ""}).make_table().key_by("transcript_id", "gene_id")
 
-    transcript_ht = mt.rename({"tx": ""}).make_table()
-    transcript_ht = transcript_ht.key_by("transcript_id", "gene_id")
+    # Annotate with the proportion of expression of transcript to gene per tissue.
+    ht = ht.annotate(expression_proportion=get_expression_proportion(ht))
+    ht = ht.select(
+        **{
+            t: hl.struct(
+                transcript_expression=ht[t],
+                expression_proportion=ht.expression_proportion[t],
+            )
+            for t in ht.expression_proportion
+        }
+    )
 
-    return transcript_ht
+    return ht
+
+
+def filter_expression_ht_by_tissues(
+    ht: hl.Table,
+    tissues_to_keep: Optional[List[str]] = None,
+    tissues_to_filter: Optional[List[str]] = None,
+) -> hl.Table:
+    """
+    Filter a Table with a row annotation for each tissue to only include specified tissues.
+
+    :param ht: Table with a row annotation for each tissue.
+    :param tissues_to_keep: Optional list of tissues to keep in the Table. Default is
+        all non-key rows in the Table.
+    :param tissues_to_filter: Optional list of tissues to exclude from the Table.
+    :return: Table with only specified tissues.
+    """
+    if tissues_to_keep is None and tissues_to_filter is None:
+        logger.info(
+            "No tissues_to_keep or tissues_to_filter specified. Returning input Table."
+        )
+        return ht
+
+    if tissues_to_keep is None:
+        tissues = list(ht.row_value)
+
+    if tissues_to_filter is not None:
+        logger.info("Filtering tissues: %s", tissues_to_filter)
+        tissues = [t for t in tissues if t not in tissues_to_filter]
+
+    ht = ht.select(tissues)
+
+    return ht
 
 
 def tissue_expression_ht_to_array(
     ht: hl.Table,
-    tissues: Optional[List[str]] = None,
+    tissues_to_keep: Optional[List[str]] = None,
     tissues_to_filter: Optional[List[str]] = None,
+    annotations_to_extract: Optional[Union[Tuple[str], List[str]]] = (
+        "transcript_expression",
+        "expression_proportion",
+    ),
 ) -> hl.Table:
     """
     Convert a Table with a row annotation for each tissue to a Table with tissues as an array.
@@ -72,66 +118,55 @@ def tissue_expression_ht_to_array(
     indicated by the "tissues" global annotation.
 
     :param ht: Table with a row annotation for each tissue.
-    :param tissues: Optional list of tissues to keep in the 'tissue_expression' array.
-        Default is all non-key rows in the Table.
+    :param tissues_to_keep: Optional list of tissues to keep in the 'tissue_expression'
+        array. Default is all non-key rows in the Table.
     :param tissues_to_filter: Optional list of tissues to exclude from the tissue
         expression array.
-    :return: Table with a field 'tissue_expression' containing an array of summarized
-        expression values by tissue.
+    :param annotations_to_extract: Optional list of tissue struct fields to extract
+        into top level array annotations. If None, the returned Table will contain a
+        single top level annotation 'tissue_expression' that contains an array of
+        structs by tissue. Default is ('transcript_expression', 'expression_proportion').
+    :return: Table with requested tissue struct annotations pulled into arrays of
+        tissue values and a 'tissues' global annotation indicating the order of tissues
+        in the arrays.
     """
-    if tissues is None:
-        tissues = list(ht.row_value)
+    ht = filter_expression_ht_by_tissues(ht, tissues_to_keep, tissues_to_filter)
 
-    if tissues_to_filter is not None:
-        logger.info("Filtering tissues: %s", tissues_to_filter)
-        tissues = [t for t in tissues if t not in tissues_to_filter]
-
+    tissues = list(ht.row_value)
     ht = ht.select_globals(tissues=tissues)
     ht = ht.select(tissue_expression=[ht[t] for t in tissues])
+
+    if annotations_to_extract is not None:
+        ht = ht.select(
+            **{
+                a: ht.tissue_expression.map(lambda x: x[a])
+                for a in annotations_to_extract
+            }
+        )
 
     return ht
 
 
-def get_expression_proportion(
-    transcript_ht: hl.Table,
-    tissues_to_filter: Optional[List[str]] = None,
-) -> hl.Table:
+def get_expression_proportion(ht: hl.Table) -> hl.expr.StructExpression:
     """
     Calculate the proportion of expression of transcript to gene per tissue.
 
-    :param transcript_ht: Table of summarized transcript expression by tissue.
-    :param gene_ht: Table of summarized gene expression by tissue.
-    :param tissues_to_filter: Optional list of tissues to filter out
+    :param ht: Table of summarized transcript expression by tissue.
     :return: Table with expression proportion of transcript to gene per tissue
         and mean expression proportion across tissues.
     """
-    transcript_ht = tissue_expression_ht_to_array(
-        transcript_ht, tissues_to_filter=tissues_to_filter
-    )
+    tissues = list(ht.row_value)
 
     # Calculate the sum of transcript expression by gene per tissue.
-    gene_ht = transcript_ht.group_by("gene_id").aggregate(
-        expression_sum=hl.agg.array_sum(transcript_ht.tissue_expression)
+    gene_ht = ht.group_by("gene_id").aggregate(
+        **{tissue: hl.agg.sum(ht[tissue]) for tissue in tissues}
     )
 
-    # Calculate the mean expression proportion across tissues.
-    transcript_ht = transcript_ht.annotate(
-        gene_exp_sum=gene_ht[transcript_ht.gene_id].expression_sum,
-        exp_prop=hl.map(
-            lambda x, y: x / y,
-            transcript_ht.tissue_expression,
-            gene_ht[transcript_ht.gene_id].expression_sum,
-        ),
-        exp_prop_mean=hl.mean(
-            hl.filter(
-                lambda e: ~hl.is_nan(e),
-                hl.map(
-                    lambda x, y: x / y,
-                    transcript_ht.tissue_expression,
-                    gene_ht[transcript_ht.gene_id].expression_sum,
-                ),
-            )
-        ),
+    # Return the proportion of expression of transcript to gene per tissue.
+    gene = gene_ht[ht.gene_id]
+    return hl.struct(
+        **{
+            tissue: hl.utils.misc.divide_null(ht[tissue], gene[tissue])
+            for tissue in tissues
+        }
     )
-
-    return transcript_ht


### PR DESCRIPTION
OK, so this is one suggestion to change this based on your comment

> Im my original code, I put transcript_expression, gene_expression, and expression_proportion in one HT, it was clearer to me that way. And pext scores on v2 exomes are actually showing the expression_proportion, unless we will change that.

We could also add gene_expression if you think that would be helpful, and it would have the `expression_proportion` you mention is what is actually shown.
