### PR TITLE
Add constants used in generating variant QC annotation HT

### DIFF
--- a/gnomad/variant_qc/pipeline.py
+++ b/gnomad/variant_qc/pipeline.py
@@ -39,7 +39,7 @@ INFO_FEATURES = [
     "AS_SOR",
     "AS_FS",
 ]
-"""List of features info to be used for variant QC."""
+"""List of features to be used for variant QC that are in the info field."""
 
 NON_INFO_FEATURES = [
     "variant_type",

--- a/gnomad/variant_qc/pipeline.py
+++ b/gnomad/variant_qc/pipeline.py
@@ -30,6 +30,29 @@ logger.setLevel(logging.INFO)
 
 INBREEDING_COEFF_HARD_CUTOFF = -0.3
 
+INFO_FEATURES = [
+    "AS_MQRankSum",
+    "AS_pab_max",
+    "AS_MQ",
+    "AS_QD",
+    "AS_ReadPosRankSum",
+    "AS_SOR",
+    "AS_FS",
+]
+"""List of features info to be used for variant QC."""
+
+NON_INFO_FEATURES = [
+    "variant_type",
+    "allele_type",
+    "n_alt_alleles",
+    "was_mixed",
+    "has_star",
+]
+"""List of features to be used for variant QC that are not in the info field."""
+
+TRUTH_DATA = ["hapmap", "omni", "mills", "kgp_phase1_hc"]
+"""List of truth datasets to be used for variant QC."""
+
 
 def create_binned_ht(
     ht: hl.Table,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request.

To make sure that this change is included in release notes, please:
- Use a descriptive title for the pull request.
- Apply one of the "Changelog" labels (if applicable).

-->
Adds `INFO_FEATURES`, `NON_INFO_FEATURES`, and `TRUTH_DATA` from gnomAD v4 pipeline code: https://github.com/broadinstitute/gnomad_qc/blob/c44f1f76fc5d7a9cd63c46b1826b0d0a376fbe4a/gnomad_qc/v4/annotations/generate_variant_qc_annotations.py#L64