### PR TITLE
Add mid to FAF and grpmax calcs

### DIFF
--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -221,7 +221,10 @@ TGP_POP_NAMES = {
 """
 
 POPS_STORED_AS_SUBPOPS = TGP_POPS + HGDP_POPS
-POPS_TO_REMOVE_FOR_POPMAX = {"asj", "fin", "oth", "ami", "remaining"}
+POPS_TO_REMOVE_FOR_POPMAX = {
+    "v3": {"asj", "fin", "mid", "oth", "ami", "remaining"},
+    "v4": {"asj", "fin", "oth", "ami", "remaining"},
+}
 """
 Populations that are removed before popmax calculations.
 """

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -221,7 +221,7 @@ TGP_POP_NAMES = {
 """
 
 POPS_STORED_AS_SUBPOPS = TGP_POPS + HGDP_POPS
-POPS_TO_REMOVE_FOR_POPMAX = {"asj", "fin", "oth", "ami", "mid", "remaining"}
+POPS_TO_REMOVE_FOR_POPMAX = {"asj", "fin", "oth", "ami", "remaining"}
 """
 Populations that are removed before popmax calculations.
 """

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -39,7 +39,7 @@ HISTS = ["gq_hist_alt", "gq_hist_all", "dp_hist_alt", "dp_hist_all", "ab_hist_al
 Quality histograms used in VCF export.
 """
 
-FAF_POPS = ["afr", "amr", "eas", "nfe", "sas"]
+FAF_POPS = ["afr", "amr", "eas", "mid", "nfe", "sas"]
 """
 Global populations that are included in filtering allele frequency (faf) calculations. Used in VCF export.
 """

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -39,7 +39,10 @@ HISTS = ["gq_hist_alt", "gq_hist_all", "dp_hist_alt", "dp_hist_all", "ab_hist_al
 Quality histograms used in VCF export.
 """
 
-FAF_POPS = ["afr", "amr", "eas", "mid", "nfe", "sas"]
+FAF_POPS = {
+    "v3": ["afr", "amr", "eas", "nfe", "sas"],
+    "v4": ["afr", "amr", "eas", "mid", "nfe", "sas"],
+}
 """
 Global populations that are included in filtering allele frequency (faf) calculations. Used in VCF export.
 """


### PR DESCRIPTION
The genetic ancestry group Middle Eastern should be considered in `grpmax` and `faf` calculations for v4. This was not considered in v3 so we're splitting these globals into version specific dictionaries where the keys are gnomad versions and values are the genetic ancestry groups. This follows the behavior of POPS.