### PR TITLE
Update VEP csqs in impact categories to match VEP

### DIFF
--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -30,20 +30,20 @@ CSQ_CODING_HIGH_IMPACT = [
     "stop_gained",
     "frameshift_variant",
     "stop_lost",
+    "start_lost",  # Considered high impact in v105, previously medium
 ]
 
 CSQ_CODING_MEDIUM_IMPACT = [
-    "start_lost",  # new in v81
     "initiator_codon_variant",  # deprecated
     "transcript_amplification",
     "inframe_insertion",
     "inframe_deletion",
     "missense_variant",
     "protein_altering_variant",  # new in v79
-    "splice_region_variant",
 ]
 
 CSQ_CODING_LOW_IMPACT = [
+    "splice_region_variant",  # Considered low impact in v105, previously medium
     "incomplete_terminal_codon_variant",
     "start_retained_variant",  # new in v92
     "stop_retained_variant",


### PR DESCRIPTION
This moves `start_lost` from medium to high impact and `splice_region_variant` from medium to low impact. These match the current ensembl table.