### PR TITLE
Add contig check to summarize_variants

### DIFF
--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -525,11 +525,6 @@ def sum_group_callstats(
     generic_field_check_loop(t, field_check_expr, verbose)
 
 
-import logging
-from pprint import pprint
-from typing import Any, Dict, List, Optional, Union
-
-
 def summarize_variants(
     t: Union[hl.MatrixTable, hl.Table],
     expected_contigs: List[str] = None,

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -566,12 +566,12 @@ def summarize_variants(
 
         if missing_contigs:
             logger.info(
-                f"FAILED contig check, the following contigs are missing: %s",
+                "FAILED contig check, the following contigs are missing: %s",
                 missing_contigs,
             )
         if unexpected_contigs:
             logger.info(
-                f"FAILED contig check, the following contigs are unexpected: %s",
+                "FAILED contig check, the following contigs are unexpected: %s",
                 unexpected_contigs,
             )
 

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -525,15 +525,23 @@ def sum_group_callstats(
     generic_field_check_loop(t, field_check_expr, verbose)
 
 
+import logging
+from pprint import pprint
+from typing import Any, Dict, List, Optional, Union
+
+
 def summarize_variants(
     t: Union[hl.MatrixTable, hl.Table],
+    expected_contigs: List[str] = None,
 ) -> hl.Struct:
     """
     Get summary of variants in a MatrixTable or Table.
 
-    Print the number of variants to stdout and check that each chromosome has variant calls.
+    Print the number of variants to stdout and check that each chromosome has variant calls. If requested,
+    check that all expected contigs are found in the variant summary and that no unexpected contigs are found.
 
     :param t: Input MatrixTable or Table to be checked.
+    :param expected_contigs: List of contigs expected to be found in the input.
     :return: Struct of variant summary
     """
     if isinstance(t, hl.MatrixTable):
@@ -546,9 +554,23 @@ def summarize_variants(
         var_summary.contigs,
     )
 
+    # Check that all contigs have variant calls.
     for contig in var_summary.contigs:
         if var_summary.contigs[contig] == 0:
             logger.warning("%s has no variants called", var_summary.contigs)
+
+    # Check that all expected contigs are found in the variant summary and that no unexpected contigs are found.
+    if expected_contigs:
+        var_summary_contigs = var_summary["contigs"].keys()
+        missing_contigs = expected_contigs - var_summary_contigs
+        unexpected_contigs = var_summary_contigs - expected_contigs
+
+        if missing_contigs or unexpected_contigs:
+            logger.warning(
+                "FAILED contig check. Expected contigs and found contigs do not match! Expected: %s, Found: %s",
+                expected_contigs,
+                var_summary_contigs,
+            )
 
     return var_summary
 

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -559,7 +559,8 @@ def summarize_variants(
         if var_summary.contigs[contig] == 0:
             logger.warning("%s has no variants called", var_summary.contigs)
 
-    # Check that all expected contigs are found in the variant summary and that no unexpected contigs are found.
+    # Check that all expected contigs are found in the variant summary
+    # and that no unexpected contigs are found.
     if expected_contigs:
         var_summary_contigs = var_summary["contigs"].keys()
         missing_contigs = expected_contigs - var_summary_contigs

--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -561,11 +561,18 @@ def summarize_variants(
         missing_contigs = expected_contigs - var_summary_contigs
         unexpected_contigs = var_summary_contigs - expected_contigs
 
-        if missing_contigs or unexpected_contigs:
-            logger.warning(
-                "FAILED contig check. Expected contigs and found contigs do not match! Expected: %s, Found: %s",
-                expected_contigs,
-                var_summary_contigs,
+        logger.info("Expected contigs: %s", expected_contigs)
+        logger.info("Found contigs: %s", list(var_summary_contigs))
+
+        if missing_contigs:
+            logger.info(
+                f"FAILED contig check, the following contigs are missing: %s",
+                missing_contigs,
+            )
+        if unexpected_contigs:
+            logger.info(
+                f"FAILED contig check, the following contigs are unexpected: %s",
+                unexpected_contigs,
             )
 
     return var_summary


### PR DESCRIPTION
Adds a 'expected_contigs' param to summarize_variants and checks that all the expected contigs are found in the summarize_variants output