### PR TITLE
Add LEN to compute_stats_per_ref_site after hail updates

### DIFF
--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1217,7 +1217,9 @@ def compute_stats_per_ref_site(
     if is_vds:
         rmt = mtds.reference_data
         mtds = hl.vds.VariantDataset(
-            rmt.select_entries(*((set(entry_keep_fields) & set(rmt.entry)) | {"END"})),
+            rmt.select_entries(
+                *((set(entry_keep_fields) & set(rmt.entry)) | {"END", "LEN"})
+            ),
             mtds.variant_data,
         )
 


### PR DESCRIPTION
hail updated to use `LEN` in their code 9 months ago -- https://github.com/hail-is/hail/pull/14681/files and we only grab `END` in this function right now https://github.com/broadinstitute/gnomad_methods/blob/daf45c05d3360228815303877a9ad5c981474b07/gnomad/utils/sparse_mt.py#L1220 this adds `LEN` to the set to let it work with hail. Keeping END so its backwards compatible. 