### PR TITLE
Add coverage entry agg function

### DIFF
--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1305,12 +1305,12 @@ def get_coverage_agg_func(
 def compute_coverage_stats(
     mtds: Union[hl.MatrixTable, hl.vds.VariantDataset],
     reference_ht: hl.Table,
-    dp_field: str = "DP",
     interval_ht: Optional[hl.Table] = None,
     coverage_over_x_bins: List[int] = [1, 5, 10, 15, 20, 25, 30, 50, 100],
     row_key_fields: List[str] = ["locus"],
     strata_expr: Optional[List[Dict[str, hl.expr.StringExpression]]] = None,
     group_membership_ht: Optional[hl.Table] = None,
+    dp_field: str = "DP",
 ) -> hl.Table:
     """
     Compute coverage statistics for every base of the `reference_ht` provided.
@@ -1327,7 +1327,6 @@ def compute_coverage_stats(
 
     :param mtds: Input sparse MT or VDS.
     :param reference_ht: Input reference HT.
-    :param dp_field: Name of sample depth field. Default is DP.
     :param interval_ht: Optional Table containing intervals to filter to.
     :param coverage_over_x_bins: List of boundaries for computing samples over X.
     :param row_key_fields: List of row key fields to use for joining `mtds` with
@@ -1338,6 +1337,7 @@ def compute_coverage_stats(
     :param group_membership_ht: Optional Table containing group membership annotations
         to stratify the coverage stats by. Only one of `group_membership_ht` or
         `strata_expr` can be specified.
+    :param dp_field: Name of sample depth field. Default is DP.
     :return: Table with per-base coverage stats.
     """
     is_vds = isinstance(mtds, hl.vds.VariantDataset)

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1295,7 +1295,10 @@ def get_coverage_agg_func(
             # This expression creates a counter DP -> number of samples for DP
             # between 0 and max_cov_bin.
             coverage_counter=hl.agg.counter(hl.min(max_cov_bin, dp)),
-            mean=hl.if_else(hl.is_nan(hl.agg.mean(dp)), 0, hl.agg.mean(dp)),
+            mean=hl.bind(
+                lambda mean_dp: hl.if_else(hl.is_nan(mean_dp), 0, mean_dp),
+                hl.agg.mean(dp),
+            ),
             median_approx=hl.or_else(hl.agg.approx_median(dp), 0),
             total_DP=hl.agg.sum(dp),
         ),

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1305,6 +1305,7 @@ def get_coverage_agg_func(
 def compute_coverage_stats(
     mtds: Union[hl.MatrixTable, hl.vds.VariantDataset],
     reference_ht: hl.Table,
+    dp_field: str = "DP",
     interval_ht: Optional[hl.Table] = None,
     coverage_over_x_bins: List[int] = [1, 5, 10, 15, 20, 25, 30, 50, 100],
     row_key_fields: List[str] = ["locus"],
@@ -1324,12 +1325,13 @@ def compute_coverage_stats(
     computed on. It needs to be keyed by `locus`. The `reference_ht` can e.g. be
     created using `get_reference_ht`.
 
-    :param mtds: Input sparse MT or VDS
-    :param reference_ht: Input reference HT
-    :param interval_ht: Optional Table containing intervals to filter to
-    :param coverage_over_x_bins: List of boundaries for computing samples over X
+    :param mtds: Input sparse MT or VDS.
+    :param reference_ht: Input reference HT.
+    :param dp_field: Name of sample depth field. Default is DP.
+    :param interval_ht: Optional Table containing intervals to filter to.
+    :param coverage_over_x_bins: List of boundaries for computing samples over X.
     :param row_key_fields: List of row key fields to use for joining `mtds` with
-        `reference_ht`
+        `reference_ht`.
     :param strata_expr: Optional list of dicts containing expressions to stratify the
         coverage stats by. Only one of `group_membership_ht` or `strata_expr` can be
         specified.
@@ -1358,7 +1360,9 @@ def compute_coverage_stats(
     max_cov_bin = cov_bins[-1]
     cov_bins = hl.array(cov_bins)
     entry_agg_funcs = {
-        "coverage_stats": get_coverage_agg_func(dp_field="DP", max_cov_bin=max_cov_bin)
+        "coverage_stats": get_coverage_agg_func(
+            dp_field=dp_field, max_cov_bin=max_cov_bin
+        )
     }
 
     ht = compute_stats_per_ref_site(
@@ -1367,7 +1371,7 @@ def compute_coverage_stats(
         entry_agg_funcs,
         row_key_fields=row_key_fields,
         interval_ht=interval_ht,
-        entry_keep_fields=[gt_field, "DP"],
+        entry_keep_fields=[gt_field, dp_field],
         strata_expr=strata_expr,
         group_membership_ht=group_membership_ht,
     )

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -3,7 +3,6 @@
 import logging
 
 import hail as hl
-import pytest
 
 from gnomad.utils.sparse_mt import get_coverage_agg_func
 
@@ -13,25 +12,6 @@ logger = logging.getLogger(__name__)
 
 class TestGetCoverageAggFunc:
     """Test the get_coverage_agg_func function."""
-
-    @pytest.fixture
-    def sample_mt(self):
-        """Fixture to create a sample MatrixTable with DP field."""
-        return hl.Table.parallelize(
-            [
-                {"locus": hl.locus("chr1", 1000), "s": "sample1", "DP": 10},
-                {"locus": hl.locus("chr1", 1000), "s": "sample2", "DP": 20},
-                {"locus": hl.locus("chr1", 1000), "s": "sample3", "DP": 30},
-                {"locus": hl.locus("chr1", 1000), "s": "sample4", "DP": None},
-                {"locus": hl.locus("chr1", 1000), "s": "sample5", "DP": 0},
-                {
-                    "locus": hl.locus("chr1", 1000),
-                    "s": "sample6",
-                    "DP": 150,
-                },  # Above max_cov_bin
-            ],
-            hl.tstruct(locus=hl.tlocus("GRCh38"), s=hl.tstr, DP=hl.tint32),
-        ).key_by("locus", "s")
 
     def test_get_coverage_agg_func_returns_tuple(self):
         """Test that get_coverage_agg_func returns a tuple of two functions."""

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -46,22 +46,6 @@ class TestGetCoverageAggFunc:
         result = hl.eval(transform_func(test_struct))
         assert result == 0
 
-    def test_get_coverage_agg_func_custom_dp_field_transform(self):
-        """Test get_coverage_agg_func transform function with custom DP field name."""
-        transform_func, _ = get_coverage_agg_func(dp_field="depth")
-
-        # Test the transform function with custom field name.
-        test_cases = [
-            ({"depth": 10}, 10),
-            ({"depth": 0}, 0),
-            ({"depth": 100}, 100),
-        ]
-
-        for input_data, expected in test_cases:
-            test_struct = hl.Struct(**input_data)
-            result = hl.eval(transform_func(test_struct))
-            assert result == expected
-
     def test_get_coverage_agg_func_with_nan_values(self):
         """Test that NaN values are handled correctly."""
         transform_func, _ = get_coverage_agg_func()
@@ -149,19 +133,6 @@ class TestGetCoverageAggFunc:
         assert result.mean == 10.4  # (-5+10+20-3+30)/5.
         assert result.coverage_counter.get(-5, 0) == 1
         assert result.coverage_counter.get(-3, 0) == 1
-
-    def test_aggregation_function_with_custom_dp_field(self):
-        """Test aggregation function works with custom DP field names."""
-        _, agg_func = get_coverage_agg_func(dp_field="depth")
-        test_data = [10, 20, 30, 40, 50]
-        ht = hl.Table.parallelize(
-            [{"depth": v} for v in test_data], hl.tstruct(depth=hl.tint32)
-        )
-        result = ht.aggregate(agg_func(ht.depth))
-
-        # Should work with custom field name.
-        assert result.mean == 30.0
-        assert result.total_DP == 150
 
     def test_aggregation_function_edge_cases(self):
         """Test aggregation function with edge cases."""

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -196,7 +196,7 @@ class TestGetCoverageAggFunc:
             [{"DP": v} for v in test_data_odd], hl.tstruct(DP=hl.tint32)
         )
         result_odd = ht_odd.aggregate(agg_func(ht_odd.DP))
-        assert result_odd.median_approx == 30  # Should be close to 30.
+        assert result_odd.median_approx == 30
 
         # Test with even number of values - approximate median may vary.
         test_data_even = [10, 20, 30, 40]
@@ -204,8 +204,10 @@ class TestGetCoverageAggFunc:
             [{"DP": v} for v in test_data_even], hl.tstruct(DP=hl.tint32)
         )
         result_even = ht_even.aggregate(agg_func(ht_even.DP))
-        # Approximate median may not be exactly 25, but should be reasonable.
-        assert result_even.median_approx in [20, 25, 30]  # Allow some variation.
+        # Hail's median_approx is non-deterministic, so we can't test for exact
+        # equality.
+        # Approximate median should be close to 25 (true median).
+        assert result_even.median_approx in [20, 25, 30]
 
     def test_transform_function_with_various_inputs(self):
         """Test the transform function with various input types."""

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -54,7 +54,7 @@ class TestGetCoverageAggFunc:
         test_cases = [
             ({"depth": 10}, 10),
             ({"depth": 0}, 0),
-            ({"depth": 100}, 100),  # Should not be capped at 50 in transform.
+            ({"depth": 100}, 100),
         ]
 
         for input_data, expected in test_cases:

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -6,7 +6,7 @@ import hail as hl
 
 from gnomad.utils.sparse_mt import get_coverage_agg_func
 
-# Set up logger for tests
+# Set up logger for tests.
 logger = logging.getLogger(__name__)
 
 
@@ -24,15 +24,15 @@ class TestGetCoverageAggFunc:
         """Test get_coverage_agg_func with default parameters."""
         transform_func, agg_func = get_coverage_agg_func()
 
-        # Test the transform function with various inputs
+        # Test the transform function with various inputs.
         test_cases = [
-            ({"DP": 10}, 10),  # Normal case
-            ({"DP": 0}, 0),  # Zero value
-            ({"DP": 150}, 150),  # Large value
+            ({"DP": 10}, 10),  # Normal case.
+            ({"DP": 0}, 0),  # Zero value.
+            ({"DP": 150}, 150),  # Large value.
         ]
 
         for input_data, expected in test_cases:
-            # Create a simple struct for testing
+            # Create a simple struct for testing.
             test_struct = hl.Struct(**input_data)
             result = hl.eval(transform_func(test_struct))
             assert result == expected
@@ -41,7 +41,7 @@ class TestGetCoverageAggFunc:
         """Test that missing values are handled correctly."""
         transform_func, agg_func = get_coverage_agg_func()
 
-        # Test with missing value - need to use hl.missing
+        # Test with missing value - need to use hl.missing.
         test_struct = hl.Struct(DP=hl.missing(hl.tint32))
         result = hl.eval(transform_func(test_struct))
         assert result == 0
@@ -52,17 +52,18 @@ class TestGetCoverageAggFunc:
             dp_field="depth", max_cov_bin=50
         )
 
-        # Test the transform function with custom field name
+        # Test the transform function with custom field name.
         test_cases = [
             ({"depth": 10}, 10),
             ({"depth": 0}, 0),
-            ({"depth": 100}, 100),  # Should not be capped at 50 in transform
+            ({"depth": 100}, 100),  # Should not be capped at 50 in transform.
         ]
 
         for input_data, expected in test_cases:
             test_struct = hl.Struct(**input_data)
             result = hl.eval(transform_func(test_struct))
             assert result == expected
+
 
     def test_get_coverage_agg_func_with_nan_values(self):
         """Test that NaN values are handled correctly."""
@@ -75,11 +76,11 @@ class TestGetCoverageAggFunc:
         """Test that the aggregation function returns the expected structure."""
         transform_func, agg_func = get_coverage_agg_func()
         test_data = [10, 20, 30, 40, 50]
-        # Create a Hail Table with a DP field
+        # Create a Hail Table with a DP field.
         ht = hl.Table.parallelize(
             [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
         )
-        # Aggregate using the aggregation function
+        # Aggregate using the aggregation function.
         result = ht.aggregate(agg_func(ht.DP))
         expected_fields = ["coverage_counter", "mean", "median_approx", "total_DP"]
         for field in expected_fields:
@@ -94,10 +95,10 @@ class TestGetCoverageAggFunc:
         )
         result = ht.aggregate(agg_func(ht.DP))
 
-        # Test computed values
-        assert result.mean == 30.0  # (10+20+30+40+50)/5
-        assert result.total_DP == 150  # 10+20+30+40+50
-        assert result.median_approx == 30  # Approximate median
+        # Test computed values.
+        assert result.mean == 30.0  # (10+20+30+40+50)/5.
+        assert result.total_DP == 150  # 10+20+30+40+50.
+        assert result.median_approx == 30  # Approximate median.
         assert result.coverage_counter.get(10, 0) == 1
         assert result.coverage_counter.get(20, 0) == 1
         assert result.coverage_counter.get(30, 0) == 1
@@ -115,10 +116,10 @@ class TestGetCoverageAggFunc:
         result = ht.aggregate(agg_func(ht.DP))
 
         # Missing values should be transformed to 0, so they should be included in
-        # aggregation
-        assert result.total_DP == 120  # 10+20+0+40+50
-        # The mean calculation may vary depending on how missing values are handled
-        # Let's check that the structure is correct
+        # aggregation.
+        assert result.total_DP == 120  # 10+20+0+40+50.
+        # The mean calculation may vary depending on how missing values are handled.
+        # Let's check that the structure is correct.
         assert hasattr(result, "mean")
         assert hasattr(result, "total_DP")
         assert hasattr(result, "coverage_counter")
@@ -132,9 +133,9 @@ class TestGetCoverageAggFunc:
         )
         result = ht.aggregate(agg_func(ht.DP))
 
-        # Zero values should be preserved
-        assert result.total_DP == 60  # 0+10+20+0+30
-        assert result.mean == 12.0  # (0+10+20+0+30)/5
+        # Zero values should be preserved.
+        assert result.total_DP == 60  # 0+10+20+0+30.
+        assert result.mean == 12.0  # (0+10+20+0+30)/5.
         assert result.coverage_counter.get(0, 0) == 2
 
     def test_aggregation_function_with_negative_values(self):
@@ -146,9 +147,9 @@ class TestGetCoverageAggFunc:
         )
         result = ht.aggregate(agg_func(ht.DP))
 
-        # Negative values should be preserved
-        assert result.total_DP == 52  # -5+10+20-3+30
-        assert result.mean == 10.4  # (-5+10+20-3+30)/5
+        # Negative values should be preserved.
+        assert result.total_DP == 52  # -5+10+20-3+30.
+        assert result.mean == 10.4  # (-5+10+20-3+30)/5.
         assert result.coverage_counter.get(-5, 0) == 1
         assert result.coverage_counter.get(-3, 0) == 1
 
@@ -161,7 +162,7 @@ class TestGetCoverageAggFunc:
         )
         result = ht.aggregate(agg_func(ht.depth))
 
-        # Should work with custom field name
+        # Should work with custom field name.
         assert result.mean == 30.0
         assert result.total_DP == 150
 
@@ -169,14 +170,14 @@ class TestGetCoverageAggFunc:
         """Test aggregation function with edge cases."""
         transform_func, agg_func = get_coverage_agg_func()
 
-        # Test with single value
+        # Test with single value.
         ht1 = hl.Table.parallelize([{"DP": 42}], hl.tstruct(DP=hl.tint32))
         result1 = ht1.aggregate(agg_func(ht1.DP))
         assert result1.mean == 42.0
         assert result1.total_DP == 42
         assert result1.coverage_counter.get(42, 0) == 1
 
-        # Test with empty table (should handle gracefully)
+        # Test with empty table (should handle gracefully).
         ht2 = hl.Table.parallelize([], hl.tstruct(DP=hl.tint32))
         result2 = ht2.aggregate(agg_func(ht2.DP))
         assert result2.total_DP == 0
@@ -205,15 +206,15 @@ class TestGetCoverageAggFunc:
         result = ht.aggregate(agg_func(ht.DP))
         coverage_counter = result.coverage_counter
 
-        # Values 1, 2, 3 should be counted as themselves
+        # Values 1, 2, 3 should be counted as themselves.
         assert coverage_counter.get(1, 0) == 1
         assert coverage_counter.get(2, 0) == 1
-        # Values 3-10 should all be counted as 3 (max_cov_bin)
+        # Values 3-10 should all be counted as 3 (max_cov_bin).
         # So there should be 8 values at position 3: the original value 3 plus 7
-        # capped values (4-10)
+        # capped values (4-10).
         assert coverage_counter.get(3, 0) == 8
 
-        # No values should be counted above max_cov_bin
+        # No values should be counted above max_cov_bin.
         assert coverage_counter.get(4, 0) == 0
         assert coverage_counter.get(5, 0) == 0
 
@@ -221,41 +222,41 @@ class TestGetCoverageAggFunc:
         """Test that median_approx provides reasonable approximation."""
         transform_func, agg_func = get_coverage_agg_func()
 
-        # Test with odd number of values
+        # Test with odd number of values.
         test_data_odd = [10, 20, 30, 40, 50]
         ht_odd = hl.Table.parallelize(
             [{"DP": v} for v in test_data_odd], hl.tstruct(DP=hl.tint32)
         )
         result_odd = ht_odd.aggregate(agg_func(ht_odd.DP))
-        assert result_odd.median_approx == 30  # Should be close to 30
+        assert result_odd.median_approx == 30  # Should be close to 30.
 
-        # Test with even number of values - approximate median may vary
+        # Test with even number of values - approximate median may vary.
         test_data_even = [10, 20, 30, 40]
         ht_even = hl.Table.parallelize(
             [{"DP": v} for v in test_data_even], hl.tstruct(DP=hl.tint32)
         )
         result_even = ht_even.aggregate(agg_func(ht_even.DP))
-        # Approximate median may not be exactly 25, but should be reasonable
-        assert result_even.median_approx in [20, 25, 30]  # Allow some variation
+        # Approximate median may not be exactly 25, but should be reasonable.
+        assert result_even.median_approx in [20, 25, 30]  # Allow some variation.
 
     def test_transform_function_with_various_inputs(self):
         """Test the transform function with various input types."""
         transform_func, agg_func = get_coverage_agg_func(max_cov_bin=100)
 
-        # Create a sample dataset
+        # Create a sample dataset.
         sample_data = [{"DP": 10}, {"DP": 20}, {"DP": 30}, {"DP": 0}, {"DP": 150}]
 
-        # Transform the data
+        # Transform the data.
         transformed_data = []
         for data in sample_data:
             test_struct = hl.Struct(**data)
             result = hl.eval(transform_func(test_struct))
             transformed_data.append(result)
 
-        # Test that transformation worked correctly
+        # Test that transformation worked correctly.
         assert len(transformed_data) == 5
-        assert 150 in transformed_data  # Large value should not be capped in transform
-        assert 0 in transformed_data  # Zero values should be preserved
+        assert 150 in transformed_data  # Large value should not be capped in transform.
+        assert 0 in transformed_data  # Zero values should be preserved.
 
     def test_different_dp_field_names(self):
         """Test that different DP field names work correctly."""
@@ -264,7 +265,7 @@ class TestGetCoverageAggFunc:
         for field_name in field_names:
             transform_func, agg_func = get_coverage_agg_func(dp_field=field_name)
 
-            # Test with the custom field name
+            # Test with the custom field name.
             test_struct = hl.Struct(**{field_name: 25})
             result = hl.eval(transform_func(test_struct))
             assert result == 25
@@ -273,10 +274,10 @@ class TestGetCoverageAggFunc:
         """Test that transform and aggregation functions work together correctly."""
         transform_func, agg_func = get_coverage_agg_func(max_cov_bin=50)
 
-        # Create test data with various edge cases (avoiding NaN for now)
+        # Create test data with various edge cases (avoiding NaN for now).
         test_data = [10, 20, None, 40, 50, 0, 100, -5]
 
-        # Test transform function on individual values
+        # Test transform function on individual values.
         transformed_values = []
         for value in test_data:
             if value is None:
@@ -286,35 +287,35 @@ class TestGetCoverageAggFunc:
             result = hl.eval(transform_func(test_struct))
             transformed_values.append(result)
 
-        # Expected transformed values: [10, 20, 0, 40, 50, 0, 100, -5]
+        # Expected transformed values: [10, 20, 0, 40, 50, 0, 100, -5].
         expected_transformed = [10, 20, 0, 40, 50, 0, 100, -5]
         assert transformed_values == expected_transformed
 
-        # Test aggregation function on the same data
+        # Test aggregation function on the same data.
         ht = hl.Table.parallelize(
             [{"DP": v if v is not None else hl.missing(hl.tint32)} for v in test_data],
             hl.tstruct(DP=hl.tint32),
         )
 
-        # Apply the transform function to each row to create transformed data
+        # Apply the transform function to each row to create transformed data.
         ht = ht.annotate(transformed_DP=transform_func(ht))
         result = ht.aggregate(agg_func(ht.transformed_DP))
 
-        # Check that aggregation works correctly
-        assert result.total_DP == 215  # 10+20+0+40+50+0+100-5
-        # The aggregation function operates on transformed data (missing values become 0)
-        # So mean should be calculated from all 8 values: 215/8 = 26.875
+        # Check that aggregation works correctly.
+        assert result.total_DP == 215  # 10+20+0+40+50+0+100-5.
+        # The aggregation function operates on transformed data (missing values become 0).
+        # So mean should be calculated from all 8 values: 215/8 = 26.875.
         assert (
             abs(result.mean - sum(expected_transformed) / len(expected_transformed))
             < 0.1
-        )  # Allow small tolerance
+        )  # Allow small tolerance.
         # Now that we're using transformed data, there are 2 zeros: one explicit,
-        # one from missing
+        # one from missing.
         assert (
             result.coverage_counter.get(0, 0) == 2
-        )  # 2 zero values (explicit 0 + missing->0)
-        # Values 50 (original) and 100 (capped) should be at position 50
-        assert result.coverage_counter.get(50, 0) == 2  # Accept actual behavior
+        )  # 2 zero values (explicit 0 + missing->0).
+        # Values 50 (original) and 100 (capped) should be at position 50.
+        assert result.coverage_counter.get(50, 0) == 2  # Accept actual behavior.
 
     def test_custom_field_transform_and_aggregation(self):
         """Test both transform and aggregation with custom field names."""
@@ -322,11 +323,11 @@ class TestGetCoverageAggFunc:
             dp_field="depth", max_cov_bin=30
         )
 
-        # Test transform function
+        # Test transform function.
         test_cases = [
             ({"depth": 10}, 10),
             ({"depth": 0}, 0),
-            ({"depth": 50}, 50),  # Should not be capped in transform
+            ({"depth": 50}, 50),  # Should not be capped in transform.
         ]
 
         for input_data, expected in test_cases:
@@ -342,8 +343,8 @@ class TestGetCoverageAggFunc:
 
         result = ht.aggregate(agg_func(ht.depth))
 
-        # Check aggregation results
-        assert result.total_DP == 275  # Sum of all values
-        assert result.mean == 27.5  # 275/10
-        # Values 35, 40, 45, 50 should be capped to 30, plus the original 30
-        assert result.coverage_counter.get(30, 0) == 5  # 4 capped + 1 original
+        # Check aggregation results.
+        assert result.total_DP == 275  # Sum of all values.
+        assert result.mean == 27.5  # 275/10.
+        # Values 35, 40, 45, 50 should be capped to 30, plus the original 30.
+        assert result.coverage_counter.get(30, 0) == 5  # 4 capped + 1 original.

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -298,8 +298,9 @@ class TestGetCoverageAggFunc:
         assert (
             result.coverage_counter.get(0, 0) == 2
         )  # 2 zero values (explicit 0 + missing->0).
-        # Values 50 (original) and 100 (capped) should be at position 50.
-        assert result.coverage_counter.get(50, 0) == 2  # Accept actual behavior.
+        # Values 50 (original) and 100 (capped to 50 by max_cov_bin) should be at
+        # position 50.
+        assert result.coverage_counter.get(50, 0) == 2
 
     def test_custom_field_transform_and_aggregation(self):
         """Test both transform and aggregation with custom field names."""

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -1,0 +1,427 @@
+"""Tests for the sparse_mt utility module."""
+
+import hail as hl
+import pytest
+
+from gnomad.utils.sparse_mt import get_coverage_agg_func
+
+
+class TestGetCoverageAggFunc:
+    """Test the get_coverage_agg_func function."""
+
+    @pytest.fixture
+    def sample_mt(self):
+        """Fixture to create a sample MatrixTable with DP field."""
+        return hl.Table.parallelize(
+            [
+                {"locus": hl.locus("chr1", 1000), "s": "sample1", "DP": 10},
+                {"locus": hl.locus("chr1", 1000), "s": "sample2", "DP": 20},
+                {"locus": hl.locus("chr1", 1000), "s": "sample3", "DP": 30},
+                {"locus": hl.locus("chr1", 1000), "s": "sample4", "DP": None},
+                {"locus": hl.locus("chr1", 1000), "s": "sample5", "DP": 0},
+                {
+                    "locus": hl.locus("chr1", 1000),
+                    "s": "sample6",
+                    "DP": 150,
+                },  # Above max_cov_bin
+            ],
+            hl.tstruct(locus=hl.tlocus("GRCh38"), s=hl.tstr, DP=hl.tint32),
+        ).key_by("locus", "s")
+
+    def test_get_coverage_agg_func_returns_tuple(self):
+        """Test that get_coverage_agg_func returns a tuple of two functions."""
+        transform_func, agg_func = get_coverage_agg_func()
+
+        assert callable(transform_func)
+        assert callable(agg_func)
+
+    def test_get_coverage_agg_func_default_params(self):
+        """Test get_coverage_agg_func with default parameters."""
+        transform_func, agg_func = get_coverage_agg_func()
+
+        # Test the transform function with various inputs
+        test_cases = [
+            ({"DP": 10}, 10),  # Normal case
+            ({"DP": 0}, 0),  # Zero value
+            ({"DP": 150}, 150),  # Large value
+        ]
+
+        for input_data, expected in test_cases:
+            # Create a simple struct for testing
+            test_struct = hl.Struct(**input_data)
+            result = hl.eval(transform_func(test_struct))
+            assert result == expected
+
+    def test_get_coverage_agg_func_missing_values(self):
+        """Test that missing values are handled correctly."""
+        transform_func, agg_func = get_coverage_agg_func()
+
+        # Test with missing value - need to use hl.missing
+        test_struct = hl.Struct(DP=hl.missing(hl.tint32))
+        result = hl.eval(transform_func(test_struct))
+        assert result == 0
+
+    def test_get_coverage_agg_func_custom_dp_field(self):
+        """Test get_coverage_agg_func with custom DP field name."""
+        transform_func, agg_func = get_coverage_agg_func(
+            dp_field="depth", max_cov_bin=50
+        )
+
+        # Test the transform function with custom field name
+        test_cases = [
+            ({"depth": 10}, 10),
+            ({"depth": 0}, 0),
+            ({"depth": 100}, 100),  # Should not be capped at 50 in transform
+        ]
+
+        for input_data, expected in test_cases:
+            test_struct = hl.Struct(**input_data)
+            result = hl.eval(transform_func(test_struct))
+            assert result == expected
+
+    def test_get_coverage_agg_func_max_cov_bin(self):
+        """Test that max_cov_bin parameter affects aggregation but not transformation."""
+        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=50)
+
+        # Transform function should not cap values
+        test_struct = hl.Struct(DP=100)
+        transform_result = hl.eval(transform_func(test_struct))
+        assert transform_result == 100  # Should not be capped
+
+        # The aggregation function would cap values during aggregation
+        # This is tested in integration tests below
+
+    def test_get_coverage_agg_func_with_nan_values(self):
+        """Test that NaN values are handled correctly."""
+        transform_func, agg_func = get_coverage_agg_func()
+        # Use Python float('nan') for NaN
+        test_struct = hl.Struct(DP=float("nan"))
+        result = hl.eval(transform_func(test_struct))
+        assert result == 0
+
+    def test_aggregation_function_structure(self):
+        """Test that the aggregation function returns the expected structure."""
+        transform_func, agg_func = get_coverage_agg_func()
+        test_data = [10, 20, 30, 40, 50]
+        # Create a Hail Table with a DP field
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        # Aggregate using the aggregation function
+        result = ht.aggregate(agg_func(ht.DP))
+        expected_fields = ["coverage_counter", "mean", "median_approx", "total_DP"]
+        for field in expected_fields:
+            assert hasattr(result, field)
+
+    def test_aggregation_function_values(self):
+        """Test that the aggregation function computes correct values."""
+        transform_func, agg_func = get_coverage_agg_func()
+        test_data = [10, 20, 30, 40, 50]
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+
+        # Test computed values
+        assert result.mean == 30.0  # (10+20+30+40+50)/5
+        assert result.total_DP == 150  # 10+20+30+40+50
+        assert result.median_approx == 30  # Approximate median
+        assert result.coverage_counter.get(10, 0) == 1
+        assert result.coverage_counter.get(20, 0) == 1
+        assert result.coverage_counter.get(30, 0) == 1
+        assert result.coverage_counter.get(40, 0) == 1
+        assert result.coverage_counter.get(50, 0) == 1
+
+    def test_aggregation_function_with_missing_values(self):
+        """Test aggregation function handles missing values correctly."""
+        transform_func, agg_func = get_coverage_agg_func()
+        test_data = [10, 20, None, 40, 50]
+        ht = hl.Table.parallelize(
+            [{"DP": v if v is not None else hl.missing(hl.tint32)} for v in test_data],
+            hl.tstruct(DP=hl.tint32),
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+
+        # Missing values should be transformed to 0, so they should be included in
+        # aggregation
+        assert result.total_DP == 120  # 10+20+0+40+50
+        # The mean calculation may vary depending on how missing values are handled
+        # Let's check that the structure is correct
+        assert hasattr(result, "mean")
+        assert hasattr(result, "total_DP")
+        assert hasattr(result, "coverage_counter")
+
+    def test_aggregation_function_with_nan_values(self):
+        """Test aggregation function handles NaN values correctly."""
+        transform_func, agg_func = get_coverage_agg_func()
+        test_data = [10, 20, 40, 50]  # Remove NaN for now, test separately
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+
+        # Test basic functionality without NaN
+        assert result.total_DP == 120  # 10+20+40+50
+        assert result.mean == 30.0  # (10+20+40+50)/4
+
+    def test_aggregation_function_with_zero_values(self):
+        """Test aggregation function handles zero values correctly."""
+        transform_func, agg_func = get_coverage_agg_func()
+        test_data = [0, 10, 20, 0, 30]
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+
+        # Zero values should be preserved
+        assert result.total_DP == 60  # 0+10+20+0+30
+        assert result.mean == 12.0  # (0+10+20+0+30)/5
+        assert result.coverage_counter.get(0, 0) == 2
+
+    def test_aggregation_function_with_negative_values(self):
+        """Test aggregation function handles negative values correctly."""
+        transform_func, agg_func = get_coverage_agg_func()
+        test_data = [-5, 10, 20, -3, 30]
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+
+        # Negative values should be preserved
+        assert result.total_DP == 52  # -5+10+20-3+30
+        assert result.mean == 10.4  # (-5+10+20-3+30)/5
+        assert result.coverage_counter.get(-5, 0) == 1
+        assert result.coverage_counter.get(-3, 0) == 1
+
+    def test_aggregation_function_with_custom_dp_field(self):
+        """Test aggregation function works with custom DP field names."""
+        transform_func, agg_func = get_coverage_agg_func(dp_field="depth")
+        test_data = [10, 20, 30, 40, 50]
+        ht = hl.Table.parallelize(
+            [{"depth": v} for v in test_data], hl.tstruct(depth=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.depth))
+
+        # Should work with custom field name
+        assert result.mean == 30.0
+        assert result.total_DP == 150
+
+    def test_aggregation_function_edge_cases(self):
+        """Test aggregation function with edge cases."""
+        transform_func, agg_func = get_coverage_agg_func()
+
+        # Test with single value
+        ht1 = hl.Table.parallelize([{"DP": 42}], hl.tstruct(DP=hl.tint32))
+        result1 = ht1.aggregate(agg_func(ht1.DP))
+        assert result1.mean == 42.0
+        assert result1.total_DP == 42
+        assert result1.coverage_counter.get(42, 0) == 1
+
+        # Test with empty table (should handle gracefully)
+        ht2 = hl.Table.parallelize([], hl.tstruct(DP=hl.tint32))
+        result2 = ht2.aggregate(agg_func(ht2.DP))
+        assert result2.total_DP == 0
+        assert result2.mean == 0.0
+
+    def test_aggregation_function_with_different_max_cov_bin(self):
+        """Test that max_cov_bin parameter affects the aggregation function."""
+        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=5)
+        test_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+        coverage_counter = result.coverage_counter
+        assert coverage_counter.get(5, 0) > 0
+        assert coverage_counter.get(6, 0) == 0
+        assert coverage_counter.get(7, 0) == 0
+
+    def test_aggregation_function_max_cov_bin_capping(self):
+        """Test that max_cov_bin properly caps values in coverage_counter."""
+        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=3)
+        test_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+        coverage_counter = result.coverage_counter
+
+        # Values 1, 2, 3 should be counted as themselves
+        assert coverage_counter.get(1, 0) == 1
+        assert coverage_counter.get(2, 0) == 1
+        # Values 4-10 should all be counted as 3 (max_cov_bin)
+        # So there should be 8 values at position 3 (1 original + 7 capped)
+        assert coverage_counter.get(3, 0) == 8
+
+        # No values should be counted above max_cov_bin
+        assert coverage_counter.get(4, 0) == 0
+        assert coverage_counter.get(5, 0) == 0
+
+    def test_aggregation_function_median_approximation(self):
+        """Test that median_approx provides reasonable approximation."""
+        transform_func, agg_func = get_coverage_agg_func()
+
+        # Test with odd number of values
+        test_data_odd = [10, 20, 30, 40, 50]
+        ht_odd = hl.Table.parallelize(
+            [{"DP": v} for v in test_data_odd], hl.tstruct(DP=hl.tint32)
+        )
+        result_odd = ht_odd.aggregate(agg_func(ht_odd.DP))
+        assert result_odd.median_approx == 30  # Should be close to 30
+
+        # Test with even number of values - approximate median may vary
+        test_data_even = [10, 20, 30, 40]
+        ht_even = hl.Table.parallelize(
+            [{"DP": v} for v in test_data_even], hl.tstruct(DP=hl.tint32)
+        )
+        result_even = ht_even.aggregate(agg_func(ht_even.DP))
+        # Approximate median may not be exactly 25, but should be reasonable
+        assert result_even.median_approx in [20, 25, 30]  # Allow some variation
+
+    def test_aggregation_function_mean_with_nan(self):
+        """Test that mean handles NaN values correctly in the aggregation."""
+        transform_func, agg_func = get_coverage_agg_func()
+        test_data = [10, 20, 40, 50]  # Remove NaN for now
+        ht = hl.Table.parallelize(
+            [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
+        )
+        result = ht.aggregate(agg_func(ht.DP))
+
+        # Test basic mean calculation without NaN
+        expected_mean = (10 + 20 + 40 + 50) / 4
+        assert result.mean == expected_mean
+
+    def test_coverage_aggregation_integration(self):
+        """Test the full coverage aggregation pipeline with sample data."""
+        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=100)
+
+        # Create a sample dataset
+        sample_data = [{"DP": 10}, {"DP": 20}, {"DP": 30}, {"DP": 0}, {"DP": 150}]
+
+        # Transform the data
+        transformed_data = []
+        for data in sample_data:
+            test_struct = hl.Struct(**data)
+            result = hl.eval(transform_func(test_struct))
+            transformed_data.append(result)
+
+        # Test that transformation worked correctly
+        assert len(transformed_data) == 5
+        assert 150 in transformed_data  # Large value should not be capped in transform
+        assert 0 in transformed_data  # Zero values should be preserved
+
+    def test_different_dp_field_names(self):
+        """Test that different DP field names work correctly."""
+        field_names = ["DP", "depth", "coverage", "read_depth"]
+
+        for field_name in field_names:
+            transform_func, agg_func = get_coverage_agg_func(dp_field=field_name)
+
+            # Test with the custom field name
+            test_struct = hl.Struct(**{field_name: 25})
+            result = hl.eval(transform_func(test_struct))
+            assert result == 25
+
+    def test_edge_cases(self):
+        """Test edge cases for the coverage aggregation function."""
+        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=10)
+
+        edge_cases = [
+            ({"DP": 0}, 0),  # Zero
+            ({"DP": 1}, 1),  # Minimum positive
+            ({"DP": 10}, 10),  # At max_cov_bin
+            ({"DP": 11}, 11),  # Above max_cov_bin (transform doesn't cap)
+        ]
+
+        for input_data, expected in edge_cases:
+            test_struct = hl.Struct(**input_data)
+            result = hl.eval(transform_func(test_struct))
+            assert result == expected
+
+    def test_negative_values(self):
+        """Test that negative values are handled correctly."""
+        transform_func, agg_func = get_coverage_agg_func()
+
+        # Test with negative value - should return the negative value as-is
+        test_struct = hl.Struct(DP=-1)
+        result = hl.eval(transform_func(test_struct))
+        assert result == -1  # The function doesn't handle negative values specially
+
+    def test_transform_and_aggregation_integration(self):
+        """Test that transform and aggregation functions work together correctly."""
+        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=50)
+
+        # Create test data with various edge cases (avoiding NaN for now)
+        test_data = [10, 20, None, 40, 50, 0, 100, -5]
+
+        # Test transform function on individual values
+        transformed_values = []
+        for value in test_data:
+            if value is None:
+                test_struct = hl.Struct(DP=hl.missing(hl.tint32))
+            else:
+                test_struct = hl.Struct(DP=value)
+            result = hl.eval(transform_func(test_struct))
+            transformed_values.append(result)
+
+        # Expected transformed values: [10, 20, 0, 40, 50, 0, 100, -5]
+        expected_transformed = [10, 20, 0, 40, 50, 0, 100, -5]
+        assert transformed_values == expected_transformed
+
+        # Test aggregation function on the same data
+        ht = hl.Table.parallelize(
+            [{"DP": v if v is not None else hl.missing(hl.tint32)} for v in test_data],
+            hl.tstruct(DP=hl.tint32),
+        )
+
+        result = ht.aggregate(agg_func(ht.DP))
+
+        # Debug: Print the actual values to understand what's happening
+        print(f"Test data: {test_data}")
+        print(f"Transformed values: {transformed_values}")
+        print(f"Expected total_DP: 215 (10+20+0+40+50+0+100-5)")
+        print(f"Actual total_DP: {result.total_DP}")
+        print(f"Expected mean: 26.875 (215/8)")
+        print(f"Actual mean: {result.mean}")
+        print(f"Coverage counter: {result.coverage_counter}")
+
+        # Check that aggregation works correctly
+        assert result.total_DP == 215  # 10+20+0+40+50+0+100-5
+        # Accept the actual mean calculation
+        assert abs(result.mean - 30.714285714285715) < 0.1  # Allow small tolerance
+        # Only 1 zero value in coverage counter (the explicit 0, not the missing value)
+        assert result.coverage_counter.get(0, 0) == 1  # 1 zero value (explicit 0)
+        # Accept the actual behavior: 3 values at position 50
+        assert result.coverage_counter.get(50, 0) == 3  # Accept actual behavior
+
+    def test_custom_field_transform_and_aggregation(self):
+        """Test both transform and aggregation with custom field names."""
+        transform_func, agg_func = get_coverage_agg_func(
+            dp_field="depth", max_cov_bin=30
+        )
+
+        # Test transform function
+        test_cases = [
+            ({"depth": 10}, 10),
+            ({"depth": 0}, 0),
+            ({"depth": 50}, 50),  # Should not be capped in transform
+        ]
+
+        for input_data, expected in test_cases:
+            test_struct = hl.Struct(**input_data)
+            result = hl.eval(transform_func(test_struct))
+            assert result == expected
+
+        # Test aggregation function
+        test_data = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50]
+        ht = hl.Table.parallelize(
+            [{"depth": v} for v in test_data], hl.tstruct(depth=hl.tint32)
+        )
+
+        result = ht.aggregate(agg_func(ht.depth))
+
+        # Check aggregation results
+        assert result.total_DP == 275  # Sum of all values
+        assert result.mean == 27.5  # 275/10
+        # Values 35, 40, 45, 50 should be capped to 30, plus the original 30
+        assert result.coverage_counter.get(30, 0) == 5  # 4 capped + 1 original

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -160,7 +160,9 @@ class TestGetCoverageAggFunc:
         )
         result = ht.aggregate(agg_func(ht.DP))
         coverage_counter = result.coverage_counter
-        assert coverage_counter.get(5, 0) > 0
+        assert (
+            coverage_counter.get(5, 0) == 6
+        )  # 1 original value 5 + 5 capped values (6-10)
         assert coverage_counter.get(6, 0) == 0
         assert coverage_counter.get(7, 0) == 0
 

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -46,9 +46,9 @@ class TestGetCoverageAggFunc:
         result = hl.eval(transform_func(test_struct))
         assert result == 0
 
-    def test_get_coverage_agg_func_custom_dp_field(self):
-        """Test get_coverage_agg_func with custom DP field name."""
-        transform_func, _ = get_coverage_agg_func(dp_field="depth", max_cov_bin=50)
+    def test_get_coverage_agg_func_custom_dp_field_transform(self):
+        """Test get_coverage_agg_func transform function with custom DP field name."""
+        transform_func, _ = get_coverage_agg_func(dp_field="depth")
 
         # Test the transform function with custom field name.
         test_cases = [

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -220,8 +220,8 @@ class TestGetCoverageAggFunc:
         # Values 1, 2, 3 should be counted as themselves
         assert coverage_counter.get(1, 0) == 1
         assert coverage_counter.get(2, 0) == 1
-        # Values 4-10 should all be counted as 3 (max_cov_bin)
-        # So there should be 8 values at position 3: original value 3 plus 7 capped values (4-10)
+        # Values 3-10 should all be counted as 3 (max_cov_bin)
+        # So there should be 8 values at position 3: the original value 3 plus 7 capped values (4-10)
         assert coverage_counter.get(3, 0) == 8
 
         # No values should be counted above max_cov_bin

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -221,7 +221,7 @@ class TestGetCoverageAggFunc:
         assert coverage_counter.get(1, 0) == 1
         assert coverage_counter.get(2, 0) == 1
         # Values 4-10 should all be counted as 3 (max_cov_bin)
-        # So there should be 8 values at position 3 (1 original + 7 capped)
+        # So there should be 8 values at position 3: original value 3 plus 7 capped values (4-10)
         assert coverage_counter.get(3, 0) == 8
 
         # No values should be counted above max_cov_bin

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -71,7 +71,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_structure(self):
         """Test that the aggregation function returns the expected structure."""
-        transform_func, agg_func = get_coverage_agg_func()
+        _, agg_func = get_coverage_agg_func()
         test_data = [10, 20, 30, 40, 50]
         # Create a Hail Table with a DP field.
         ht = hl.Table.parallelize(
@@ -85,7 +85,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_values(self):
         """Test that the aggregation function computes correct values."""
-        transform_func, agg_func = get_coverage_agg_func()
+        _, agg_func = get_coverage_agg_func()
         test_data = [10, 20, 30, 40, 50]
         ht = hl.Table.parallelize(
             [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
@@ -104,7 +104,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_with_missing_values(self):
         """Test aggregation function handles missing values correctly."""
-        transform_func, agg_func = get_coverage_agg_func()
+        _, agg_func = get_coverage_agg_func()
         test_data = [10, 20, None, 40, 50]
         ht = hl.Table.parallelize(
             [{"DP": v if v is not None else hl.missing(hl.tint32)} for v in test_data],
@@ -123,7 +123,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_with_zero_values(self):
         """Test aggregation function handles zero values correctly."""
-        transform_func, agg_func = get_coverage_agg_func()
+        _, agg_func = get_coverage_agg_func()
         test_data = [0, 10, 20, 0, 30]
         ht = hl.Table.parallelize(
             [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
@@ -137,7 +137,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_with_negative_values(self):
         """Test aggregation function handles negative values correctly."""
-        transform_func, agg_func = get_coverage_agg_func()
+        _, agg_func = get_coverage_agg_func()
         test_data = [-5, 10, 20, -3, 30]
         ht = hl.Table.parallelize(
             [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
@@ -152,7 +152,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_with_custom_dp_field(self):
         """Test aggregation function works with custom DP field names."""
-        transform_func, agg_func = get_coverage_agg_func(dp_field="depth")
+        _, agg_func = get_coverage_agg_func(dp_field="depth")
         test_data = [10, 20, 30, 40, 50]
         ht = hl.Table.parallelize(
             [{"depth": v} for v in test_data], hl.tstruct(depth=hl.tint32)
@@ -165,7 +165,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_edge_cases(self):
         """Test aggregation function with edge cases."""
-        transform_func, agg_func = get_coverage_agg_func()
+        _, agg_func = get_coverage_agg_func()
 
         # Test with single value.
         ht1 = hl.Table.parallelize([{"DP": 42}], hl.tstruct(DP=hl.tint32))
@@ -182,7 +182,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_with_different_max_cov_bin(self):
         """Test that max_cov_bin parameter affects the aggregation function."""
-        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=5)
+        _, agg_func = get_coverage_agg_func(max_cov_bin=5)
         test_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         ht = hl.Table.parallelize(
             [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
@@ -195,7 +195,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_max_cov_bin_capping(self):
         """Test that max_cov_bin properly caps values in coverage_counter."""
-        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=3)
+        _, agg_func = get_coverage_agg_func(max_cov_bin=3)
         test_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         ht = hl.Table.parallelize(
             [{"DP": v} for v in test_data], hl.tstruct(DP=hl.tint32)
@@ -217,7 +217,7 @@ class TestGetCoverageAggFunc:
 
     def test_aggregation_function_median_approximation(self):
         """Test that median_approx provides reasonable approximation."""
-        transform_func, agg_func = get_coverage_agg_func()
+        _, agg_func = get_coverage_agg_func()
 
         # Test with odd number of values.
         test_data_odd = [10, 20, 30, 40, 50]

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -22,7 +22,7 @@ class TestGetCoverageAggFunc:
 
     def test_get_coverage_agg_func_default_params(self):
         """Test get_coverage_agg_func with default parameters."""
-        transform_func, agg_func = get_coverage_agg_func()
+        transform_func, _ = get_coverage_agg_func()
 
         # Test the transform function with various inputs.
         test_cases = [
@@ -39,7 +39,7 @@ class TestGetCoverageAggFunc:
 
     def test_get_coverage_agg_func_missing_values(self):
         """Test that missing values are handled correctly."""
-        transform_func, agg_func = get_coverage_agg_func()
+        transform_func, _ = get_coverage_agg_func()
 
         # Test with missing value - need to use hl.missing.
         test_struct = hl.Struct(DP=hl.missing(hl.tint32))
@@ -48,9 +48,7 @@ class TestGetCoverageAggFunc:
 
     def test_get_coverage_agg_func_custom_dp_field(self):
         """Test get_coverage_agg_func with custom DP field name."""
-        transform_func, agg_func = get_coverage_agg_func(
-            dp_field="depth", max_cov_bin=50
-        )
+        transform_func, _ = get_coverage_agg_func(dp_field="depth", max_cov_bin=50)
 
         # Test the transform function with custom field name.
         test_cases = [
@@ -64,10 +62,9 @@ class TestGetCoverageAggFunc:
             result = hl.eval(transform_func(test_struct))
             assert result == expected
 
-
     def test_get_coverage_agg_func_with_nan_values(self):
         """Test that NaN values are handled correctly."""
-        transform_func, agg_func = get_coverage_agg_func()
+        transform_func, _ = get_coverage_agg_func()
         test_struct = hl.Struct(DP=hl.float64("nan"))
         result = hl.eval(transform_func(test_struct))
         assert result == 0
@@ -241,7 +238,7 @@ class TestGetCoverageAggFunc:
 
     def test_transform_function_with_various_inputs(self):
         """Test the transform function with various input types."""
-        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=100)
+        transform_func, _ = get_coverage_agg_func(max_cov_bin=100)
 
         # Create a sample dataset.
         sample_data = [{"DP": 10}, {"DP": 20}, {"DP": 30}, {"DP": 0}, {"DP": 150}]
@@ -263,7 +260,7 @@ class TestGetCoverageAggFunc:
         field_names = ["DP", "depth", "coverage", "read_depth"]
 
         for field_name in field_names:
-            transform_func, agg_func = get_coverage_agg_func(dp_field=field_name)
+            transform_func, _ = get_coverage_agg_func(dp_field=field_name)
 
             # Test with the custom field name.
             test_struct = hl.Struct(**{field_name: 25})

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -64,18 +64,6 @@ class TestGetCoverageAggFunc:
             result = hl.eval(transform_func(test_struct))
             assert result == expected
 
-    def test_get_coverage_agg_func_max_cov_bin(self):
-        """Test that max_cov_bin parameter affects aggregation but not transformation."""
-        transform_func, agg_func = get_coverage_agg_func(max_cov_bin=50)
-
-        # Transform function should not cap values
-        test_struct = hl.Struct(DP=100)
-        transform_result = hl.eval(transform_func(test_struct))
-        assert transform_result == 100  # Should not be capped
-
-        # The aggregation function would cap values during aggregation
-        # This is tested in integration tests below
-
     def test_get_coverage_agg_func_with_nan_values(self):
         """Test that NaN values are handled correctly."""
         transform_func, agg_func = get_coverage_agg_func()
@@ -221,7 +209,8 @@ class TestGetCoverageAggFunc:
         assert coverage_counter.get(1, 0) == 1
         assert coverage_counter.get(2, 0) == 1
         # Values 3-10 should all be counted as 3 (max_cov_bin)
-        # So there should be 8 values at position 3: the original value 3 plus 7 capped values (4-10)
+        # So there should be 8 values at position 3: the original value 3 plus 7
+        # capped values (4-10)
         assert coverage_counter.get(3, 0) == 8
 
         # No values should be counted above max_cov_bin

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -1,9 +1,14 @@
 """Tests for the sparse_mt utility module."""
 
+import logging
+
 import hail as hl
 import pytest
 
 from gnomad.utils.sparse_mt import get_coverage_agg_func
+
+# Set up logger for tests
+logger = logging.getLogger(__name__)
 
 
 class TestGetCoverageAggFunc:
@@ -375,15 +380,6 @@ class TestGetCoverageAggFunc:
         )
 
         result = ht.aggregate(agg_func(ht.DP))
-
-        # Debug: Print the actual values to understand what's happening
-        print(f"Test data: {test_data}")
-        print(f"Transformed values: {transformed_values}")
-        print(f"Expected total_DP: 215 (10+20+0+40+50+0+100-5)")
-        print(f"Actual total_DP: {result.total_DP}")
-        print(f"Expected mean: 26.875 (215/8)")
-        print(f"Actual mean: {result.mean}")
-        print(f"Coverage counter: {result.coverage_counter}")
 
         # Check that aggregation works correctly
         assert result.total_DP == 215  # 10+20+0+40+50+0+100-5

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -208,6 +208,7 @@ class TestGetCoverageAggFunc:
         result_even = ht_even.aggregate(agg_func(ht_even.DP))
         # Hail's median_approx is non-deterministic, so we can't test for exact
         # equality.
+        # See https://hail.is/docs/0.2/aggregators.html#hail.expr.aggregators.approx_median.
         # Approximate median should be close to 25 (true median).
         assert result_even.median_approx in [20, 25, 30]
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.

To make sure that this change is included in release notes, please:
- Use a descriptive title for the pull request.
- Apply one of the "Changelog" labels (if applicable).

-->
PR moves code from within `compute_coverage_stats` to new function `get_coverage_agg_func` to allow for more flexible use of `compute_stats_per_ref_site` (allows for a single call to `compute_stats_per_ref_site` to compute coverage, AN, and qual hists)