### PR TITLE
amr dict value description fix

### DIFF
--- a/gnomad/sample_qc/ancestry.py
+++ b/gnomad/sample_qc/ancestry.py
@@ -22,7 +22,7 @@ logger.setLevel(logging.INFO)
 POP_NAMES = {
     "afr": "African/African-American",
     "ami": "Amish",
-    "amr": "Latino",
+    "amr": "Admixed American",
     "asj": "Ashkenazi Jewish",
     "eas": "East Asian",
     "eur": "European",

--- a/gnomad/sample_qc/ancestry.py
+++ b/gnomad/sample_qc/ancestry.py
@@ -32,6 +32,7 @@ POP_NAMES = {
     "mid": "Middle Eastern",
     "nfe": "Non-Finnish European",
     "oth": "Other",
+    "remaining": "Remaining individuals",
     "sas": "South Asian",
     "uniform": "Uniform",
     "sas_non_consang": "South Asian (F < 0.05)",


### PR DESCRIPTION
We missed updating "amr" from "Latino" to "Admixed American" in v4.0. This addresses https://github.com/broadinstitute/gnomad_production/issues/1305. 

 This also adds "remaining" to the pop_name dict so we do not have to treat it special like we did in v4.0:https://github.com/broadinstitute/gnomad_qc/blob/b87f62a7fba9473b73bee9cea927bf4559fabfb2/gnomad_qc/v4/create_release/validate_and_export_vcf.py#L135

