### PR TITLE
Add create_vds function that only supports creating from gvcfs

### DIFF
--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -246,7 +246,7 @@ def create_vds(
         combiner_plan.json.
     :param use_genome_default_intervals: Use the default genome intervals.
     :param use_exome_default_intervals: Use the default exome intervals.
-    :param intervals: List of intervals to use.
+    :param intervals: Path to text file with intervals to use for VDS creation.
     :param gvcf_batch_size: Number of GVCFs to combine into a Variant Dataset at once.
     :return: Combined VDS.
     """
@@ -254,6 +254,7 @@ def create_vds(
         save_path = temp_path + "combiner_plan.json"
 
     gvcfs = read_list_data(gvcfs)
+    intervals = read_list_data(intervals) if intervals else None
 
     if not len(gvcfs) > 0:
         raise DataException("No GVCFs provided in file")

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -231,8 +231,9 @@ def create_vds(
     save_path: Optional[str] = None,
     use_genome_default_intervals: bool = False,
     use_exome_default_intervals: bool = False,
-    intervals: Optional[List[str]] = None,
+    intervals: Optional[str] = None,
     gvcf_batch_size: Optional[int] = None,
+    reference_genome: str = "GRCh38",
 ) -> hl.vds.VariantDataset:
     """
     Combine GVCFs into a single VDS.
@@ -248,13 +249,20 @@ def create_vds(
     :param use_exome_default_intervals: Use the default exome intervals.
     :param intervals: Path to text file with intervals to use for VDS creation.
     :param gvcf_batch_size: Number of GVCFs to combine into a Variant Dataset at once.
+    :param reference_genome: Reference genome to use. Default is GRCh38.
     :return: Combined VDS.
     """
     if not save_path and temp_path:
         save_path = temp_path + "combiner_plan.json"
 
     gvcfs = read_list_data(gvcfs)
-    intervals = read_list_data(intervals) if intervals else None
+    intervals = (
+        hl.import_locus_intervals(
+            intervals, reference_genome=reference_genome
+        ).collect()
+        if intervals
+        else None
+    )
 
     if not len(gvcfs) > 0:
         raise DataException("No GVCFs provided in file")

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -259,6 +259,9 @@ def create_vds(
     if not len(gvcfs) > 0:
         raise DataException("No GVCFs provided in file")
 
+    if intervals and not len(intervals) > 0:
+        raise DataException("No intervals provided in passed intervals file")
+
     logger.info("Combining %s GVCFs into a single VDS", len(gvcfs))
     combiner = hl.vds.new_combiner(
         output_path=output_path,

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -237,7 +237,7 @@ def create_vds(
     """
     Combine GVCFs into a single VDS.
 
-    :param gvcfs: Path to file containing gVCF paths with no header.
+    :param gvcfs: Path to file containing GVCF paths with no header.
     :param output_path: Path to write output VDS.
     :param temp_path: Path to write temporary files. A bucket with a life-cycle
         policy is recommended.

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -259,7 +259,7 @@ def create_vds(
     intervals = (
         hl.import_locus_intervals(
             intervals, reference_genome=reference_genome
-        ).collect()
+        ).interval.collect()
         if intervals
         else None
     )

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -227,7 +227,7 @@ def repartition_for_join(
 def create_vds(
     gvcfs: str,
     output_path: str,
-    temp_path: Optional[str] = None,
+    temp_path: str,
     save_path: Optional[str] = None,
     use_genome_default_intervals: bool = False,
     use_exome_default_intervals: bool = False,
@@ -235,17 +235,18 @@ def create_vds(
     gvcf_batch_size: Optional[int] = None,
 ) -> hl.vds.VariantDataset:
     """
-    Combine gVCFs into a single VDS.
+    Combine GVCFs into a single VDS.
 
     :param gvcfs: Path to file containing gVCF paths with no header.
-    :param str output_path: Path to write output VDS.
-    :param str temp_path: Path to write temporary files.
-    :param str save_path: Path to write combiner to on failure. Can be used to restart
+    :param output_path: Path to write output VDS.
+    :param temp_path: Path to write temporary files. A bucket with a life-cycle
+        policy is recommended.
+    :param save_path: Path to write combiner to on failure. Can be used to restart
         combiner from a failed state. If not specified, defaults to temp_path +
         combiner_plan.json.
-    :param bool use_genome_default_intervals: Use the default genome intervals.
-    :param bool use_exome_default_intervals: Use the default exome intervals.
-    :param List[str] intervals: List of intervals to use.
+    :param use_genome_default_intervals: Use the default genome intervals.
+    :param use_exome_default_intervals: Use the default exome intervals.
+    :param intervals: List of intervals to use.
     :param gvcf_batch_size: Number of GVCFs to combine into a Variant Dataset at once.
     :return: Combined VDS.
     """
@@ -255,9 +256,9 @@ def create_vds(
     gvcfs = read_list_data(gvcfs)
 
     if not len(gvcfs) > 0:
-        raise DataException("No gVCFs provided in file")
+        raise DataException("No GVCFs provided in file")
 
-    logger.info("Combining %s gVCFs into a single VDS", len(gvcfs))
+    logger.info("Combining %s GVCFs into a single VDS", len(gvcfs))
     combiner = hl.vds.new_combiner(
         output_path=output_path,
         temp_path=temp_path,

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -239,7 +239,7 @@ def create_vds(
 
     :param gvcfs: Path to file containing GVCF paths with no header.
     :param output_path: Path to write output VDS.
-    :param temp_path: Path to write temporary files. A bucket with a life-cycle
+    :param temp_path: Directory path to write temporary files. A bucket with a life-cycle
         policy is recommended.
     :param save_path: Path to write combiner to on failure. Can be used to restart
         combiner from a failed state. If not specified, defaults to temp_path +


### PR DESCRIPTION
Adds a function to create a VDS from GVCFs only. This is mainly a wrapper around hails function with limited utility. We can expand this function's utility to ingest VDS when the time comes and that is needed.