### PR TITLE
Pull ploidy optimization into a function

### DIFF
--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -34,6 +34,8 @@ def adjusted_sex_ploidy_expr(
     :param xx_karyotype_str: String representing XX karyotype. Default is "XX".
     :return: Genotype adjusted for sex ploidy
     """
+    # An optimization that annotates the locus's matrix table with the
+    # fields in the case statements below as an optimization step
     col_idx, row_idx = prep_ploidy_ht(
         locus_expr, karyotype_expr, xy_karyotype_str, xx_karyotype_str
     )

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -631,7 +631,8 @@ def prep_ploidy_ht(
     """
     source_mt = locus_expr._indices.source
     col_ht = source_mt.annotate_cols(
-        xy=karyotype_expr == xy_karyotype_str, xx=karyotype_expr == xx_karyotype_str
+        xy=karyotype_expr.upper() == xy_karyotype_str,
+        xx=karyotype_expr.upper() == xx_karyotype_str,
     ).cols()
     row_ht = source_mt.annotate_rows(
         in_non_par=~locus_expr.in_autosome_or_par(),
@@ -678,7 +679,8 @@ def get_is_haploid_expr(
             "Both 'locus_expr' and 'karyotype_expr' are required if no 'gt_expr' is "
             "supplied."
         )
-
+    # An optimization that annotates the locus's matrix table with the
+    # fields in the case statements below as an optimization step
     col_idx, row_idx = prep_ploidy_ht(
         locus_expr, karyotype_expr, xy_karyotype_str, xx_karyotype_str
     )
@@ -702,7 +704,7 @@ def get_dp_gq_adj_expr(
     """
     Get adj annotation using only GQ and DP.
 
-    Defaults correspond to gnomAD values.
+    Default thresholds correspond to gnomAD values.
 
     .. note::
 
@@ -722,7 +724,7 @@ def get_dp_gq_adj_expr(
     :param adj_gq: GQ threshold for adj. Default is 20.
     :param adj_dp: DP threshold for adj. Default is 10.
     :param haploid_adj_dp: Haploid DP threshold for adj. Default is 5.
-    :return: Boolean expression indicating adj filter using GQ and DP.
+    :return: Boolean expression indicating adj filter.
     """
     return (gq_expr >= adj_gq) & hl.if_else(
         get_is_haploid_expr(gt_expr, locus_expr, karyotype_expr),
@@ -2121,7 +2123,7 @@ def agg_by_strata(
         to stratify the aggregations by. If not provided, the 'group_membership'
         annotation is expected to be present on `mt`.
     :param entry_agg_group_membership: Optional dict indicating the subset of group
-        strata in 'freq_meta' to use the entry aggregation functions on. The keys of
+        strata in 'freq_meta' to run the entry aggregation functions on. The keys of
         the dict can be any of the keys in `entry_agg_funcs` and the values are lists
         of dicts. Each dict in the list contains the strata in 'freq_meta' to use for
         the corresponding entry aggregation function. If provided, 'freq_meta' must be
@@ -2180,8 +2182,8 @@ def agg_by_strata(
 
     if entry_agg_group_membership is not None and "freq_meta" not in group_globals:
         raise ValueError(
-            "The 'freq_meta' global annotation is not found and "
-            "'entry_agg_group_membership' is specified."
+            "The 'freq_meta' global annotation must be supplied when the"
+            " 'entry_agg_group_membership' is specified."
         )
 
     entry_agg_group_membership = entry_agg_group_membership or {}
@@ -2257,6 +2259,9 @@ def agg_by_strata(
         )
 
     # Add annotations for any supplied entry transform and aggregation functions.
+    # Filter groups to only those in entry_agg_group_membership if specified.
+    # If there are no specific entry group indices for an annotation, use ht[g]
+    # to consider all groups without filtering.
     ht = ht.select(
         *select_fields,
         **{


### PR DESCRIPTION
I figured there was redundancy in the current code so pulled it out into a function. It probably should be a private module function, `_prep_ploidy_ht`, but since the two functions that use it are in different modules, it seems like not the best practive to import a "private" function so decided against it. Everything else looks good, mostly just a few comments.