### PR TITLE
Update sex terms repo-wide

### DIFF
--- a/gnomad/assessment/validity_checks.py
+++ b/gnomad/assessment/validity_checks.py
@@ -622,7 +622,7 @@ def sum_group_callstats(
     delimiter: str = "_",
     metric_first_field: bool = True,
     metrics: List[str] = ["AC", "AN", "nhomalt"],
-    gen_anc_label_name: str = "pop",
+    gen_anc_label_name: str = "gen_anc",
 ) -> None:
     """
     Compute the sum of annotations for a specified group of annotations, and compare to the annotated version.
@@ -639,9 +639,9 @@ def sum_group_callstats(
     :param verbose: If True, show top values of annotations being checked, including checks that pass; if False, show only top values of annotations that fail checks. Default is False.
     :param sort_order: List containing order to sort label group combinations. Default is SORT_ORDER.
     :param delimiter: String to use as delimiter when making group label combinations. Default is "_".
-    :param metric_first_field: If True, metric precedes label group, e.g. AC-afr-male. If False, label group precedes metric, afr-male-AC. Default is True.
+    :param metric_first_field: If True, metric precedes label group, e.g. AC-afr-XY. If False, label group precedes metric, afr-XY-AC. Default is True.
     :param metrics: List of metrics to sum and compare to annotationed versions. Default is ["AC", "AN", "nhomalt"].
-    :param gen_anc_label_name: Name of label used to denote genetic ancestry groups, such as "pop" or "gen_anc". Default is "pop".
+    :param gen_anc_label_name: Name of label used to denote genetic ancestry groups, such as "gen_anc" or "pop". Default is "gen_anc".
     :return: None
     """
     # TODO: Add support for subpop sums.
@@ -754,7 +754,7 @@ def check_raw_and_adj_callstats(
     :param subsets: List of sample subsets.
     :param verbose: If True, show top values of annotations being checked, including checks that pass; if False, show only top values of annotations that fail checks.
     :param delimiter: String to use as delimiter when making group label combinations. Default is "_".
-    :param metric_first_field: If True, metric precedes label group, e.g. AC-afr-male. If False, label group precedes metric, afr-male-AC. Default is True.
+    :param metric_first_field: If True, metric precedes label group, e.g. AC-afr-XY. If False, label group precedes metric, afr-XY-AC. Default is True.
     :param nhomalt_metric: Name of metric denoting homozygous alternate counts. Default is "nhomalt".
     :return: None
     """
@@ -1260,7 +1260,7 @@ def validate_release_t(
     :param verbose: If True, display top values of relevant annotations being checked, regardless of whether check conditions are violated; if False, display only top values of relevant annotations if check conditions are violated.
     :param show_percent_sites: Show percentage of sites that fail checks. Default is False.
     :param delimiter: String to use as delimiter when making group label combinations. Default is "-".
-    :param metric_first_field: If True, metric precedes label group, e.g. AC-afr-male. If False, label group precedes metric, afr-male-AC. Default is True.
+    :param metric_first_field: If True, metric precedes label group, e.g. AC-afr-XY. If False, label group precedes metric, afr-XY-AC. Default is True.
     :param sum_metrics: List of metrics to sum and compare to annotationed versions and between subsets and entire callset. Default is ["AC", "AN", "nhomalt"].
     :param sexes: List of sexes in table. Default is SEXES.
     :param groups: List of callstat groups, e.g. "adj" and "raw" contained within the callset. gnomAD does not store the raw callstats for the pop or sex groupings of any subset. Default is ["adj"]

--- a/gnomad/sample_qc/pipeline.py
+++ b/gnomad/sample_qc/pipeline.py
@@ -708,8 +708,8 @@ def annotate_sex(
         sex_ht = hl.impute_sex(
             mt[gt_expr],
             aaf_threshold=aaf_threshold,
-            male_threshold=f_stat_cutoff,
-            female_threshold=f_stat_cutoff,
+            xy_threshold=f_stat_cutoff,
+            xx_threshold=f_stat_cutoff,
             aaf=aaf_expr,
         )
 

--- a/gnomad/sample_qc/relatedness.py
+++ b/gnomad/sample_qc/relatedness.py
@@ -400,10 +400,10 @@ def infer_families(
 
     .. note::
 
-        This function only returns complete trios defined as: one child, one father and one mother (sex is required for both parents).
+        This function only returns complete trios defined as: one child, one father, and one mother (sex is required for both parents).
 
     :param relationship_ht: Input relationship table
-    :param sex: A Table or dict giving the sex for each sample (`TRUE`=female, `FALSE`=male). If a Table is given, it should have a field `is_female`.
+    :param sex: A Table or dict giving the sex for each sample (`TRUE`=XX, `FALSE`=XY). If a Table is given, it should have a field `is_xx`.
     :param duplicated_samples: All duplicated samples TO REMOVE (If not provided, this function won't work as it assumes that each child has exactly two parents)
     :param i_col: Column containing the 1st sample of the pair in the relationship table
     :param j_col: Column containing the 2nd sample of the pair in the relationship table
@@ -581,7 +581,7 @@ def infer_families(
                             fam_id=fam_id,
                             pat_id=possible_parents[0],
                             mat_id=possible_parents[1],
-                            is_female=sex.get(s),
+                            is_xx=sex.get(s),
                         )
                         for s in children
                     ]
@@ -661,7 +661,7 @@ def infer_families(
 
     # If sex is a Table, extract sex information as a Dict
     if isinstance(sex, hl.Table):
-        sex = dict(hl.tuple([sex.s, sex.is_female]).collect())
+        sex = dict(hl.tuple([sex.s, sex.is_xx]).collect())
 
     # Collect all related sample pairs and
     # create a dictionnary with pairs as keys and relationships as values
@@ -766,7 +766,7 @@ def create_fake_pedigree(
                 pat_id=pat_id,
                 mat_id=mat_id,
                 fam_id=f"fake_{str(len(fake_trios))}",
-                is_female=bool(random.getrandbits(1)),
+                is_xx=bool(random.getrandbits(1)),
             )
 
     if tries == max_tries:
@@ -1051,7 +1051,7 @@ def generate_trio_stats_expr(
     :param transmitted_strata: Strata for the transmission counts
     :param de_novo_strata: Strata for the de novo counts
     :param ac_strata: Strata for the parent and child allele counts
-    :param proband_is_female_expr: An optional expression giving the sex the proband. If not given, DNMs are only computed for autosomes.
+    :param proband_is_xx_expr: An optional expression giving the karyotype of the proband (XX=True, XY=False). If not given, DNMs are only computed for autosomes.
     :return: An expression with the counts
     """
     # Create map for transmitted, untransmitted and DNM
@@ -1099,10 +1099,10 @@ def generate_trio_stats_expr(
         father_gt: hl.expr.CallExpression,
         mother_gt: hl.expr.CallExpression,
         locus: hl.expr.LocusExpression,
-        proband_is_female: Optional[hl.expr.BooleanExpression],
+        proband_is_xx: Optional[hl.expr.BooleanExpression],
     ) -> hl.expr.BooleanExpression:
         """Determine whether a trio genotype combination is a DNM."""
-        if proband_is_female is None:
+        if proband_is_xx is None:
             logger.warning(
                 "Since no proband sex expression was given to generate_trio_stats_expr,"
                 " only DNMs in autosomes will be counted."
@@ -1112,10 +1112,10 @@ def generate_trio_stats_expr(
                 proband_gt.is_het() & father_gt.is_hom_ref() & mother_gt.is_hom_ref(),
             )
         return hl.if_else(
-            locus.in_autosome_or_par() | (proband_is_female & locus.in_x_nonpar()),
+            locus.in_autosome_or_par() | (proband_is_xx & locus.in_x_nonpar()),
             proband_gt.is_het() & father_gt.is_hom_ref() & mother_gt.is_hom_ref(),
             hl.or_missing(
-                ~proband_is_female, proband_gt.is_hom_var() & father_gt.is_hom_ref()
+                ~proband_is_xx, proband_gt.is_hom_var() & father_gt.is_hom_ref()
             ),
         )
 

--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -14,7 +14,7 @@ logging.basicConfig(format="%(levelname)s (%(name)s %(lineno)s): %(message)s")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-SEXES = {"Male": "Male", "Female": "Female"}
+SEXES = {"XY": "XY", "XX": "XX"}
 
 
 def adjusted_sex_ploidy_expr(
@@ -61,20 +61,20 @@ def adjusted_sex_ploidy_expr(
 def adjust_sex_ploidy(
     mt: hl.MatrixTable,
     sex_expr: hl.expr.StringExpression,
-    male_str: str = "male",
-    female_str: str = "female",
+    xy_str: str = "xy",
+    xx_str: str = "xx",
 ) -> hl.MatrixTable:
     """
-    Convert males to haploid on non-PAR X/Y, sets females to missing on Y.
+    Convert XY to haploid on non-PAR X/Y, sets XX to missing on Y.
 
     :param mt: Input MatrixTable
-    :param sex_expr: Expression pointing to sex in MT (if not male_str or female_str, no change)
-    :param male_str: String for males (default 'male')
-    :param female_str: String for females (default 'female')
+    :param sex_expr: Expression pointing to sex in MT (if not xy_str or xx_str, no change)
+    :param xy_str: String for XY (default 'xy')
+    :param xx_str: String for XX (default 'xx')
     :return: MatrixTable with fixed ploidy for sex chromosomes
     """
     return mt.annotate_entries(
-        GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, sex_expr, male_str, female_str)
+        GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, sex_expr, xy_str, xx_str)
     )
 
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1239,23 +1239,23 @@ def missing_callstats_expr() -> hl.expr.StructExpression:
     )
 
 
-def set_female_y_metrics_to_na_expr(
+def set_xx_y_metrics_to_na_expr(
     t: Union[hl.Table, hl.MatrixTable],
     freq_expr: Union[hl.expr.ArrayExpression, str] = "freq",
     freq_meta_expr: Union[hl.expr.ArrayExpression, str] = "freq_meta",
     freq_index_dict_expr: Union[hl.expr.DictExpression, str] = "freq_index_dict",
 ) -> hl.expr.ArrayExpression:
     """
-    Set Y-variant frequency callstats for female-specific metrics to missing structs.
+    Set Y-variant frequency callstats for XX-specific metrics to missing structs.
 
-    :param t: Table or MatrixTable for which to adjust female metrics.
+    :param t: Table or MatrixTable for which to adjust XX metrics.
     :param freq_expr: Array expression or string annotation name for the frequency
         array. Default is "freq".
     :param freq_meta_expr: Array expression or string annotation name for the frequency
         metadata. Default is "freq_meta".
     :param freq_index_dict_expr: Dict expression or string annotation name for the
         frequency metadata index dictionary. Default is "freq_index_dict".
-    :return: Hail array expression to set female Y-variant metrics to missing values.
+    :return: Hail array expression to set XX Y-variant metrics to missing values.
     """
     if isinstance(freq_expr, str):
         freq_expr = t[freq_expr]
@@ -1264,7 +1264,7 @@ def set_female_y_metrics_to_na_expr(
     if isinstance(freq_index_dict_expr, str):
         freq_index_dict_expr = t[freq_index_dict_expr]
 
-    female_idx = hl.map(
+    xx_idx = hl.map(
         lambda x: freq_index_dict_expr[x],
         hl.filter(lambda x: x.contains("XX"), freq_index_dict_expr.keys()),
     )
@@ -1274,7 +1274,7 @@ def set_female_y_metrics_to_na_expr(
         (t.locus.in_y_nonpar() | t.locus.in_y_par()),
         hl.map(
             lambda x: hl.if_else(
-                female_idx.contains(x), missing_callstats_expr(), freq_expr[x]
+                xx_idx.contains(x), missing_callstats_expr(), freq_expr[x]
             ),
             freq_idx_range,
         ),

--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -26,7 +26,7 @@ SORT_ORDER = [
 ]
 """
 Order to sort subgroupings during VCF export.
-Ensures that INFO labels in VCF are in desired order (e.g., raw_AC_afr_female).
+Ensures that INFO labels in VCF are in desired order (e.g., raw_AC_afr_XX).
 """
 
 GROUPS = ["adj", "raw"]
@@ -675,11 +675,11 @@ def make_label_combos(
     """
     Make combinations of all possible labels for a supplied dictionary of label groups.
 
-    For example, if label_groups is `{"sex": ["male", "female"], "pop": ["afr", "nfe", "amr"]}`,
-    this function will return `["afr_male", "afr_female", "nfe_male", "nfe_female", "amr_male", "amr_female']`
+    For example, if label_groups is {"sex": ["XY", "XX"], "gen_anc": ["afr", "nfe", "amr"]},
+    this function will return ["afr_XY", "afr_XX", "nfe_XY", "nfe_XX", "amr_XY", "amr_XX']
 
     :param label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
-        e.g. "sex" or "pop", and value is a list of all possible values for that grouping (e.g. ["male", "female"] or ["afr", "nfe", "amr"]).
+        e.g. "sex" or "gen_anc", and value is a list of all possible values for that grouping (e.g. ["XY", "XX"] or ["afr", "nfe", "amr"]).
     :param sort_order: List containing order to sort label group combinations. Default is SORT_ORDER.
     :param label_delimiter: String to use as delimiter when making group label combinations.
     :return: list of all possible combinations of values for the supplied label groupings.
@@ -711,7 +711,7 @@ def index_globals(
     :param globals_array: Ordered list containing dictionary entries describing all the grouping combinations contained in the globals_array annotation.
        Keys are the grouping type (e.g., 'group', 'pop', 'sex') and values are the grouping attribute (e.g., 'adj', 'eas', 'XY').
     :param label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
-        e.g. "sex" or "pop", and value is a list of all possible values for that grouping (e.g. ["male", "female"] or ["afr", "nfe", "amr"])
+        e.g. "sex" or "gen_anc", and value is a list of all possible values for that grouping (e.g. ["XY", "XX"] or ["afr", "nfe", "amr"])
     :param label_delimiter: String used as delimiter when making group label combinations.
     :return: Dictionary keyed by specified label grouping combinations, with values describing the corresponding index
         of each grouping entry in the globals
@@ -735,14 +735,14 @@ def make_combo_header_text(
     """
     Programmatically generate text to populate the VCF header description for a given variant annotation with specific groupings and subset.
 
-    For example, if preposition is "for", group_types is ["group", "pop", "sex"], and combo_fields is ["adj", "afr", "female"],
-    this function will return the string " for female samples in the African-American/African genetic ancestry group".
+    For example, if preposition is "for", group_types is ["group", "gen_anc", "sex"], and combo_fields is ["adj", "afr", "XX"],
+    this function will return the string " for XX samples in the African-American/African genetic ancestry group".
 
     :param preposition: Relevant preposition to precede automatically generated text.
     :param combo_dict: Dict with grouping types as keys and values for grouping type as values. This function generates text for these values.
-        Possible grouping types are: "group", "pop", "sex", and "subpop".
-        Example input: {"pop": "afr", "sex": "female"}
-    :param pop_names: Dict with global population names (keys) and population descriptions (values).
+        Possible grouping types are: "group", "gen_anc", "sex", and "subgroup".
+        Example input: {"gen_anc": "afr", "sex": "XX"}
+    :param pop_names: Dict with global genetic ancestry group names (keys) and genetic ancestry group descriptions (values).
     :return: String with automatically generated description text for a given set of combo fields.
     """
     header_text = " " + preposition
@@ -831,15 +831,15 @@ def make_info_dict(
     Creates:
         - INFO fields for age histograms (bin freq, n_smaller, and n_larger for heterozygous and homozygous variant carriers)
         - INFO fields for popmax AC, AN, AF, nhomalt, and popmax population
-        - INFO fields for AC, AN, AF, nhomalt for each combination of sample population, sex, and subpopulation, both for adj and raw data
+        - INFO fields for AC, AN, AF, nhomalt for each combination of sample genetic ancestry group, sex, and subgroup, both for adj and raw data
         - INFO fields for filtering allele frequency (faf) annotations
 
     :param prefix: Prefix string for data, e.g. "gnomAD". Default is empty string.
     :param suffix: Suffix string for data, e.g. "gnomAD". Default is empty string.
     :param prefix_before_metric: Whether prefix should be added before the metric (AC, AN, AF, nhomalt, faf95, faf99) in INFO field. Default is True.
-    :param pop_names: Dict with global population names (keys) and population descriptions (values). Default is POP_NAMES.
+    :param pop_names: Dict with global genetic ancestry group names (keys) and genetic ancestry group descriptions (values). Default is POP_NAMES.
     :param label_groups: Dictionary containing an entry for each label group, where key is the name of the grouping,
-        e.g. "sex" or "pop", and value is a list of all possible values for that grouping (e.g. ["male", "female"] or ["afr", "nfe", "amr"]).
+        e.g. "sex" or "gen_anc", and value is a list of all possible values for that grouping (e.g. ["XY", "XX"] or ["afr", "nfe", "amr"]).
     :param label_delimiter: String to use as delimiter when making group label combinations.
     :param bin_edges: Dictionary keyed by annotation type, with values that reflect the bin edges corresponding to the annotation.
     :param faf: If True, use alternate logic to auto-populate dictionary values associated with filter allele frequency annotations.
@@ -1482,21 +1482,21 @@ def make_hist_dict(
     return header_hist_dict
 
 
-def set_female_y_metrics_to_na(
+def set_xx_y_metrics_to_na(
     t: Union[hl.Table, hl.MatrixTable],
 ) -> Dict[str, hl.expr.Int32Expression]:
     """
-    Set AC, AN, and nhomalt chrY variant annotations for females to NA (instead of 0).
+    Set AC, AN, and nhomalt chrY variant annotations for XX samples to NA (instead of 0).
 
-    :param t: Table/MatrixTable containing female variant annotations.
+    :param t: Table/MatrixTable containing XX variant annotations.
     :return: Dictionary with reset annotations
     """
     metrics = list(t.row.info)
-    female_metrics = [x for x in metrics if "_female" in x or "_XX" in x]
+    xx_metrics = [x for x in metrics if "_XX" in x]
 
-    female_metrics_dict = {}
-    for metric in female_metrics:
-        female_metrics_dict.update(
+    xx_metrics_dict = {}
+    for metric in xx_metrics:
+        xx_metrics_dict.update(
             {
                 f"{metric}": hl.or_missing(
                     (~t.locus.in_y_nonpar() & ~t.locus.in_y_par()),
@@ -1504,7 +1504,7 @@ def set_female_y_metrics_to_na(
                 )
             }
         )
-    return female_metrics_dict
+    return xx_metrics_dict
 
 
 def build_vcf_export_reference(


### PR DESCRIPTION
PR updates terms to use karyotype terms (XX/xx, XY/xy) instead of gender terms. PR also updates a few instances of "population"/"pop" to "genetic ancestry"/"gen_anc"
