### PR TITLE
Add RGQ to the FORMAT_DICT for VCF export

### DIFF
--- a/gnomad/utils/vcf.py
+++ b/gnomad/utils/vcf.py
@@ -575,6 +575,14 @@ FORMAT_DICT = {
         "Number": "4",
         "Type": "Integer",
     },
+    "RGQ": {
+        "Description": (
+            "Unconditional reference genotype confidence, encoded as a phred"
+            " quality -10*log10 p(genotype call is wrong)"
+        ),
+        "Number": "1",
+        "Type": "Integer",
+    },
 }
 """
 Dictionary used during VCF export to export MatrixTable entries.


### PR DESCRIPTION
This was never put in the common code. I could not find a reason but I think it just slipped through the cracks. The field is considered a sparse entry field but it sticks around after densify.  Our subset code exports it so we should have it stored in this repo. If someone chooses to omit it, they can just drop it from the dictionary. 