### PR TITLE
Assign ONNX to 1.17.0 to avoid ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ hail
 hdbscan
 ipywidgets
 networkx
-onnx==0.17.0
+onnx==1.17.0
 onnxruntime
 scikit-learn
 skl2onnx

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ hail
 hdbscan
 ipywidgets
 networkx
-onnx
+onnx==0.17.0
 onnxruntime
 scikit-learn
 skl2onnx


### PR DESCRIPTION
I ran into this error using the latest release of ONNX 1.18.0 on May 12, 2025: 
```
Traceback (most recent call last):
  File "/home/jupyter/packages/gnomad_qc/v5/sample_qc/hard_filters.py", line 7, in <module>
    from gnomad.resources.grch38.reference_data import telomeres_and_centromeres
  File "/home/jupyter/packages/gnomad/resources/grch38/__init__.py", line 3, in <module>
    from .gnomad import *
  File "/home/jupyter/packages/gnomad/resources/grch38/gnomad.py", line 15, in <module>
    from gnomad.sample_qc.ancestry import POP_NAMES
  File "/home/jupyter/packages/gnomad/sample_qc/ancestry.py", line 13, in <module>
    from skl2onnx import convert_sklearn
  File "/home/jupyter/.local/lib/python3.10/site-packages/skl2onnx/__init__.py", line 16, in <module>
    from .convert import convert_sklearn, to_onnx, wrap_as_onnx_mixin
  File "/home/jupyter/.local/lib/python3.10/site-packages/skl2onnx/convert.py", line 8, in <module>
    from .proto import get_latest_tested_opset_version
  File "/home/jupyter/.local/lib/python3.10/site-packages/skl2onnx/proto/__init__.py", line 22, in <module>
    from onnx.helper import split_complex_to_pairs
ImportError: cannot import name 'split_complex_to_pairs' from 'onnx.helper' (/home/jupyter/.local/lib/python3.10/site-packages/onnx/helper.py)
```
Rolling back to 1.17.0 solved it, but I also reported it to **ONNX** github repo: https://github.com/onnx/onnx/issues/6962
They replied very quickly, because this function is becoming an internal in this new release, but **skl2onnx** hasn't updated accordingly, I also created an issue in their repo: https://github.com/onnx/sklearn-onnx/issues/1180. 
