### PR TITLE
Add browser tables to resources

### DIFF
--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -152,7 +152,7 @@ def _public_browser_gene_ht_path() -> str:
 
     :return: Path to browser gene Table.
     """
-    return ("gs://gnomad-public-requester-pays/resources/grch37/browser/gnomad.genes.GRCh37.GENCODEv19.pext.ht")
+    return "gs://gnomad-public-requester-pays/resources/grch37/browser/gnomad.genes.GRCh37.GENCODEv19.pext.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -146,7 +146,7 @@ def _public_browser_gene_ht_path() -> str:
     Get public browser gene table path.
 
     .. note::
-       This table has smaller number of partitions (n=50) for faster computation and
+       This table has smaller number of partitions (n=100) for faster computation and
        contains pext data compared to gnomad.genes.GRCh37.GENCODEv19.ht (which was
        used by the browser for ES export) under the same path.
 

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -146,6 +146,7 @@ def _public_browser_gene_ht_path() -> str:
     Get public browser gene table path.
 
     .. note::
+
        This table has smaller number of partitions (n=100) for faster computation and
        contains pext data compared to gnomad.genes.GRCh37.GENCODEv19.ht (which was
        used by the browser for ES export) under the same path.

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -145,9 +145,14 @@ def _public_browser_gene_ht_path() -> str:
     """
     Get public browser gene table path.
 
+    .. note::
+       This table has smaller number of partitions (n=50) for faster computation and
+       contains pext data compared to gnomad.genes.GRCh37.GENCODEv19.ht (which was
+       used by the browser for ES export) under the same path.
+
     :return: Path to browser gene Table.
     """
-    return "gs://gnomad-public-requester-pays/resources/grch37/browser/gnomad.genes.GRCh37.GENCODEv19.ht"
+    return ("gs://gnomad-public-requester-pays/resources/grch37/browser/gnomad.genes.GRCh37.GENCODEv19.pext.ht")
 
 
 def public_release(data_type: str) -> VersionedTableResource:

--- a/gnomad/resources/grch37/gnomad.py
+++ b/gnomad/resources/grch37/gnomad.py
@@ -141,6 +141,15 @@ def _public_pext_path(pext_type: str = "base_level") -> str:
     return pext_paths[pext_type]
 
 
+def _public_browser_gene_ht_path() -> str:
+    """
+    Get public browser gene table path.
+
+    :return: Path to browser gene Table.
+    """
+    return "gs://gnomad-public-requester-pays/resources/grch37/browser/gnomad.genes.GRCh37.GENCODEv19.ht"
+
+
 def public_release(data_type: str) -> VersionedTableResource:
     """
     Retrieve publicly released versioned table resource.
@@ -275,3 +284,12 @@ def constraint() -> GnomadPublicTableResource:
     :return: Gene constraint Table.
     """
     return GnomadPublicTableResource(path=_public_constraint_ht_path())
+
+
+def browser_gene() -> GnomadPublicTableResource:
+    """
+    Retrieve browser gene table.
+
+    :return: Browser gene Table.
+    """
+    return GnomadPublicTableResource(path=_public_browser_gene_ht_path())

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -409,6 +409,7 @@ def _public_browser_gene_ht_path() -> str:
     Get public browser gene table path.
 
     .. note::
+
        This table has smaller number of partitions (n=100) for faster computation and
        contains pext data compared to gnomad.genes.GRCh38.GENCODEv39.ht (which was
        used by the browser for ES export) under the same path.

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -415,7 +415,7 @@ def _public_browser_gene_ht_path() -> str:
 
     :return: Path to browser gene Table.
     """
-    return ("gs://gnomad-public-requester-pays/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.pext.ht")
+    return "gs://gnomad-public-requester-pays/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.pext.ht"
 
 
 def public_release(data_type: str) -> VersionedTableResource:
@@ -788,7 +788,9 @@ def constraint(version: str = CURRENT_EXOME_RELEASE) -> VersionedTableResource:
     )
 
 
-def browser_variant(version: str = CURRENT_BROWSER_RELEASE) -> GnomadPublicTableResource:
+def browser_variant(
+    version: str = CURRENT_BROWSER_RELEASE,
+) -> GnomadPublicTableResource:
     """
     Retrieve browser variant table.
 

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -391,6 +391,25 @@ def _public_constraint_ht_path(version: str) -> str:
     return f"gs://gnomad-public-requester-pays/release/{version}/constraint/gnomad.v{version}.constraint_metrics.ht"
 
 
+def _public_browser_variant_ht_path(version: str) -> str:
+    """
+    Get public browser variant table path.
+
+    :param version: One of the release versions of gnomAD on GRCh38.
+    :return: Path to browser variant Table.
+    """
+    return f"gs://gnomad-public-requester-pays/release/{version}/ht/browser/gnomad.browser.v{version}.sites.ht"
+
+
+def _public_browser_gene_ht_path() -> str:
+    """
+    Get public browser gene table path.
+
+    :return: Path to browser gene Table.
+    """
+    return "gs://gnomad-public-requester-pays/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.ht"
+
+
 def public_release(data_type: str) -> VersionedTableResource:
     """
     Retrieve publicly released versioned table resource.
@@ -759,3 +778,28 @@ def constraint(version: str = CURRENT_EXOME_RELEASE) -> VersionedTableResource:
             for release in EXOME_RELEASES
         },
     )
+
+
+def browser_variant(version: str = CURRENT_EXOME_RELEASE) -> GnomadPublicTableResource:
+    """
+    Retrieve browser variant table.
+
+    :param version: One of the release versions of gnomAD on GRCh38. Default is the current exome release.
+    :return: Browser variant Table.
+    :raises ValueError: If the version is not a valid release.
+    """
+    if version not in EXOME_RELEASES:
+        raise ValueError(
+            f"Invalid version: {version}. Must be one of {EXOME_RELEASES}."
+        )
+
+    return GnomadPublicTableResource(path=_public_browser_variant_ht_path(version))
+
+
+def browser_gene() -> GnomadPublicTableResource:
+    """
+    Retrieve browser gene table.
+
+    :return: Browser gene Table.
+    """
+    return GnomadPublicTableResource(path=_public_browser_gene_ht_path())

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -409,7 +409,7 @@ def _public_browser_gene_ht_path() -> str:
     Get public browser gene table path.
 
     .. note::
-       This table has smaller number of partitions (n=50) for faster computation and
+       This table has smaller number of partitions (n=100) for faster computation and
        contains pext data compared to gnomad.genes.GRCh38.GENCODEv39.ht (which was
        used by the browser for ES export) under the same path.
 

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -26,6 +26,8 @@ CURRENT_EXOME_RELEASE = "4.1"
 CURRENT_GENOME_RELEASE = "4.1"
 CURRENT_JOINT_RELEASE = "4.1"
 
+CURRENT_BROWSER_RELEASE = "4.1"
+
 CURRENT_EXOME_COVERAGE_RELEASE = "4.0"
 CURRENT_GENOME_COVERAGE_RELEASE = "3.0.1"
 
@@ -35,6 +37,7 @@ CURRENT_GENOME_AN_RELEASE = "4.1"
 EXOME_RELEASES = ["4.0", "4.1"]
 GENOME_RELEASES = ["3.0", "3.1", "3.1.1", "3.1.2", "4.0", "4.1"]
 JOINT_RELEASES = ["4.1"]
+BROWSER_RELEASES = ["4.1"]
 
 EXOME_COVERAGE_RELEASES = ["4.0"]
 GENOME_COVERAGE_RELEASES = ["3.0", "3.0.1"]
@@ -405,9 +408,14 @@ def _public_browser_gene_ht_path() -> str:
     """
     Get public browser gene table path.
 
+    .. note::
+       This table has smaller number of partitions (n=50) for faster computation and
+       contains pext data compared to gnomad.genes.GRCh38.GENCODEv39.ht (which was
+       used by the browser for ES export) under the same path.
+
     :return: Path to browser gene Table.
     """
-    return "gs://gnomad-public-requester-pays/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.ht"
+    return ("gs://gnomad-public-requester-pays/resources/grch38/browser/gnomad.genes.GRCh38.GENCODEv39.pext.ht")
 
 
 def public_release(data_type: str) -> VersionedTableResource:
@@ -780,7 +788,7 @@ def constraint(version: str = CURRENT_EXOME_RELEASE) -> VersionedTableResource:
     )
 
 
-def browser_variant(version: str = CURRENT_EXOME_RELEASE) -> GnomadPublicTableResource:
+def browser_variant(version: str = CURRENT_BROWSER_RELEASE) -> GnomadPublicTableResource:
     """
     Retrieve browser variant table.
 
@@ -788,9 +796,9 @@ def browser_variant(version: str = CURRENT_EXOME_RELEASE) -> GnomadPublicTableRe
     :return: Browser variant Table.
     :raises ValueError: If the version is not a valid release.
     """
-    if version not in EXOME_RELEASES:
+    if version not in BROWSER_RELEASES:
         raise ValueError(
-            f"Invalid version: {version}. Must be one of {EXOME_RELEASES}."
+            f"Invalid version: {version}. Must be one of {BROWSER_RELEASES}."
         )
 
     return GnomadPublicTableResource(path=_public_browser_variant_ht_path(version))

--- a/gnomad/resources/grch38/gnomad.py
+++ b/gnomad/resources/grch38/gnomad.py
@@ -789,22 +789,21 @@ def constraint(version: str = CURRENT_EXOME_RELEASE) -> VersionedTableResource:
     )
 
 
-def browser_variant(
-    version: str = CURRENT_BROWSER_RELEASE,
-) -> GnomadPublicTableResource:
+def browser_variant() -> VersionedTableResource:
     """
     Retrieve browser variant table.
 
-    :param version: One of the release versions of gnomAD on GRCh38. Default is the current exome release.
     :return: Browser variant Table.
-    :raises ValueError: If the version is not a valid release.
     """
-    if version not in BROWSER_RELEASES:
-        raise ValueError(
-            f"Invalid version: {version}. Must be one of {BROWSER_RELEASES}."
-        )
-
-    return GnomadPublicTableResource(path=_public_browser_variant_ht_path(version))
+    return VersionedTableResource(
+        CURRENT_BROWSER_RELEASE,
+        {
+            release: GnomadPublicTableResource(
+                path=_public_browser_variant_ht_path(release)
+            )
+            for release in BROWSER_RELEASES
+        },
+    )
 
 
 def browser_gene() -> GnomadPublicTableResource:


### PR DESCRIPTION
This is to add browser variant and gene tables in gnomad resources. For gene tables, they ran [multiple steps](https://github.com/broadinstitute/gnomad-browser/blob/main/data-pipeline/src/data_pipeline/data_types/gene.py) of transformation to get the intervals for CDS, UTR and exon. 