### PR TITLE
Update default vep version for context table resource

### DIFF
--- a/gnomad/resources/grch38/reference_data.py
+++ b/gnomad/resources/grch38/reference_data.py
@@ -132,7 +132,7 @@ na12878_giab_hc_intervals = GnomadPublicTableResource(
 
 # Versioned resources: versions should be listed from most recent to oldest
 vep_context = VersionedTableResource(
-    default_version="95",
+    default_version="105",
     versions={
         "95": GnomadPublicTableResource(
             path="gs://gnomad-public-requester-pays/resources/context/grch38_context_vep_annotated.ht",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.

To make sure that this change is included in release notes, please:
- Use a descriptive title for the pull request.
- Apply one of the "Changelog" labels (if applicable).

-->
Update default VEP version from 95 to 105, which is the version we used for gnomAD v4/v4.1