### PR TITLE
Fix `generic_field_check` in validity_checks.py print of failed checks

### DIFF
--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -313,8 +313,11 @@ def summarize_variant_filters(
     )
     _filter_agg_order(t, {"is_filtered": t.is_filtered})
 
-    logger.info("Checking distributions of variant type amongst variant filters...")
-    _filter_agg_order(t, {"allele_type": t.info.allele_type})
+    add_agg_expr = {}
+    if "allele_type" in t.info:
+        logger.info("Checking distributions of variant type amongst variant filters...")
+        _filter_agg_order(t, {"allele_type": t.info.allele_type})
+        add_agg_expr["allele_type"] = t.info.allele_type
 
     logger.info(
         "Checking distributions of variant type and region type amongst variant"
@@ -322,28 +325,26 @@ def summarize_variant_filters(
     )
     _filter_agg_order(
         t,
-        {
-            "allele_type": t.info.allele_type,
-            "in_problematic_region": t.in_problematic_region,
-        },
+        {**add_agg_expr, "in_problematic_region": t.in_problematic_region},
         n_rows,
         n_cols,
     )
 
-    logger.info(
-        "Checking distributions of variant type, region type, and number of alt alleles"
-        " amongst variant filters..."
-    )
-    _filter_agg_order(
-        t,
-        {
-            "allele_type": t.info.allele_type,
-            "in_problematic_region": t.in_problematic_region,
-            "n_alt_alleles": t.info.n_alt_alleles,
-        },
-        n_rows,
-        n_cols,
-    )
+    if "n_alt_alleles" in t.info:
+        logger.info(
+            "Checking distributions of variant type, region type, and number of alt alleles"
+            " amongst variant filters..."
+        )
+        _filter_agg_order(
+            t,
+            {
+                **add_agg_expr,
+                "in_problematic_region": t.in_problematic_region,
+                "n_alt_alleles": t.info.n_alt_alleles,
+            },
+            n_rows,
+            n_cols,
+        )
 
 
 def generic_field_check_loop(

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -582,8 +582,7 @@ def check_raw_and_adj_callstats(
     field_check_expr = {}
 
     for group in ["raw", "adj"]:
-        # Check raw and adj AC and nhomalt missing if AN is missing and defined if AN
-        # is defined.
+        # Check AC and nhomalt missing if AN is missing and defined if AN is defined.
         for subfield in ["AC", "nhomalt"]:
             check_field = f"{subfield}{delimiter}{group}"
             an_field = f"AN{delimiter}{group}"
@@ -601,9 +600,7 @@ def check_raw_and_adj_callstats(
                 ),
             }
 
-    for group in ["raw", "adj"]:
-        # Check raw and adj AF missing if AN is missing and defined if AN is defined
-        # and > 0.
+        # Check AF missing if AN is missing and defined if AN is defined and > 0.
         check_field = f"AF{delimiter}{group}"
         an_field = f"AN{delimiter}{group}"
         field_check_expr[

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -311,40 +311,29 @@ def summarize_variant_filters(
     logger.info(
         "Checking distributions of filtered variants amongst variant filters..."
     )
-    _filter_agg_order(t, {"is_filtered": t.is_filtered})
+    _filter_agg_order(t, {"is_filtered": t.is_filtered}, n_rows, n_cols)
 
     add_agg_expr = {}
     if "allele_type" in t.info:
         logger.info("Checking distributions of variant type amongst variant filters...")
-        _filter_agg_order(t, {"allele_type": t.info.allele_type})
         add_agg_expr["allele_type"] = t.info.allele_type
+        _filter_agg_order(t, add_agg_expr, n_rows, n_cols)
 
-    logger.info(
-        "Checking distributions of variant type and region type amongst variant"
-        " filters..."
-    )
-    _filter_agg_order(
-        t,
-        {**add_agg_expr, "in_problematic_region": t.in_problematic_region},
-        n_rows,
-        n_cols,
-    )
+    if "in_problematic_region" in t.info:
+        logger.info(
+            "Checking distributions of variant type and region type amongst variant"
+            " filters..."
+        )
+        add_agg_expr["in_problematic_region"] = t.in_problematic_region
+        _filter_agg_order(t, add_agg_expr, n_rows, n_cols)
 
     if "n_alt_alleles" in t.info:
         logger.info(
             "Checking distributions of variant type, region type, and number of alt alleles"
             " amongst variant filters..."
         )
-        _filter_agg_order(
-            t,
-            {
-                **add_agg_expr,
-                "in_problematic_region": t.in_problematic_region,
-                "n_alt_alleles": t.info.n_alt_alleles,
-            },
-            n_rows,
-            n_cols,
-        )
+        add_agg_expr["n_alt_alleles"] = t.info.n_alt_alleles
+        _filter_agg_order(t, add_agg_expr, n_rows, n_cols)
 
 
 def generic_field_check_loop(

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -319,7 +319,7 @@ def summarize_variant_filters(
         add_agg_expr["allele_type"] = t.info.allele_type
         _filter_agg_order(t, add_agg_expr, n_rows, n_cols)
 
-    if "in_problematic_region" in t.info:
+    if "in_problematic_region" in t.row:
         logger.info(
             "Checking distributions of variant type and region type amongst variant"
             " filters..."


### PR DESCRIPTION
When checks are failing, `generic_field_check` is printing a `show()` of the first rows of the input HT instead of the first few rows that are failing the check