### PR TITLE
Add functions `fill_missing_key_combinations` and `missing_struct_expr`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,13 +11,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        files: gnomad
+        files: gnomad tests
   - repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v2.0.2 # This should be kept in sync with the version in requirements-dev.in
     hooks:
       - id: autopep8
         args: ["--exit-code", "--in-place"]
-        files: gnomad
+        files: gnomad tests
   - repo: https://github.com/pycqa/pydocstyle
     rev: 6.3.0 # This should be kept in sync with the version in requirements-dev.in
     hooks:
@@ -27,4 +27,4 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
-        files: gnomad
+        files: gnomad tests

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2408,18 +2408,20 @@ def fill_missing_key_combinations(
 
     Example::
 
-    .. code-block:: python
+        .. code-block:: python
 
-        ht = hl.Table.parallelize(
-                [{'key1': 'A', 'key2': 1, 'value': 10},
-                {'key1': 'A', 'key2': 2, 'value': 20},
-                {'key1': 'B', 'key2': 1, 'value': 30}],
+            ht = hl.Table.parallelize(
+                [
+                    {'key1': 'A', 'key2': 1, 'value': 10},
+                    {'key1': 'A', 'key2': 2, 'value': 20},
+                    {'key1': 'B', 'key2': 1, 'value': 30},
+                ],
                 hl.tstruct(key1=hl.tstr, key2=hl.tint32, value=hl.tint32),
-                key=['key1', 'key2']
+                key=['key1', 'key2'],
             )
-        fill_values = {'value': hl.missing(hl.tint32)}
-        filled_ht = fill_missing_key_combinations(ht, fill_values)
-        filled_ht.show()
+            fill_values = {'value': hl.missing(hl.tint32)}
+            filled_ht = fill_missing_key_combinations(ht, fill_values)
+            filled_ht.show()
 
         +------+------+
         | key1 | key2 | value |

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2406,6 +2406,34 @@ def fill_missing_key_combinations(
     happen when you are aggregating data and want to ensure that all possible key
     combinations are present in the output Table, not only the ones that are present.
 
+    Example:
+
+    .. code-block:: python
+
+        ht = hl.Table.parallelize(
+                [{'key1': 'A', 'key2': 1, 'value': 10},
+                {'key1': 'A', 'key2': 2, 'value': 20},
+                {'key1': 'B', 'key2': 1, 'value': 30}],
+                hl.tstruct(key1=hl.tstr, key2=hl.tint32, value=hl.tint32),
+                key=['key1', 'key2']
+            )
+        fill_values = {'value': hl.missing(hl.tint32)}
+        filled_ht = fill_missing_key_combinations(ht, fill_values)
+        filled_ht.show()
+
+        +------+------+
+        | key1 | key2 | value |
+        +------+------+
+        |  A   |  1   |  10   |
+        |  A   |  2   |  20   |
+        |  B   |  1   |  30   |
+        |  B   |  2   | null  |
+        +------+------+
+
+    In this example, the input table is missing the combination (B, 2).
+    After applying `fill_missing_key_combinations`, the missing key combination
+    (B, 2) is filled with the specified fill value for 'value' (null in this case).
+
     :param ht: Input Table containing key fields.
     :param fill_values: Dictionary of fill values to use for missing key combinations.
     :param key_values: Optional dictionary of unique values to use for each key field.
@@ -2445,7 +2473,7 @@ def missing_struct_expr(
     dtypes: hl.expr.types.tstruct,
 ) -> hl.expr.StructExpression:
     """
-    Create a struct of missing values for each field and type in the input struct.
+    Create a struct of missing values corresponding to each field and type in the input struct.
 
     :param dtypes: StructExpression containing the field names and missing values.
     """

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2388,6 +2388,70 @@ def update_structured_annotations(
     return ht.annotate(**updated_rows)
 
 
+def fill_missing_key_combinations(
+    ht: hl.Table,
+    fill_values: Dict[str, hl.expr.Expression],
+    key_values: Optional[Dict[str, List]] = None,
+) -> hl.Table:
+    """
+    Fill missing key combinations with requested fill values.
+
+    This function fills missing key combinations in the input Table with requested fill
+    values. The fill values are specified in the `fill_values` dictionary. The unique
+    values for each key field are collected from the input Table unless specified in
+    the `key_values` dictionary.
+
+    This is useful when you want to ensure that all possible key combinations are
+    present in a Table, even if they are missing from the input Table. This can
+    happen when you are aggregating data and want to ensure that all possible key
+    combinations are present in the output Table, not only the ones that are present.
+
+    :param ht: Input Table containing key fields.
+    :param fill_values: Dictionary of fill values to use for missing key combinations.
+    :param key_values: Optional dictionary of unique values to use for each key field.
+        Default is None. If None, the unique values for each key field are collected
+        from the input Table.
+    :return: Table with missing key combinations filled with requested fill values.
+    """
+    key_fields = list(ht.key.keys())
+
+    # Extract unique values for each annotation.
+    key_values = key_values or {}
+    key_values = [
+        key_values.get(f, ht.aggregate(hl.agg.collect_as_set(ht[f])))
+        for f in key_fields
+    ]
+
+    # Create all combinations of the unique values for each key.
+    all_combinations = list(itertools.product(*key_values))
+
+    # Convert the list of combinations to a Hail Table.
+    all_combinations_ht = hl.Table.parallelize(
+        [{f: c for f, c in zip(key_fields, combo)} for combo in all_combinations],
+        hl.tstruct(**{f: ht[f].dtype for f in key_fields}),
+    ).key_by(*key_fields)
+
+    # Left join original table with all_combinations to include all possible
+    # combinations.
+    ht = all_combinations_ht.join(ht, how="left")
+
+    # Fill missing row annotations with requested fill values.
+    ht = ht.annotate(**{f: hl.coalesce(ht[f], v) for f, v in fill_values.items()})
+
+    return ht
+
+
+def missing_struct_expr(
+    dtypes: hl.expr.types.tstruct,
+) -> hl.expr.StructExpression:
+    """
+    Create a struct of missing values for each field and type in the input struct.
+
+    :param dtypes: StructExpression containing the field names and missing values.
+    """
+    return hl.struct(**{f: hl.missing(t) for f, t in dtypes.items()})
+
+
 def add_gks_vrs(
     input_locus: hl.locus,
     input_vrs: hl.struct,

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2406,7 +2406,8 @@ def fill_missing_key_combinations(
     happen when you are aggregating data and want to ensure that all possible key
     combinations are present in the output Table, not only the ones that are present.
 
-    Example:
+    Example::
+
     .. code-block:: python
 
         ht = hl.Table.parallelize(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2407,7 +2407,6 @@ def fill_missing_key_combinations(
     combinations are present in the output Table, not only the ones that are present.
 
     Example:
-
     .. code-block:: python
 
         ht = hl.Table.parallelize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Pytest configuration file for Hail tests."""
+
 import pytest
 import hail as hl
 
@@ -12,7 +13,7 @@ def setup_hail():
     session and will be stopped after all tests are completed.
     """
     if not hl.utils.java.Env.is_fully_initialized():
-        hl.init(log='/dev/null')
+        hl.init(log="/dev/null")
 
     yield
     hl.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Pytest configuration file for Hail tests."""
+import pytest
+import hail as hl
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_hail():
+    """
+    Set up Hail before running tests.
+
+    This fixture will ensure that the Hail context is initialized only once per test
+    session and will be stopped after all tests are completed.
+    """
+    if not hl.utils.java.Env.is_fully_initialized():
+        hl.init(log='/dev/null')
+
+    yield
+    hl.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Pytest configuration file for Hail tests."""
 
-import pytest
 import hail as hl
+import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,4 +1,5 @@
 """Tests for the annotations utility module."""
+
 from typing import Dict, List
 import pytest
 import hail as hl
@@ -9,19 +10,19 @@ class TestFillMissingKeyCombinations:
     """Test the fill_missing_key_combinations function."""
 
     expected_result = [
-        hl.Struct(key1='A', key2=1, value=10),
-        hl.Struct(key1='A', key2=2, value=20),
-        hl.Struct(key1='B', key2=1, value=30),
-        hl.Struct(key1='B', key2=2, value=None),
+        hl.Struct(key1="A", key2=1, value=10),
+        hl.Struct(key1="A", key2=2, value=20),
+        hl.Struct(key1="B", key2=1, value=30),
+        hl.Struct(key1="B", key2=2, value=None),
     ]
 
     expected_result_extra = [
-        hl.Struct(key1='A', key2=1, value=10),
-        hl.Struct(key1='A', key2=2, value=20),
-        hl.Struct(key1='B', key2=1, value=30),
-        hl.Struct(key1='B', key2=2, value=None),
-        hl.Struct(key1='C', key2=1, value=None),
-        hl.Struct(key1='C', key2=2, value=None),
+        hl.Struct(key1="A", key2=1, value=10),
+        hl.Struct(key1="A", key2=2, value=20),
+        hl.Struct(key1="B", key2=1, value=30),
+        hl.Struct(key1="B", key2=2, value=None),
+        hl.Struct(key1="C", key2=1, value=None),
+        hl.Struct(key1="C", key2=2, value=None),
     ]
 
     @pytest.fixture
@@ -29,21 +30,24 @@ class TestFillMissingKeyCombinations:
         """Fixture to create a sample Hail Table."""
         return hl.Table.parallelize(
             [
-                {'key1': 'A', 'key2': 1, 'value': 10},
-                {'key1': 'A', 'key2': 2, 'value': 20},
-                {'key1': 'B', 'key2': 1, 'value': 30}
+                {"key1": "A", "key2": 1, "value": 10},
+                {"key1": "A", "key2": 2, "value": 20},
+                {"key1": "B", "key2": 1, "value": 30},
             ],
-            hl.tstruct(key1=hl.tstr, key2=hl.tint32, value=hl.tint32)
-        ).key_by('key1', 'key2')
+            hl.tstruct(key1=hl.tstr, key2=hl.tint32, value=hl.tint32),
+        ).key_by("key1", "key2")
 
     @pytest.mark.parametrize(
         "expected,key_values",
         [
             (expected_result, None),
-            (expected_result, {'key1': ['A', 'B'], 'key2': [1, 2]}),
-            (expected_result_extra, {'key1': ['A', 'B', 'C'], 'key2': [1, 2]}),
-            (expected_result_extra, {'key1': ['A', 'B', 'C'], 'key2': [1, 2], 'key3': ['X']}),
-        ]
+            (expected_result, {"key1": ["A", "B"], "key2": [1, 2]}),
+            (expected_result_extra, {"key1": ["A", "B", "C"], "key2": [1, 2]}),
+            (
+                expected_result_extra,
+                {"key1": ["A", "B", "C"], "key2": [1, 2], "key3": ["X"]},
+            ),
+        ],
     )
     def test_fill_missing_key_combinations(
         self,
@@ -53,7 +57,7 @@ class TestFillMissingKeyCombinations:
     ) -> None:
         """Test the `fill_missing_key_combinations` function."""
         # Define fill values.
-        fill_values = {'value': hl.missing(hl.tint32)}
+        fill_values = {"value": hl.missing(hl.tint32)}
 
         # Call the function.
         result_ht = fill_missing_key_combinations(
@@ -73,11 +77,7 @@ class TestFillMissingKeyCombinations:
 def test_missing_struct_expr() -> None:
     """Test the missing_struct_expr function."""
     # Define a sample tstruct.
-    dtypes = hl.tstruct(
-        field1=hl.tint32,
-        field2=hl.tstr,
-        field3=hl.tfloat64
-    )
+    dtypes = hl.tstruct(field1=hl.tint32, field2=hl.tstr, field3=hl.tfloat64)
 
     # Call the function.
     result = missing_struct_expr(dtypes)
@@ -86,7 +86,7 @@ def test_missing_struct_expr() -> None:
     expected = hl.struct(
         field1=hl.missing(hl.tint32),
         field2=hl.missing(hl.tstr),
-        field3=hl.missing(hl.tfloat64)
+        field3=hl.missing(hl.tfloat64),
     )
 
     # Verify the result.

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,8 +1,10 @@
 """Tests for the annotations utility module."""
 
 from typing import Dict, List
-import pytest
+
 import hail as hl
+import pytest
+
 from gnomad.utils.annotations import fill_missing_key_combinations, missing_struct_expr
 
 

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,0 +1,93 @@
+"""Tests for the annotations utility module."""
+from typing import Dict, List
+import pytest
+import hail as hl
+from gnomad.utils.annotations import fill_missing_key_combinations, missing_struct_expr
+
+
+class TestFillMissingKeyCombinations:
+    """Test the fill_missing_key_combinations function."""
+
+    expected_result = [
+        hl.Struct(key1='A', key2=1, value=10),
+        hl.Struct(key1='A', key2=2, value=20),
+        hl.Struct(key1='B', key2=1, value=30),
+        hl.Struct(key1='B', key2=2, value=None),
+    ]
+
+    expected_result_extra = [
+        hl.Struct(key1='A', key2=1, value=10),
+        hl.Struct(key1='A', key2=2, value=20),
+        hl.Struct(key1='B', key2=1, value=30),
+        hl.Struct(key1='B', key2=2, value=None),
+        hl.Struct(key1='C', key2=1, value=None),
+        hl.Struct(key1='C', key2=2, value=None),
+    ]
+
+    @pytest.fixture
+    def sample_hail_table(self):
+        """Fixture to create a sample Hail Table."""
+        return hl.Table.parallelize(
+            [
+                {'key1': 'A', 'key2': 1, 'value': 10},
+                {'key1': 'A', 'key2': 2, 'value': 20},
+                {'key1': 'B', 'key2': 1, 'value': 30}
+            ],
+            hl.tstruct(key1=hl.tstr, key2=hl.tint32, value=hl.tint32)
+        ).key_by('key1', 'key2')
+
+    @pytest.mark.parametrize(
+        "expected,key_values",
+        [
+            (expected_result, None),
+            (expected_result, {'key1': ['A', 'B'], 'key2': [1, 2]}),
+            (expected_result_extra, {'key1': ['A', 'B', 'C'], 'key2': [1, 2]}),
+            (expected_result_extra, {'key1': ['A', 'B', 'C'], 'key2': [1, 2], 'key3': ['X']}),
+        ]
+    )
+    def test_fill_missing_key_combinations(
+        self,
+        sample_hail_table: hl.Table,
+        expected: List[hl.Struct],
+        key_values: Dict[str, List[str]],
+    ) -> None:
+        """Test the `fill_missing_key_combinations` function."""
+        # Define fill values.
+        fill_values = {'value': hl.missing(hl.tint32)}
+
+        # Call the function.
+        result_ht = fill_missing_key_combinations(
+            sample_hail_table, fill_values, key_values
+        )
+
+        # Collect results.
+        result = result_ht.collect()
+
+        print(result)
+        print(expected)
+
+        # Verify the result.
+        assert result == expected
+
+
+def test_missing_struct_expr() -> None:
+    """Test the missing_struct_expr function."""
+    # Define a sample tstruct.
+    dtypes = hl.tstruct(
+        field1=hl.tint32,
+        field2=hl.tstr,
+        field3=hl.tfloat64
+    )
+
+    # Call the function.
+    result = missing_struct_expr(dtypes)
+
+    # Expected result.
+    expected = hl.struct(
+        field1=hl.missing(hl.tint32),
+        field2=hl.missing(hl.tstr),
+        field3=hl.missing(hl.tfloat64)
+    )
+
+    # Verify the result.
+    assert hl.eval(result == expected)


### PR DESCRIPTION
fill_missing_key_combinations: Fill missing key combinations with requested fill values.
missing_struct_expr: Create a struct of missing values for each field and type in the input struct.

Also added test code for both