### PR TITLE
remove hardcoding of v4 in gnomad_gks

### DIFF
--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -599,7 +599,7 @@ def gnomad_gks(
         ht = ht.annotate(fraction_cov_over_20=coverage_ht[ht.locus].over_20)
 
     # Retrieve ancestry groups from the imported POPS dictionary.
-    pops_list = list(POPS["v4"][data_type]) if by_ancestry_group else None
+    pops_list = list(POPS[high_level_version][data_type]) if by_ancestry_group else None
 
     # Throw warnings if contradictory arguments are passed.
     if by_ancestry_group and vrs_only:


### PR DESCRIPTION
Just making this more flexible for the future, there's a warning a few lines above that gnomad_gks() is currently only implemented for gnomAD v4