### PR TITLE
Function to get max pext per gene

### DIFF
--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -485,8 +485,15 @@ def get_max_pext_per_gene(ht: hl.Table) -> hl.Table:
     :return: Table of maximum transcript expression proportion per gene and maximum
         mean transcript expression proportion across all tissues for each gene.
     """
-    # TODO: Use isinstance to check if tx_annotation is already a struct.
     # TODO: Should we make it compatible with existing v2 pext?
+    # If the input Table already has a 'tx_annotation' field, use it.
+    if "tx_annotation" in ht.row:
+        ht = ht.select(**ht.tx_annotation)
+    if ["gene_id", "gene_symbol", "most_severe_consequence"] not in ht.row:
+        raise ValueError(
+            "Input Table must have 'gene_id', 'gene_symbol', and"
+            " 'most_severe_consequence' fields."
+        )
     tissues = hl.eval(ht.tissues)
     csq_all = hl.literal(set(CSQ_CODING_ALL_IMPACT))
 

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -548,7 +548,7 @@ def get_max_pext_per_gene(
     if "tx_annotation" in ht.row:
         ht = ht.explode("tx_annotation")
         ht = ht.select(**ht.tx_annotation)
-    if ["gene_id", "gene_symbol", "most_severe_consequence"] not in ht.row:
+    if tuple(["gene_id", "gene_symbol", "most_severe_consequence"]) not in ht.row:
         raise ValueError(
             "Input Table must have 'gene_id', 'gene_symbol', and"
             " 'most_severe_consequence' fields."

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -484,6 +484,8 @@ def get_max_pext_per_gene(ht: hl.Table) -> hl.Table:
     :return: Table of maximum transcript expression proportion per gene and maximum
         mean transcript expression proportion across all tissues for each gene.
     """
+    # TODO: Use isinstance to check if tx_annotation is already a struct.
+    # TODO: Should we make it compatible with existing v2 pext?
     tissues = hl.eval(ht.tissues)
     csq_all = hl.literal(set(CSQ_CODING_ALL_IMPACT))
 

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -466,17 +466,18 @@ def get_max_pext_per_gene(ht: hl.Table) -> hl.Table:
     Get the maximum pext value of each gene.
 
     .. note::
-        For a minority of genes, when RSEM assigns higher relative expression to
+        "For a minority of genes, when RSEM assigns higher relative expression to
         non-coding transcripts, the sum of the value of coding transcripts can be
-        much smaller than the gene expression value for the transcript, resulting in
+        much smaller than the gene expression value of all transcripts, resulting in
         low pext scores for all coding variants in the gene, and thus resulting in
         possible filtering of all variants for a given gene. In many cases this
         appears to be the result of spurious non-coding transcripts with a high
         degree of exon overlap with true coding transcripts.
 
-        To get around this artifact from affecting our analyses, you can calculate
+        To get around this artifact from affecting the analyses, you can calculate
         the maximum pext score for all variants across all protein coding genes,
-        and removed any gene where the maximum pext score is below a given threshold.
+        and removed any gene where the maximum pext score is below a given threshold."
+        -- adapted from https://doi.org/10.1038/s41586-020-2329-2
 
     :param ht: Table of variants annotated with transcript expression information,
         and aggregated by additional grouping fields, including at least 'gene_id',

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -548,10 +548,12 @@ def get_max_pext_per_gene(
     if "tx_annotation" in ht.row:
         ht = ht.explode("tx_annotation")
         ht = ht.select(**ht.tx_annotation)
-    if tuple(["gene_id", "gene_symbol", "most_severe_consequence"]) not in ht.row:
+
+    required_fields = ["gene_id", "gene_symbol", "most_severe_consequence"]
+    if not all(field in ht.row for field in required_fields):
         raise ValueError(
-            "Input Table must have 'gene_id', 'gene_symbol', and"
-            " 'most_severe_consequence' fields."
+            "Input Table must have 'gene_id', 'gene_symbol', "
+            "and 'most_severe_consequence' fields."
         )
 
     tissues = hl.eval(ht.tissues)

--- a/gnomad/utils/transcript_annotation.py
+++ b/gnomad/utils/transcript_annotation.py
@@ -368,7 +368,7 @@ def tx_aggregate_variants(
     return ht
 
 
-def combined_tx_pipeline(
+def perform_tx_based_annotation_pipeline(
     ht: hl.Table,
     tx_ht: hl.Table,
     tissues_to_filter: Optional[List[str]] = None,
@@ -411,7 +411,6 @@ def combined_tx_pipeline(
     )
 
     tx_ht = tx_aggregate_variants(tx_ht, additional_group_by=additional_group_by)
-    tx_ht = tx_ht.collect_by_key("tx_annotation")
 
     return tx_ht
 

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -51,6 +51,10 @@ CSQ_CODING_LOW_IMPACT = [
     "coding_sequence_variant",
 ]
 
+CSQ_CODING_ALL_IMPACT = (
+    CSQ_CODING_HIGH_IMPACT + CSQ_CODING_MEDIUM_IMPACT + CSQ_CODING_LOW_IMPACT
+)
+
 CSQ_NON_CODING = [
     "mature_miRNA_variant",
     "5_prime_UTR_variant",

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -51,10 +51,6 @@ CSQ_CODING_LOW_IMPACT = [
     "coding_sequence_variant",
 ]
 
-CSQ_CODING_ALL_IMPACT = (
-    CSQ_CODING_HIGH_IMPACT + CSQ_CODING_MEDIUM_IMPACT + CSQ_CODING_LOW_IMPACT
-)
-
 CSQ_NON_CODING = [
     "mature_miRNA_variant",
     "5_prime_UTR_variant",


### PR DESCRIPTION
This is an optional function to get maximum pext score per gene, by filtering to only coding variants and aggregating by gene, in case the transcript expression proportion of coding transcripts is smaller than that of non-coding transcripts in a gene. 
