### PR TITLE
Note difference in rounding behavior between Sklearn and Onnx models 

### DIFF
--- a/gnomad/sample_qc/ancestry.py
+++ b/gnomad/sample_qc/ancestry.py
@@ -169,6 +169,9 @@ def apply_sklearn_classification_model(
     except TypeError:
         raise TypeError("The supplied model is not an sklearn model!")
 
+    logger.warning(
+        "sklearn models have different rounding behavior than ONNX models. This may lead to subtly different results around cutoffs."
+    )
     classification = fit.predict(data_pd)
     probs = fit.predict_proba(data_pd)
     probs = pd.DataFrame(probs, columns=[f"prob_{p}" for p in fit.classes_])


### PR DESCRIPTION
Note that gnomAD's assign_population_pcs() code DOES round outputs for prob_gen_anc when using an sklearn model but does NOT when using an onnx model.

For a given cutoff of 0.75 (for example) for prob_nfe , some sample with a real probability of 0.7499999999 could be imputed as 'Remaining' when using an onnx model but as 'Non-Finnish European' when using a sklearn model. 