### PR TITLE
Update ancestry population names in gks method to always use v4

### DIFF
--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -572,11 +572,7 @@ def gnomad_gks(
         ht = ht.annotate(fraction_cov_over_20=coverage_ht[ht.locus].over_20)
 
     # Retrieve ancestry groups from the imported POPS dictionary.
-    pops_list = (
-        list(POPS["v4" if data_type == "exomes" else "v3"])
-        if by_ancestry_group
-        else None
-    )
+    pops_list = list(POPS["v4"]) if by_ancestry_group else None
 
     # Throw warnings if contradictory arguments are passed.
     if by_ancestry_group and vrs_only:


### PR DESCRIPTION
Annotating v4 genomes now fails since the v4 genomes table uses ancestry population names from v4. This fixes that.