### PR TITLE
Change filter_mt_to_trios to also filter on vds

### DIFF
--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -987,24 +987,22 @@ def compute_related_samples_to_drop(
     return related_samples_to_drop_ht
 
 
-def filter_mt_to_trios(mt: hl.MatrixTable, fam_ht: hl.Table) -> hl.MatrixTable:
+def filter_vds_to_trios(vds: hl.vds, fam_ht: hl.Table) -> hl.vds:
     """
     Filter a MatrixTable to a set of trios in `fam_ht` and annotates with adj.
 
-    :param mt: A Matrix Table to filter to only trios
+    :param vds: A Variant Dataset to filter to only trios
     :param fam_ht: A Table of trios to filter to, loaded using `hl.import_fam`
-    :return: A MT filtered to trios and adj annotated
+    :return: A Variant Dataset with only the trios in `fam_ht`
     """
     # Filter MT to samples present in any of the trios
     fam_ht = fam_ht.annotate(fam_members=[fam_ht.id, fam_ht.pat_id, fam_ht.mat_id])
     fam_ht = fam_ht.explode("fam_members", name="s")
     fam_ht = fam_ht.key_by("s").select().distinct()
 
-    mt = mt.filter_cols(hl.is_defined(fam_ht[mt.col_key]))
-    if "adj" not in mt.entry:
-        mt = annotate_adj(mt)
+    vds = hl.vds.filter_samples(vds, fam_ht)
 
-    return mt
+    return vds
 
 
 def generate_trio_stats_expr(

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -986,8 +986,8 @@ def compute_related_samples_to_drop(
 
 
 def filter_to_trios(
-    mtds: Union[hl.vds, hl.matrixtable], fam_ht: hl.Table
-) -> Union[hl.vds, hl.matrixtable]:
+    mtds: Union[hl.MatrixTable, hl.vds.VariantDataset], fam_ht: hl.Table
+) -> Union[hl.MatrixTable, hl.vds.VariantDataset]:
     """
     Filter a Matrix Table or a Variant Dataset to a set of trios in `fam_ht`.
 
@@ -1000,7 +1000,7 @@ def filter_to_trios(
     :param fam_ht: A Table of trios to filter to, loaded using `hl.import_fam`
     :return: A Matrix Table or a Variant Dataset with only the trios in `fam_ht`
     """
-    # Filter VDS to samples present in any of the trios
+    # Filter to samples present in any of the trios.
     fam_ht = fam_ht.annotate(fam_members=[fam_ht.id, fam_ht.pat_id, fam_ht.mat_id])
     fam_ht = fam_ht.explode("fam_members", name="s")
     fam_ht = fam_ht.key_by("s").select().distinct()
@@ -1010,7 +1010,7 @@ def filter_to_trios(
     elif isinstance(mtds, hl.vds.VariantDataset):
         mtds = hl.vds.filter_samples(mtds, fam_ht)
     else:
-        raise ValueError("t must be a MatrixTable or VariantDataset")
+        raise ValueError("mtds must be a MatrixTable or VariantDataset")
 
     return mtds
 

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -985,7 +985,9 @@ def compute_related_samples_to_drop(
     return related_samples_to_drop_ht
 
 
-def filter_mt_to_trios(t: Union[hl.vds, hl.matrixtable], fam_ht: hl.Table) -> Union[hl.vds, hl.matrixtable]:
+def filter_mt_to_trios(
+    t: Union[hl.vds, hl.matrixtable], fam_ht: hl.Table
+) -> Union[hl.vds, hl.matrixtable]:
     """
     Filter a Matrix Table or a Variant Dataset to a set of trios in `fam_ht`.
 

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -989,7 +989,7 @@ def compute_related_samples_to_drop(
 
 def filter_vds_to_trios(vds: hl.vds, fam_ht: hl.Table) -> hl.vds:
     """
-    Filter a MatrixTable to a set of trios in `fam_ht` and annotates with adj.
+    Filter a Variant Dataset to a set of trios in `fam_ht`.
 
     :param vds: A Variant Dataset to filter to only trios
     :param fam_ht: A Table of trios to filter to, loaded using `hl.import_fam`

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -985,13 +985,18 @@ def compute_related_samples_to_drop(
     return related_samples_to_drop_ht
 
 
-def filter_mt_to_trios(
-    t: Union[hl.vds, hl.matrixtable], fam_ht: hl.Table
+def filter_to_trios(
+    mtds: Union[hl.vds, hl.matrixtable], fam_ht: hl.Table
 ) -> Union[hl.vds, hl.matrixtable]:
     """
     Filter a Matrix Table or a Variant Dataset to a set of trios in `fam_ht`.
 
-    :param t: A Variant Dataset to filter to only trios
+    .. note::
+           Using `filter_cols` in MatrixTable will not affect the number of rows (
+           variants), however, using `filter_samples` in VariantDataset will remove
+           the variants that are not present in any of the trios.
+
+    :param mtds: A Variant Dataset or a Matrix Table to filter to only trios
     :param fam_ht: A Table of trios to filter to, loaded using `hl.import_fam`
     :return: A Matrix Table or a Variant Dataset with only the trios in `fam_ht`
     """
@@ -1000,14 +1005,14 @@ def filter_mt_to_trios(
     fam_ht = fam_ht.explode("fam_members", name="s")
     fam_ht = fam_ht.key_by("s").select().distinct()
 
-    if isinstance(t, hl.MatrixTable):
-        t = t.filter_cols(hl.is_defined(fam_ht[t.col_key]))
-    elif isinstance(t, hl.vds.VariantDataset):
-        t = hl.vds.filter_samples(t, fam_ht)
+    if isinstance(mtds, hl.MatrixTable):
+        mtds = mtds.filter_cols(hl.is_defined(fam_ht[mtds.col_key]))
+    elif isinstance(mtds, hl.vds.VariantDataset):
+        mtds = hl.vds.filter_samples(mtds, fam_ht)
     else:
         raise ValueError("t must be a MatrixTable or VariantDataset")
 
-    return t
+    return mtds
 
 
 def generate_trio_stats_expr(

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -8,8 +8,6 @@ from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 import hail as hl
 import networkx as nx
 
-from gnomad.utils.annotations import annotate_adj
-
 logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -995,7 +993,7 @@ def filter_vds_to_trios(vds: hl.vds, fam_ht: hl.Table) -> hl.vds:
     :param fam_ht: A Table of trios to filter to, loaded using `hl.import_fam`
     :return: A Variant Dataset with only the trios in `fam_ht`
     """
-    # Filter MT to samples present in any of the trios
+    # Filter VDS to samples present in any of the trios
     fam_ht = fam_ht.annotate(fam_members=[fam_ht.id, fam_ht.pat_id, fam_ht.mat_id])
     fam_ht = fam_ht.explode("fam_members", name="s")
     fam_ht = fam_ht.key_by("s").select().distinct()


### PR DESCRIPTION
As suggested by Chris, we're filtering VDS to trios by `hl.vds.filter_samples`, which will greatly drop the number of variants to the ones with at least one ALT allele in the trio samples; Also, this function has been only used once in gnomad_qc, `annotate_adj` has been used twice before, it will be removed from this function. 

It will not pass the checks if I changed the function name, should I just write another function? 
