### PR TITLE
Account for missingness in int64 to int32 VCF type conversion

### DIFF
--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -561,7 +561,12 @@ def adjust_vcf_incompatible_types(
                 f,
             )
             info_type_convert_expr.update(
-                {f: hl.int32(hl.min(2**31 - 1, ht.info[f]))}
+                {
+                    f: hl.or_missing(
+                        hl.is_defined(ht.info[f]),
+                        hl.int32(hl.min(2**31 - 1, ht.info[f])),
+                    )
+                }
             )
         elif ft == hl.dtype("array<int64>"):
             logger.warning(
@@ -570,7 +575,13 @@ def adjust_vcf_incompatible_types(
                 f,
             )
             info_type_convert_expr.update(
-                {f: ht.info[f].map(lambda x: hl.int32(hl.min(2**31 - 1, x)))}
+                {
+                    f: ht.info[f].map(
+                        lambda x: hl.or_missing(
+                            hl.is_defined(x), hl.int32(hl.min(2**31 - 1, x))
+                        )
+                    )
+                }
             )
 
     ht = ht.annotate(info=ht.info.annotate(**info_type_convert_expr))


### PR DESCRIPTION
The adjust_vcf_incompatible_types function does not account for missingness in the int64 -> int32 conversion. Current behavior will make any missing int64 the max int32 value, `2147483647`. This was seen in the v4 exome chrY VCF where the int64 field was converted to int32s but all missing values (homozygote counts  within the freq array for XX groupings on chrY) where made 2147483647. This fixes the function by only converting defined values and leaving them missing otherwise. 