### PR TITLE
Add opt-in reduce_to_minimal_groups optimization to annotate_freq and compute_stats_per_ref_site

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1700,6 +1700,8 @@ def annotate_freq(
     ds_gen_anc_counts: Optional[Dict[str, int]] = None,
     entry_agg_funcs: Optional[Dict[str, Tuple[Callable, Callable]]] = None,
     annotate_mt: bool = True,
+    reduce_to_minimal_groups: bool = False,
+    non_summable_axes: Optional[Set[str]] = None,
 ) -> Union[hl.Table, hl.MatrixTable]:
     """
     Annotate `mt` with stratified allele frequencies.
@@ -1817,6 +1819,20 @@ def annotate_freq(
         output from the first function.
     :param annotate_mt: Whether to return the full MatrixTable with annotations added
         instead of only a Table with `freq` and other annotations. Default is True.
+    :param reduce_to_minimal_groups: When True, per-variant call statistics are
+        computed only on a minimal "leaf" subset of stratification groups (those
+        that cannot be derived by summing other groups in `freq_meta`). The
+        remaining groups are reconstructed by element-wise summation of leaves
+        as a cheap post-processing step, so the returned `freq` /
+        `freq_meta` / `freq_meta_sample_count` are identical to the
+        `reduce_to_minimal_groups=False` output. This is a pure cost
+        optimization for large stratifications. Any annotations produced by
+        `entry_agg_funcs` are also expanded by element-wise summation, which
+        assumes the values are summable (integers or struct-of-integers); do
+        **not** enable this when `entry_agg_funcs` returns non-summable
+        values such as means or medians. Default is False.
+    :param non_summable_axes: Axis names that should never be summed across
+        when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
     :return: MatrixTable or Table with `freq` annotation.
     """
     errors = []
@@ -1865,13 +1881,75 @@ def annotate_freq(
         strata_expr,
         downsamplings=downsamplings,
         ds_gen_anc_counts=ds_gen_anc_counts,
+        reduce_to_minimal_groups=reduce_to_minimal_groups,
+        non_summable_axes=non_summable_axes,
     )
 
+    # When reducing, the leaf-only group_membership no longer has the
+    # historical "index 0 = first adj group, index 1 = raw" layout — the
+    # all-adj group at position 0 is typically eliminated as a non-leaf. Pass
+    # `freq_meta` through on the MT's globals so `compute_freq_by_strata`
+    # derives `adj_groups` from it instead of the hardcoded layout rule.
+    mt_with_membership = mt.annotate_cols(
+        group_membership=ht[mt.col_key].group_membership
+    )
+    if reduce_to_minimal_groups:
+        mt_with_membership = mt_with_membership.annotate_globals(
+            freq_meta=ht.index_globals().freq_meta
+        )
+
     freq_ht = compute_freq_by_strata(
-        mt.annotate_cols(group_membership=ht[mt.col_key].group_membership),
+        mt_with_membership,
         entry_agg_funcs=entry_agg_funcs,
     )
     freq_ht = freq_ht.annotate_globals(**ht.index_globals())
+
+    if reduce_to_minimal_groups:
+        # Expand the leaf-only per-strata annotations back to full length
+        # using the decomposition map stored on the group-membership Table.
+        leaf_indices = hl.eval(freq_ht.freq_leaf_indices)
+        decomposition_serialized = hl.eval(freq_ht.freq_group_decomposition)
+        freq_meta_full = hl.eval(freq_ht.freq_meta_full)
+        freq_meta_sample_count_full = hl.eval(freq_ht.freq_meta_sample_count_full)
+        n_full = len(freq_meta_full)
+        decomposition = {
+            i: list(children)
+            for i, children in enumerate(decomposition_serialized)
+            if children
+        }
+
+        expansion_exprs = {
+            "freq": expand_strata_array_from_leaves(
+                freq_ht.freq,
+                leaf_indices,
+                decomposition,
+                n_full,
+                is_freq_struct=True,
+            )
+        }
+        if entry_agg_funcs is not None:
+            for ann in entry_agg_funcs:
+                expansion_exprs[ann] = expand_strata_array_from_leaves(
+                    freq_ht[ann],
+                    leaf_indices,
+                    decomposition,
+                    n_full,
+                    is_freq_struct=False,
+                )
+        freq_ht = freq_ht.annotate(**expansion_exprs)
+
+        # Restore the original full freq_meta / freq_meta_sample_count and
+        # drop the now-redundant reduction-tracking globals.
+        freq_ht = freq_ht.annotate_globals(
+            freq_meta=freq_meta_full,
+            freq_meta_sample_count=freq_meta_sample_count_full,
+        )
+        freq_ht = freq_ht.drop(
+            "freq_meta_full",
+            "freq_meta_sample_count_full",
+            "freq_leaf_indices",
+            "freq_group_decomposition",
+        )
 
     if annotate_mt:
         mt = mt.annotate_rows(**freq_ht[mt.row_key])
@@ -2033,6 +2111,218 @@ def build_freq_stratification_list(
     return strata_expr
 
 
+def find_minimal_strata_groups(
+    freq_meta: List[Dict[str, str]],
+    non_summable_axes: Optional[Set[str]] = None,
+) -> Tuple[List[int], Dict[int, List[int]]]:
+    """
+    Identify the minimal "leaf" set of stratification groups in a `freq_meta`.
+
+    A "leaf" group is one that cannot be derived by summing other groups in
+    `freq_meta`. The remaining ("non-leaf") groups can be reconstructed by
+    element-wise summation of leaves with matching values on the parent's keys
+    and matching non-summable axes (e.g., same `downsampling` value). This is
+    the basis for an opt-in optimization that computes per-variant call stats
+    only on the leaves and reconstructs the rest by summation in a cheap
+    post-processing step (see `expand_strata_array_from_leaves`).
+
+    The algorithm partitions `freq_meta` by the value of the `"group"` key
+    (typically `"adj"` and `"raw"`) and runs leaf detection independently in
+    each partition. This is required because `adj` and `raw` are
+    *genotype-level* filters and never sum into each other; both `annotate_freq`
+    (which produces a mix of `adj` and `raw` entries) and
+    `compute_stats_per_ref_site` (which produces only `raw` entries) are
+    handled correctly.
+
+    Within each partition, an entry's "summable axes" are the keys of its
+    metadata dict excluding `"group"` and excluding any axis listed in
+    `non_summable_axes`. The leaves are the entries whose summable-axes set is
+    maximal-by-inclusion within the partition. A non-leaf is decomposed into
+    every leaf in the same partition that (a) has the same non-summable axes
+    (e.g., same `downsampling` value) and (b) agrees with the parent on every
+    key the parent has. If a non-leaf cannot be decomposed (no matching
+    leaves), it is kept as a leaf as a no-op fallback.
+
+    `non_summable_axes` defaults to `{"downsampling"}` because gnomAD's
+    `{downsampling: N, gen_anc: X}` groups select the first N samples of the
+    given gen_anc using a randomized rank — they are disjoint from
+    `{downsampling: N, gen_anc: Y}` and never sum into a global
+    `{downsampling: N}` entry.
+
+    :param freq_meta: List of `freq_meta` dicts as produced by
+        `generate_freq_group_membership_array`.
+    :param non_summable_axes: Axis names that should never be summed across.
+        Default is `{"downsampling"}`.
+    :return: Tuple of `(leaf_indices, decomposition)` where `leaf_indices` is
+        a sorted list of indices into `freq_meta` marking the leaves, and
+        `decomposition` maps each non-leaf index to the list of leaf indices
+        that sum to it.
+    """
+    if non_summable_axes is None:
+        non_summable_axes = {"downsampling"}
+    else:
+        non_summable_axes = set(non_summable_axes)
+
+    def summable_axes_of(e: Dict[str, str]) -> frozenset:
+        return frozenset(
+            k for k in e.keys() if k != "group" and k not in non_summable_axes
+        )
+
+    def non_summable_of(e: Dict[str, str]) -> frozenset:
+        return frozenset(k for k in e.keys() if k != "group" and k in non_summable_axes)
+
+    # Partition indices by group value (e.g., "adj" vs "raw").
+    partitions: Dict[Optional[str], List[int]] = {}
+    for i, e in enumerate(freq_meta):
+        partitions.setdefault(e.get("group"), []).append(i)
+
+    is_leaf = [False] * len(freq_meta)
+    decomposition: Dict[int, List[int]] = {}
+
+    for indices in partitions.values():
+        # Within this partition, determine the maximal-by-inclusion summable
+        # axis sets — those are the leaf axis sets.
+        axis_sets = {summable_axes_of(freq_meta[i]) for i in indices}
+        leaf_axis_sets = {s for s in axis_sets if not any(s < s2 for s2 in axis_sets)}
+
+        for i in indices:
+            if summable_axes_of(freq_meta[i]) in leaf_axis_sets:
+                is_leaf[i] = True
+
+        # Decompose non-leaves using only same-partition leaves.
+        leaf_indices_in_partition = [i for i in indices if is_leaf[i]]
+        for i in indices:
+            if is_leaf[i]:
+                continue
+            e = freq_meta[i]
+            e_keys = {k: v for k, v in e.items() if k != "group"}
+            e_non_summable = non_summable_of(e)
+            matches = []
+            for j in leaf_indices_in_partition:
+                f = freq_meta[j]
+                if non_summable_of(f) != e_non_summable:
+                    continue
+                if any(f.get(k) != v for k, v in e_keys.items()):
+                    continue
+                matches.append(j)
+            if matches:
+                decomposition[i] = matches
+            else:
+                # Cannot decompose — keep as a leaf so the result is still
+                # computed directly.
+                is_leaf[i] = True
+
+    leaf_indices = [i for i, leaf in enumerate(is_leaf) if leaf]
+    return leaf_indices, decomposition
+
+
+def expand_strata_array_from_leaves(
+    leaf_array: hl.expr.ArrayExpression,
+    leaf_indices: List[int],
+    decomposition: Dict[int, List[int]],
+    n_full: int,
+    is_freq_struct: bool = False,
+) -> hl.expr.ArrayExpression:
+    """
+    Reconstruct a full-length per-strata array from a leaf-only array.
+
+    This is the post-processing companion to `find_minimal_strata_groups`. For
+    each position `i` in the full (original) `freq_meta`:
+
+      - If `i` is a leaf, the value at `leaf_array[leaf_pos[i]]` is used
+        directly.
+      - Otherwise, the values at the positions corresponding to
+        `decomposition[i]` are summed element-wise.
+
+    For `is_freq_struct=True`, each element is treated as a struct with `AC`,
+    `AN`, and `homozygote_count` int fields; AF is recomputed after summation
+    as `or_missing(AN > 0, AC / AN)`. Otherwise, the element type is
+    inspected: integer arrays are summed with `_sum_or_diff_values`, and
+    struct arrays have each int field summed independently.
+
+    :param leaf_array: Hail array expression of length `len(leaf_indices)`
+        produced by aggregating only the leaf groups.
+    :param leaf_indices: Original-`freq_meta` indices of the leaves, in the
+        same order as `leaf_array`.
+    :param decomposition: Map from non-leaf original index to list of original
+        leaf indices that sum to it.
+    :param n_full: Length of the original (full) `freq_meta`.
+    :param is_freq_struct: If True, treat each element as a freq struct
+        (`AC`, `AF`, `AN`, `homozygote_count`) and recompute `AF` after
+        summing. Default False.
+    :return: Hail array expression of length `n_full`.
+    """
+    # Map original-freq_meta index → position in the reduced leaf_array.
+    leaf_pos = {orig_idx: pos for pos, orig_idx in enumerate(leaf_indices)}
+
+    element_type = leaf_array.dtype.element_type
+    is_struct = isinstance(element_type, hl.tstruct)
+
+    if is_freq_struct:
+        struct_fields = ["AC", "AN", "homozygote_count"]
+    elif is_struct:
+        struct_fields = list(element_type.fields)
+    else:
+        struct_fields = None
+
+    def _select_struct(elem: hl.expr.Expression) -> hl.expr.Expression:
+        """Project a struct element down to the fields used for summation.
+
+        For freq structs, this drops `AF` (it will be recomputed at the
+        end). For other struct types, it's a no-op.
+        """
+        if struct_fields is None:
+            return elem
+        return elem.select(*struct_fields)
+
+    def _sum_elements(positions: List[int]) -> hl.expr.Expression:
+        """Element-wise sum of leaf_array at the given reduced positions."""
+        first = _select_struct(leaf_array[positions[0]])
+        if struct_fields is None:
+            acc = first
+            for p in positions[1:]:
+                acc = _sum_or_diff_values(acc, leaf_array[p], "sum")
+            return acc
+        # Struct path: sum each numeric field independently.
+        acc_fields = {f: first[f] for f in struct_fields}
+        for p in positions[1:]:
+            nxt = leaf_array[p]
+            acc_fields = {
+                f: _sum_or_diff_values(acc_fields[f], nxt[f], "sum")
+                for f in struct_fields
+            }
+        return hl.struct(**acc_fields)
+
+    full = []
+    for i in range(n_full):
+        if i in leaf_pos:
+            # Project leaf elements to the same field shape as the summed
+            # non-leaf elements so the resulting array has a uniform element
+            # type (Hail's `hl.array` requires this).
+            full.append(_select_struct(leaf_array[leaf_pos[i]]))
+        elif i in decomposition:
+            child_positions = [leaf_pos[j] for j in decomposition[i]]
+            full.append(_sum_elements(child_positions))
+        else:
+            # Should not happen — every non-leaf must be in `decomposition`.
+            raise ValueError(
+                f"Index {i} is neither a leaf nor in the decomposition map."
+            )
+
+    expanded = hl.array(full)
+
+    if is_freq_struct:
+        # Recompute AF from the summed AC/AN, and select the canonical field
+        # order used elsewhere in the codebase.
+        expanded = expanded.map(
+            lambda x: x.annotate(AF=hl.or_missing(x.AN > 0, x.AC / x.AN)).select(
+                "AC", "AF", "AN", "homozygote_count"
+            )
+        )
+
+    return expanded
+
+
 def generate_freq_group_membership_array(
     ht: hl.Table,
     strata_expr: List[Dict[str, hl.expr.StringExpression]],
@@ -2040,6 +2330,8 @@ def generate_freq_group_membership_array(
     ds_gen_anc_counts: Optional[Dict[str, int]] = None,
     remove_zero_sample_groups: bool = False,
     no_raw_group: bool = False,
+    reduce_to_minimal_groups: bool = False,
+    non_summable_axes: Optional[Set[str]] = None,
 ) -> hl.Table:
     """
     Generate a Table with a 'group_membership' array for each sample indicating whether the sample belongs to specific stratification groups.
@@ -2060,6 +2352,26 @@ def generate_freq_group_membership_array(
     sample belongs to specific stratification groups. All possible value combinations
     are determined for each stratification grouping in the `strata_expr` list.
 
+    .. rubric:: The `reduce_to_minimal_groups` parameter
+
+    When `reduce_to_minimal_groups` is True, the returned `group_membership`,
+    `freq_meta`, and `freq_meta_sample_count` are reduced to only the "leaf"
+    groups (those that cannot be derived by summing other groups in
+    `freq_meta`). The original full versions are preserved as additional
+    globals so that downstream callers can reconstruct the full per-strata
+    arrays after their (cheaper) leaf-only aggregation:
+
+        - freq_meta_full: original full freq_meta before reduction.
+        - freq_meta_sample_count_full: original full sample counts.
+        - freq_leaf_indices: indices into freq_meta_full marking the leaves
+          (in the same order as the reduced freq_meta).
+        - freq_group_decomposition: list of length len(freq_meta_full) where
+          each element is the list of freq_meta_full indices whose stats sum
+          to that position. Leaves get an empty list.
+
+    See `find_minimal_strata_groups` for the leaf-detection algorithm and
+    `expand_strata_array_from_leaves` for the reconstruction step.
+
     :param ht: Input Table that contains Expressions specified by `strata_expr`.
     :param strata_expr: List of dictionaries specifying stratification groups where
         the keys of each dictionary are strings and the values are corresponding
@@ -2071,6 +2383,15 @@ def generate_freq_group_membership_array(
     :param no_raw_group: Whether to remove the raw group from the 'group_membership'
         annotation and the 'freq_meta' and 'freq_meta_sample_count' global annotations.
         Default is False.
+    :param reduce_to_minimal_groups: Whether to reduce the returned
+        `group_membership`/`freq_meta`/`freq_meta_sample_count` to only the
+        leaf groups whose call stats cannot be derived by summing other
+        groups. The full versions and the leaf-decomposition map are stored
+        as additional globals so a downstream caller (e.g., `annotate_freq`)
+        can reconstruct the full per-strata array after aggregation. Default
+        is False.
+    :param non_summable_axes: Axis names that should never be summed across
+        when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
     :return: Table with the 'group_membership' array annotation.
     """
     errors = []
@@ -2209,6 +2530,48 @@ def generate_freq_group_membership_array(
         "freq_meta_sample_count": freq_meta_sample_count,
     }
 
+    if reduce_to_minimal_groups:
+        # `freq_meta_sample_count` may be a Hail expression at this point (it
+        # is wrapped in `hl.array(...).extend(...)` above when raw is
+        # prepended). Materialize it back to a Python list so we can slice
+        # both arrays in Python.
+        if not isinstance(freq_meta_sample_count, list):
+            freq_meta_sample_count_full = list(hl.eval(freq_meta_sample_count))
+        else:
+            freq_meta_sample_count_full = list(freq_meta_sample_count)
+
+        freq_meta_full = [dict(m) for m in freq_meta]
+        leaf_indices, decomposition = find_minimal_strata_groups(
+            freq_meta_full, non_summable_axes=non_summable_axes
+        )
+
+        n_full = len(freq_meta_full)
+        # Serialize the decomposition as a list of length `n_full`, indexed
+        # by the original freq_meta position. Leaves get an empty list.
+        freq_group_decomposition = [decomposition.get(i, []) for i in range(n_full)]
+
+        logger.info(
+            "Reducing freq_meta from %d to %d groups (leaf-only).",
+            n_full,
+            len(leaf_indices),
+        )
+
+        # Slice freq_meta and sample counts down to the leaves.
+        freq_meta = [freq_meta_full[i] for i in leaf_indices]
+        freq_meta_sample_count = [freq_meta_sample_count_full[i] for i in leaf_indices]
+
+        # Slice the per-sample group_membership array to the leaf positions.
+        ht = ht.annotate(
+            group_membership=hl.array([ht.group_membership[i] for i in leaf_indices])
+        )
+
+        global_expr["freq_meta"] = freq_meta
+        global_expr["freq_meta_sample_count"] = freq_meta_sample_count
+        global_expr["freq_meta_full"] = freq_meta_full
+        global_expr["freq_meta_sample_count_full"] = freq_meta_sample_count_full
+        global_expr["freq_leaf_indices"] = leaf_indices
+        global_expr["freq_group_decomposition"] = freq_group_decomposition
+
     if downsamplings is not None:
         global_expr["downsamplings"] = downsamplings
     if ds_gen_anc_counts is not None:
@@ -2268,13 +2631,22 @@ def compute_freq_by_strata(
             )
         )
 
-    # Add adj_groups global annotation indicating that the second element in
-    # group_membership is 'raw' and all others are 'adj'.
-    mt = mt.annotate_globals(
-        adj_groups=hl.range(hl.len(mt.group_membership.take(1)[0])).map(
-            lambda x: x != 1
+    # Determine the adj_groups global annotation. If `freq_meta` is present
+    # in the input MT globals (e.g., when called from `annotate_freq` with a
+    # reduced/leaf-only group_membership where the layout is no longer
+    # "index 0 = first adj, index 1 = raw"), derive adj_groups from
+    # freq_meta directly. Otherwise, fall back to the historical assumption
+    # that index 1 is the 'raw' group and all other indices are 'adj'.
+    if "freq_meta" in mt.globals:
+        mt = mt.annotate_globals(
+            adj_groups=mt.freq_meta.map(lambda x: x.get("group", "NA") == "adj")
         )
-    )
+    else:
+        mt = mt.annotate_globals(
+            adj_groups=hl.range(hl.len(mt.group_membership.take(1)[0])).map(
+                lambda x: x != 1
+            )
+        )
 
     if entry_agg_funcs is None:
         entry_agg_funcs = {}

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1701,7 +1701,7 @@ def annotate_freq(
     entry_agg_funcs: Optional[Dict[str, Tuple[Callable, Callable]]] = None,
     annotate_mt: bool = True,
     reduce_to_minimal_groups: bool = False,
-    non_summable_axes: Optional[Set[str]] = None,
+    non_summable_strata: Optional[Set[str]] = None,
 ) -> Union[hl.Table, hl.MatrixTable]:
     """
     Annotate `mt` with stratified allele frequencies.
@@ -1831,7 +1831,7 @@ def annotate_freq(
         assumes the values are summable (integers or struct-of-integers); do
         **not** enable this when `entry_agg_funcs` returns non-summable
         values such as means or medians. Default is False.
-    :param non_summable_axes: Axis names that should never be summed across
+    :param non_summable_strata: Strata names that should never be summed across
         when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
     :return: MatrixTable or Table with `freq` annotation.
     """
@@ -1882,7 +1882,7 @@ def annotate_freq(
         downsamplings=downsamplings,
         ds_gen_anc_counts=ds_gen_anc_counts,
         reduce_to_minimal_groups=reduce_to_minimal_groups,
-        non_summable_axes=non_summable_axes,
+        non_summable_strata=non_summable_strata,
     )
 
     # Forward `freq_meta` onto the MT's globals so `compute_freq_by_strata`
@@ -2127,7 +2127,7 @@ def _read_reduction_globals(
 def find_minimal_strata_groups(
     freq_meta: List[Dict[str, str]],
     freq_meta_sample_count: List[int],
-    non_summable_axes: Optional[Set[str]] = None,
+    non_summable_strata: Optional[Set[str]] = None,
 ) -> Tuple[List[int], Dict[int, List[int]]]:
     """
     Identify the minimal "leaf" set of stratification groups in a `freq_meta`.
@@ -2148,25 +2148,25 @@ def find_minimal_strata_groups(
     `compute_stats_per_ref_site` (which produces only `raw` entries) are
     handled correctly.
 
-    Within each partition, an entry's "summable axes" are the keys of its
-    metadata dict excluding `"group"` and excluding any axis listed in
-    `non_summable_axes`. The leaves are the entries whose summable-axes set is
-    maximal-by-inclusion within the partition.
+    Within each partition, an entry's "summable strata" are the keys of its
+    metadata dict excluding `"group"` and excluding any name listed in
+    `non_summable_strata`. The leaves are the entries whose summable-strata
+    set is maximal-by-inclusion within the partition.
 
-    For each non-leaf, candidate leaves (same non-summable axes, agreeing on
-    every key the parent has) are grouped by their full summable-axes set so
-    that each candidate decomposition lives in a single axis-family. A
-    candidate is *valid* iff its leaves' sample counts sum to the parent's.
-    If multiple candidates are valid, the smallest (fewest leaves) is chosen.
-    If none are valid, the parent is promoted to a leaf and computed
-    directly.
+    For each non-leaf, candidate leaves (same non-summable strata, agreeing
+    on every key the parent has) are grouped by their full summable-strata
+    set so that each candidate decomposition lives in a single
+    strata-family. A candidate is *valid* iff its leaves' sample counts sum
+    to the parent's. If multiple candidates are valid, the smallest (fewest
+    leaves) is chosen. If none are valid, the parent is promoted to a leaf
+    and computed directly.
 
     The sample-count check is what makes this safe when `freq_meta` has
-    multiple non-comparable axis families (e.g., `{gen_anc, sex}` and
+    multiple non-comparable strata families (e.g., `{gen_anc, sex}` and
     `{gatk_version, gen_anc}`): without it, a parent like the all-adj entry
     would silently sum across both families and double-count samples.
 
-    `non_summable_axes` defaults to `{"downsampling"}` because gnomAD's
+    `non_summable_strata` defaults to `{"downsampling"}` because gnomAD's
     `{downsampling: N, gen_anc: X}` groups select the first N samples of the
     given gen_anc using a randomized rank — they are disjoint from
     `{downsampling: N, gen_anc: Y}` and never sum into a global
@@ -2176,8 +2176,8 @@ def find_minimal_strata_groups(
         `generate_freq_group_membership_array`.
     :param freq_meta_sample_count: Per-entry sample counts aligned with
         `freq_meta`. Used to validate candidate decompositions.
-    :param non_summable_axes: Axis names that should never be summed across.
-        Default is `{"downsampling"}`.
+    :param non_summable_strata: Strata names that should never be summed
+        across. Default is `{"downsampling"}`.
     :return: Tuple of `(leaf_indices, decomposition)` where `leaf_indices` is
         a list of indices into `freq_meta` marking the leaves, in ascending
         order, and `decomposition` maps each non-leaf index to the list of
@@ -2189,18 +2189,20 @@ def find_minimal_strata_groups(
             f"(got {len(freq_meta_sample_count)} vs {len(freq_meta)})."
         )
 
-    if non_summable_axes is None:
-        non_summable_axes = {"downsampling"}
+    if non_summable_strata is None:
+        non_summable_strata = {"downsampling"}
     else:
-        non_summable_axes = set(non_summable_axes)
+        non_summable_strata = set(non_summable_strata)
 
-    def summable_axes_of(e: Dict[str, str]) -> frozenset:
+    def summable_strata_of(e: Dict[str, str]) -> frozenset:
         return frozenset(
-            k for k in e.keys() if k != "group" and k not in non_summable_axes
+            k for k in e.keys() if k != "group" and k not in non_summable_strata
         )
 
-    def non_summable_of(e: Dict[str, str]) -> frozenset:
-        return frozenset(k for k in e.keys() if k != "group" and k in non_summable_axes)
+    def non_summable_strata_of(e: Dict[str, str]) -> frozenset:
+        return frozenset(
+            k for k in e.keys() if k != "group" and k in non_summable_strata
+        )
 
     # Partition indices by group value (e.g., "adj" vs "raw").
     partitions: Dict[Optional[str], List[int]] = {}
@@ -2212,12 +2214,14 @@ def find_minimal_strata_groups(
 
     for indices in partitions.values():
         # Within this partition, determine the maximal-by-inclusion summable
-        # axis sets — those are the leaf axis sets.
-        axis_sets = {summable_axes_of(freq_meta[i]) for i in indices}
-        leaf_axis_sets = {s for s in axis_sets if not any(s < s2 for s2 in axis_sets)}
+        # strata sets — those are the leaf strata sets.
+        strata_sets = {summable_strata_of(freq_meta[i]) for i in indices}
+        leaf_strata_sets = {
+            s for s in strata_sets if not any(s < s2 for s2 in strata_sets)
+        }
 
         for i in indices:
-            if summable_axes_of(freq_meta[i]) in leaf_axis_sets:
+            if summable_strata_of(freq_meta[i]) in leaf_strata_sets:
                 is_leaf[i] = True
 
         # Decompose non-leaves using only same-partition leaves.
@@ -2227,29 +2231,29 @@ def find_minimal_strata_groups(
                 continue
             e = freq_meta[i]
             e_keys = {k: v for k, v in e.items() if k != "group"}
-            e_non_summable = non_summable_of(e)
+            e_non_summable = non_summable_strata_of(e)
             parent_count = freq_meta_sample_count[i]
 
-            # Group candidate leaves by their full summable-axes set so each
-            # candidate decomposition lives in a single axis-family.
-            by_axis: Dict[frozenset, List[int]] = {}
+            # Group candidate leaves by their full summable-strata set so
+            # each candidate decomposition lives in a single strata-family.
+            by_strata: Dict[frozenset, List[int]] = {}
             for j in leaf_indices_in_partition:
                 f = freq_meta[j]
-                if non_summable_of(f) != e_non_summable:
+                if non_summable_strata_of(f) != e_non_summable:
                     continue
                 if any(f.get(k) != v for k, v in e_keys.items()):
                     continue
-                by_axis.setdefault(summable_axes_of(f), []).append(j)
+                by_strata.setdefault(summable_strata_of(f), []).append(j)
 
             valid = [
                 cand
-                for cand in by_axis.values()
+                for cand in by_strata.values()
                 if sum(freq_meta_sample_count[j] for j in cand) == parent_count
             ]
             if valid:
                 decomposition[i] = min(valid, key=len)
             else:
-                # No candidate axis-family fully covers the parent — compute
+                # No candidate strata-family fully covers the parent — compute
                 # this entry directly to keep the output correct.
                 logger.info(
                     "Non-leaf entry at index %d (%s) has no sample-count-valid "
@@ -2376,7 +2380,7 @@ def generate_freq_group_membership_array(
     remove_zero_sample_groups: bool = False,
     no_raw_group: bool = False,
     reduce_to_minimal_groups: bool = False,
-    non_summable_axes: Optional[Set[str]] = None,
+    non_summable_strata: Optional[Set[str]] = None,
     group_label: str = "adj",
 ) -> hl.Table:
     """
@@ -2436,7 +2440,7 @@ def generate_freq_group_membership_array(
         as additional globals so a downstream caller (e.g., `annotate_freq`)
         can reconstruct the full per-strata array after aggregation. Default
         is False.
-    :param non_summable_axes: Axis names that should never be summed across
+    :param non_summable_strata: Strata names that should never be summed across
         when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
     :param group_label: Value to use for the `"group"` key on every constructed
         freq_meta entry. Default is `"adj"`. Set to `"raw"` for callers that
@@ -2595,7 +2599,7 @@ def generate_freq_group_membership_array(
         leaf_indices, decomposition = find_minimal_strata_groups(
             freq_meta_full,
             freq_meta_sample_count_full,
-            non_summable_axes=non_summable_axes,
+            non_summable_strata=non_summable_strata,
         )
 
         n_full = len(freq_meta_full)

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2154,9 +2154,9 @@ def find_minimal_strata_groups(
     :param non_summable_axes: Axis names that should never be summed across.
         Default is `{"downsampling"}`.
     :return: Tuple of `(leaf_indices, decomposition)` where `leaf_indices` is
-        a sorted list of indices into `freq_meta` marking the leaves, and
-        `decomposition` maps each non-leaf index to the list of leaf indices
-        that sum to it.
+        a list of indices into `freq_meta` marking the leaves, in ascending
+        order, and `decomposition` maps each non-leaf index to the list of
+        leaf indices that sum to it.
     """
     if non_summable_axes is None:
         non_summable_axes = {"downsampling"}
@@ -2210,6 +2210,12 @@ def find_minimal_strata_groups(
             else:
                 # Cannot decompose — keep as a leaf so the result is still
                 # computed directly.
+                logger.info(
+                    "Non-leaf entry at index %d (%s) could not be decomposed;"
+                    " promoting to leaf.",
+                    i,
+                    freq_meta[i],
+                )
                 is_leaf[i] = True
 
     leaf_indices = [i for i, leaf in enumerate(is_leaf) if leaf]

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1819,20 +1819,21 @@ def annotate_freq(
         output from the first function.
     :param annotate_mt: Whether to return the full MatrixTable with annotations added
         instead of only a Table with `freq` and other annotations. Default is True.
-    :param reduce_to_minimal_groups: When True, per-variant call statistics are
-        computed only on a minimal "leaf" subset of stratification groups (those
-        that cannot be derived by summing other groups in `freq_meta`). The
-        remaining groups are reconstructed by element-wise summation of leaves
-        as a cheap post-processing step, so the returned `freq` /
-        `freq_meta` / `freq_meta_sample_count` are identical to the
+    :param reduce_to_minimal_groups: Whether to compute per-variant call
+        statistics only on the "leaf" stratification groups (those that
+        cannot be derived by summing other groups in `freq_meta`) and
+        reconstruct the rest by element-wise summation as a cheap
+        post-processing step. The returned `freq`, `freq_meta`, and
+        `freq_meta_sample_count` are identical to the
         `reduce_to_minimal_groups=False` output. This is a pure cost
-        optimization for large stratifications. Any annotations produced by
-        `entry_agg_funcs` are also expanded by element-wise summation, which
-        assumes the values are summable (integers or struct-of-integers); do
-        **not** enable this when `entry_agg_funcs` returns non-summable
-        values such as means or medians. Default is False.
-    :param non_summable_strata: Strata names that should never be summed across
-        when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
+        optimization for large stratifications. Any annotations produced
+        by `entry_agg_funcs` are also expanded by element-wise summation,
+        so their values must be summable (integers or
+        struct-of-integers). Do not enable when `entry_agg_funcs` returns
+        non-summable values such as means or medians. Default is False.
+    :param non_summable_strata: Strata names that should never be summed
+        across their values when `reduce_to_minimal_groups` is True.
+        Default is `{"downsampling"}`.
     :return: MatrixTable or Table with `freq` annotation.
     """
     errors = []
@@ -2093,17 +2094,17 @@ def _read_reduction_globals(
     globals_source: hl.expr.StructExpression,
 ) -> Dict[str, Any]:
     """
-    Eval the four reduction-tracking globals and build a Python decomposition map.
+    Materialize the reduction-tracking globals into Python in a single round-trip.
 
     Used by both `annotate_freq` and `compute_stats_per_ref_site` to recover
-    the leaf-decomposition information from a `group_membership_ht` (or a
-    Table that has it on its globals) in a single round-trip.
+    the leaf-decomposition information needed to expand leaf-only
+    per-strata arrays back to full length.
 
-    :param globals_source: Hail globals struct that contains
-        `freq_leaf_indices`, `freq_group_decomposition`, `freq_meta_full`, and
-        `freq_meta_sample_count_full`.
-    :return: Dict with keys `leaf_indices`, `decomposition`, `freq_meta_full`,
-        `freq_meta_sample_count_full`, and `n_full`.
+    :param globals_source: Hail globals struct expected to contain
+        `freq_leaf_indices`, `freq_group_decomposition`, `freq_meta_full`,
+        and `freq_meta_sample_count_full`.
+    :return: Dict with keys `leaf_indices`, `decomposition`,
+        `freq_meta_full`, `freq_meta_sample_count_full`, and `n_full`.
     """
     g = hl.eval(
         globals_source.select(
@@ -2135,41 +2136,41 @@ def find_minimal_strata_groups(
     A "leaf" group is one that cannot be derived by summing other groups in
     `freq_meta`. The remaining ("non-leaf") groups can be reconstructed by
     element-wise summation of leaves whose sample counts partition the
-    parent's. This is the basis for an opt-in optimization that computes
-    per-variant call stats only on the leaves and reconstructs the rest by
-    summation in a cheap post-processing step (see
+    parent's sample count. This supports an opt-in optimization that
+    computes per-variant call stats only on the leaves and reconstructs the
+    rest by summation as a cheap post-processing step (see
     `expand_strata_array_from_leaves`).
 
     The algorithm partitions `freq_meta` by the value of the `"group"` key
-    (typically `"adj"` and `"raw"`) and runs leaf detection independently in
-    each partition. This is required because `adj` and `raw` are
-    *genotype-level* filters and never sum into each other; both `annotate_freq`
-    (which produces a mix of `adj` and `raw` entries) and
-    `compute_stats_per_ref_site` (which produces only `raw` entries) are
-    handled correctly.
+    (typically `"adj"` and `"raw"`) and runs leaf detection independently
+    in each partition. `adj` and `raw` are genotype-level filters and never
+    sum into each other, so both `annotate_freq` (which produces a mix of
+    `adj` and `raw` entries) and `compute_stats_per_ref_site` (which
+    produces only `raw` entries) are handled correctly.
 
     Within each partition, an entry's "summable strata" are the keys of its
-    metadata dict excluding `"group"` and excluding any name listed in
+    metadata dict excluding `"group"` and excluding any stratum listed in
     `non_summable_strata`. The leaves are the entries whose summable-strata
     set is maximal-by-inclusion within the partition.
 
-    For each non-leaf, candidate leaves (same non-summable strata, agreeing
-    on every key the parent has) are grouped by their full summable-strata
-    set so that each candidate decomposition lives in a single
-    strata-family. A candidate is *valid* iff its leaves' sample counts sum
-    to the parent's. If multiple candidates are valid, the smallest (fewest
-    leaves) is chosen. If none are valid, the parent is promoted to a leaf
-    and computed directly.
+    For each non-leaf, candidate leaves (those with the same non-summable
+    strata and agreeing on every key the parent has) are grouped by their
+    full summable-strata set so each candidate decomposition lives in a
+    single strata-family. A candidate is valid when its leaves' sample
+    counts sum to the parent's sample count. If multiple candidates are
+    valid, the candidate with the fewest leaves is chosen. If none are
+    valid, the parent is promoted to a leaf and computed directly.
 
-    The sample-count check is what makes this safe when `freq_meta` has
-    multiple non-comparable strata families (e.g., `{gen_anc, sex}` and
-    `{gatk_version, gen_anc}`): without it, a parent like the all-adj entry
-    would silently sum across both families and double-count samples.
+    The sample-count check is what makes this safe when `freq_meta`
+    contains multiple non-comparable strata families (e.g., `{gen_anc,
+    sex}` and `{gatk_version, gen_anc}`). Without it, a parent like the
+    all-adj entry would silently sum across both families and double-count
+    samples.
 
     `non_summable_strata` defaults to `{"downsampling"}` because gnomAD's
-    `{downsampling: N, gen_anc: X}` groups select the first N samples of the
-    given gen_anc using a randomized rank — they are disjoint from
-    `{downsampling: N, gen_anc: Y}` and never sum into a global
+    `{downsampling: N, gen_anc: X}` groups select the first N samples of
+    the given gen_anc using a randomized rank. These groups are disjoint
+    from `{downsampling: N, gen_anc: Y}` and never sum into a global
     `{downsampling: N}` entry.
 
     :param freq_meta: List of `freq_meta` dicts as produced by
@@ -2177,10 +2178,10 @@ def find_minimal_strata_groups(
     :param freq_meta_sample_count: Per-entry sample counts aligned with
         `freq_meta`. Used to validate candidate decompositions.
     :param non_summable_strata: Strata names that should never be summed
-        across. Default is `{"downsampling"}`.
-    :return: Tuple of `(leaf_indices, decomposition)` where `leaf_indices` is
-        a list of indices into `freq_meta` marking the leaves, in ascending
-        order, and `decomposition` maps each non-leaf index to the list of
+        across their values. Default is `{"downsampling"}`.
+    :return: Tuple of `(leaf_indices, decomposition)`. `leaf_indices` is a
+        list of indices into `freq_meta` marking the leaves, in ascending
+        order. `decomposition` maps each non-leaf index to the list of
         leaf indices that sum to it.
     """
     if len(freq_meta_sample_count) != len(freq_meta):
@@ -2276,35 +2277,37 @@ def expand_strata_array_from_leaves(
     """
     Reconstruct a full-length per-strata array from a leaf-only array.
 
-    This is the post-processing companion to `find_minimal_strata_groups`. For
-    each position `i` in the full (original) `freq_meta`:
+    This is the post-processing companion to `find_minimal_strata_groups`.
+    For each position `i` in the full (original) `freq_meta`:
 
-      - If `i` is a leaf, the value at `leaf_array[leaf_pos[i]]` is used
-        directly.
-      - Otherwise, the values at the positions corresponding to
-        `decomposition[i]` are summed element-wise.
+        - If `i` is a leaf, the corresponding value in `leaf_array` is
+          used directly.
+        - Otherwise, the `leaf_array` values at the positions identified
+          by `decomposition[i]` are summed element-wise.
 
-    The element type is inspected to decide how to sum: integers are summed
-    directly, and structs have each numeric field summed independently. As a
-    special case, struct elements with an `"AF"` field are treated as freq
-    structs — `AF` is dropped before summing and recomputed at the end as
-    `or_missing(AN > 0, AC / AN)`.
+    The element type is inspected to decide how to sum: integers are
+    summed directly, and structs have each numeric field summed
+    independently. Struct elements with an `"AF"` field are treated as
+    freq structs: `AF` is dropped before summing and recomputed at the
+    end as `or_missing(AN > 0, AC / AN)`.
 
     The expansion is encoded as a compact Hail IR operation
     (`hl_children.map(...)`) with lookup tables for leaf positions and
-    child-index lists, so the serialized IR size is O(n_full) regardless of
-    how many groups there are. This avoids Jackson's JSON string-length limit
-    that would be hit if each group's expression were inlined as a separate
-    Python-side Hail expression literal.
+    child-index lists. The serialized IR size is therefore O(n_full)
+    regardless of how many groups there are. This avoids Jackson's JSON
+    string-length limit that would otherwise be hit if each group's
+    expression were inlined as a separate Python-side Hail expression
+    literal.
 
     :param leaf_array: Hail array expression of length `len(leaf_indices)`
         produced by aggregating only the leaf groups.
-    :param leaf_indices: Original-`freq_meta` indices of the leaves, in the
-        same order as `leaf_array`.
-    :param decomposition: Map from non-leaf original index to list of original
-        leaf indices that sum to it.
+    :param leaf_indices: Indices into the original `freq_meta` marking the
+        leaves, in the same order as `leaf_array`.
+    :param decomposition: Map from non-leaf original index to the list of
+        original leaf indices that sum to it.
     :param n_full: Length of the original (full) `freq_meta`.
-    :return: Hail array expression of length `n_full`.
+    :return: Hail array expression of length `n_full` whose element type
+        matches `leaf_array`'s.
     """
     # Map original-freq_meta index → position in the reduced leaf_array.
     leaf_pos = {orig_idx: pos for pos, orig_idx in enumerate(leaf_indices)}
@@ -2404,20 +2407,24 @@ def generate_freq_group_membership_array(
 
     .. rubric:: The `reduce_to_minimal_groups` parameter
 
-    When `reduce_to_minimal_groups` is True, the returned `group_membership`,
-    `freq_meta`, and `freq_meta_sample_count` are reduced to only the "leaf"
-    groups (those that cannot be derived by summing other groups in
-    `freq_meta`). The original full versions are preserved as additional
-    globals so that downstream callers can reconstruct the full per-strata
-    arrays after their (cheaper) leaf-only aggregation:
+    When `reduce_to_minimal_groups` is True, the returned
+    `group_membership`, `freq_meta`, and `freq_meta_sample_count` are
+    reduced to only the "leaf" groups (those that cannot be derived by
+    summing other groups in `freq_meta`). The original full versions are
+    preserved as additional globals so a downstream caller can
+    reconstruct the full per-strata arrays after its (cheaper) leaf-only
+    aggregation:
 
-        - freq_meta_full: original full freq_meta before reduction.
-        - freq_meta_sample_count_full: original full sample counts.
-        - freq_leaf_indices: indices into freq_meta_full marking the leaves
-          (in the same order as the reduced freq_meta).
-        - freq_group_decomposition: list of length len(freq_meta_full) where
-          each element is the list of freq_meta_full indices whose stats sum
-          to that position. Leaves get an empty list.
+        - `freq_meta_full`: original full `freq_meta` before reduction.
+        - `freq_meta_sample_count_full`: original full sample counts.
+        - `freq_leaf_indices`: indices into `freq_meta_full` marking the
+          leaves, in the same order as the reduced `freq_meta`.
+        - `freq_group_decomposition`: list of length
+          `len(freq_meta_full)` where each element is the list of
+          `freq_meta_full` indices that sum to that position. Leaves get
+          an empty list.
+        - `freq_reduced`: True, signalling that the reduction has been
+          applied.
 
     See `find_minimal_strata_groups` for the leaf-detection algorithm and
     `expand_strata_array_from_leaves` for the reconstruction step.
@@ -2434,17 +2441,18 @@ def generate_freq_group_membership_array(
         annotation and the 'freq_meta' and 'freq_meta_sample_count' global annotations.
         Default is False.
     :param reduce_to_minimal_groups: Whether to reduce the returned
-        `group_membership`/`freq_meta`/`freq_meta_sample_count` to only the
-        leaf groups whose call stats cannot be derived by summing other
-        groups. The full versions and the leaf-decomposition map are stored
-        as additional globals so a downstream caller (e.g., `annotate_freq`)
-        can reconstruct the full per-strata array after aggregation. Default
-        is False.
-    :param non_summable_strata: Strata names that should never be summed across
-        when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
-    :param group_label: Value to use for the `"group"` key on every constructed
-        freq_meta entry. Default is `"adj"`. Set to `"raw"` for callers that
-        don't apply any genotype-level filtering (e.g.,
+        `group_membership`, `freq_meta`, and `freq_meta_sample_count` to
+        only the leaf groups whose call stats cannot be derived by summing
+        other groups. The full versions and the leaf-decomposition map
+        are stored as additional globals so a downstream caller (e.g.,
+        `annotate_freq`) can reconstruct the full per-strata array after
+        aggregation. Default is False.
+    :param non_summable_strata: Strata names that should never be summed
+        across their values when `reduce_to_minimal_groups` is True.
+        Default is `{"downsampling"}`.
+    :param group_label: Value to use for the `"group"` key on every
+        constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
+        for callers that don't apply any genotype-level filtering (e.g.,
         `compute_stats_per_ref_site`).
     :return: Table with the 'group_membership' array annotation.
     """

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2773,8 +2773,12 @@ def agg_by_strata(
         of dicts. Each dict in the list contains the strata in 'freq_meta' to use for
         the corresponding entry aggregation function. If provided, 'freq_meta' must be
         present in `group_membership_ht` or `mt` and represent the same strata as those
-        in 'group_membership'. If not provided, all entries of the 'group_membership'
-        annotation will have the entry aggregation functions applied to them.
+        in 'group_membership'. Under leaf reduction (when `freq_reduced=True` is set on
+        the supplied globals), targets may also reference non-leaf parents present in
+        `freq_meta_full`; their sample-sets are reconstructed by flattening the
+        `s_indices` of their leaf-children listed in `freq_group_decomposition`. If not
+        provided, all entries of the 'group_membership' annotation will have the entry
+        aggregation functions applied to them.
     :return: Table with annotations of stratified aggregations.
     """
     if group_membership_ht is None and "group_membership" not in mt.col:
@@ -2832,10 +2836,75 @@ def agg_by_strata(
         )
 
     entry_agg_group_membership = entry_agg_group_membership or {}
-    entry_agg_group_membership = {
-        ann: [group_globals["freq_meta"].index(s) for s in strata]
-        for ann, strata in entry_agg_group_membership.items()
-    }
+
+    # Resolve each `entry_agg_group_membership` target to either a leaf
+    # position in the (possibly reduced) `freq_meta`, or — if the target
+    # is a non-leaf parent under reduction — the list of leaf positions
+    # whose disjoint sample-sets sum to it. Resolution happens in
+    # Python because the metadata is small (~100s of entries) and we
+    # need the leaf-vs-parent decision before building the per-target
+    # aggregation expression.
+    if entry_agg_group_membership:
+        freq_meta_py = [dict(m) for m in hl.eval(group_globals["freq_meta"])]
+        is_reduced_for_lookup = "freq_reduced" in group_globals and hl.eval(
+            group_globals.freq_reduced
+        )
+        if is_reduced_for_lookup:
+            freq_meta_full_py = [dict(m) for m in hl.eval(group_globals.freq_meta_full)]
+            decomposition_py = list(hl.eval(group_globals.freq_group_decomposition))
+            leaf_indices_py = list(hl.eval(group_globals.freq_leaf_indices))
+            full_to_leaf_pos = {f_i: lp for lp, f_i in enumerate(leaf_indices_py)}
+        else:
+            freq_meta_full_py = freq_meta_py
+            decomposition_py = [[] for _ in freq_meta_py]
+            full_to_leaf_pos = {i: i for i in range(len(freq_meta_py))}
+
+        def _resolve_target(target_dict):
+            target = dict(target_dict)
+            for i, m in enumerate(freq_meta_py):
+                if m == target:
+                    return ("leaf", i, target.get("group", "NA") == "adj")
+            if not is_reduced_for_lookup:
+                raise ValueError(
+                    f"`entry_agg_group_membership` target {target} is not in"
+                    " `freq_meta`."
+                )
+            for i, m in enumerate(freq_meta_full_py):
+                if m == target:
+                    children_full = list(decomposition_py[i])
+                    if not children_full:
+                        raise ValueError(
+                            f"`entry_agg_group_membership` target {target} is in"
+                            " `freq_meta_full` but has empty decomposition; under"
+                            " reduction this means it is neither a leaf nor a"
+                            " summable parent (likely spans `non_summable_strata`"
+                            " in a way that prevents decomposition)."
+                        )
+                    try:
+                        children_leaf_pos = [
+                            full_to_leaf_pos[ci] for ci in children_full
+                        ]
+                    except KeyError as e:
+                        raise ValueError(
+                            f"`entry_agg_group_membership` target {target}"
+                            f" decomposes to a non-leaf at full index {e.args[0]};"
+                            " decomposition is expected to map each non-leaf"
+                            " directly to leaves."
+                        )
+                    return (
+                        "parent",
+                        children_leaf_pos,
+                        target.get("group", "NA") == "adj",
+                    )
+            raise ValueError(
+                f"`entry_agg_group_membership` target {target} is not in"
+                " `freq_meta` or `freq_meta_full`."
+            )
+
+        entry_agg_group_membership = {
+            ann: [_resolve_target(t) for t in targets]
+            for ann, targets in entry_agg_group_membership.items()
+        }
 
     n_adj_groups = hl.eval(hl.len(global_expr["adj_groups"]))
     if n_adj_groups != n_groups:
@@ -2903,23 +2972,49 @@ def agg_by_strata(
             adj_groups_expr,
         )
 
+    # Build per-target (s_indices, adj) arrays for each annotation in
+    # `entry_agg_group_membership`. Leaf targets reuse the
+    # `indices_by_group` / `adj_groups` slots directly; non-leaf parent
+    # targets synthesize their `s_indices` as the flatten of their
+    # leaf-children's index arrays (safe — the leaves of a parent's
+    # decomposition are pairwise disjoint, enforced by the sample-count
+    # check in `find_minimal_strata_groups`). The parent's adj flag is
+    # taken from its own `group` key, equivalent to any leaf-child's
+    # adj because a parent's leaf-set shares the same `group` value.
+    def _per_target_indices_and_adj(target_resolutions):
+        s_indices_per_target = []
+        adj_per_target = []
+        for kind, payload, adj in target_resolutions:
+            if kind == "leaf":
+                s_indices_per_target.append(ht.indices_by_group[payload])
+                adj_per_target.append(ht.adj_groups[payload])
+            else:  # parent
+                s_indices_per_target.append(
+                    hl.flatten(hl.array([ht.indices_by_group[lp] for lp in payload]))
+                )
+                adj_per_target.append(hl.literal(adj))
+        return hl.array(s_indices_per_target), hl.array(adj_per_target)
+
     # Add annotations for any supplied entry transform and aggregation functions.
     # Filter groups to only those in entry_agg_group_membership if specified.
     # If there are no specific entry group indices for an annotation, use ht[g]
     # to consider all groups without filtering.
+    def _agg_for(ann, f):
+        if ann in entry_agg_group_membership:
+            s_indices, adjs = _per_target_indices_and_adj(
+                entry_agg_group_membership[ann]
+            )
+            return _agg_by_group(s_indices, adjs, agg_func=f[1], ann_expr=ht[ann])
+        return _agg_by_group(
+            ht.indices_by_group,
+            ht.adj_groups,
+            agg_func=f[1],
+            ann_expr=ht[ann],
+        )
+
     ht = ht.select(
         *select_fields,
-        **{
-            ann: _agg_by_group(
-                *[
-                    [ht[g][i] for i in entry_agg_group_membership.get(ann, [])] or ht[g]
-                    for g in ["indices_by_group", "adj_groups"]
-                ],
-                agg_func=f[1],
-                ann_expr=ht[ann],
-            )
-            for ann, f in entry_agg_funcs.items()
-        },
+        **{ann: _agg_for(ann, f) for ann, f in entry_agg_funcs.items()},
     )
 
     return ht.drop("cols")

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1885,18 +1885,13 @@ def annotate_freq(
         non_summable_axes=non_summable_axes,
     )
 
-    # When reducing, the leaf-only group_membership no longer has the
-    # historical "index 0 = first adj group, index 1 = raw" layout — the
-    # all-adj group at position 0 is typically eliminated as a non-leaf. Pass
-    # `freq_meta` through on the MT's globals so `compute_freq_by_strata`
-    # derives `adj_groups` from it instead of the hardcoded layout rule.
+    # Forward `freq_meta` onto the MT's globals so `compute_freq_by_strata`
+    # always derives `adj_groups` from it. This is required when reducing
+    # (where the leaf-only group_membership no longer follows the historical
+    # "index 0 = first adj, index 1 = raw" layout) and harmless otherwise.
     mt_with_membership = mt.annotate_cols(
         group_membership=ht[mt.col_key].group_membership
-    )
-    if reduce_to_minimal_groups:
-        mt_with_membership = mt_with_membership.annotate_globals(
-            freq_meta=ht.index_globals().freq_meta
-        )
+    ).annotate_globals(freq_meta=ht.index_globals().freq_meta)
 
     freq_ht = compute_freq_by_strata(
         mt_with_membership,
@@ -1907,48 +1902,31 @@ def annotate_freq(
     if reduce_to_minimal_groups:
         # Expand the leaf-only per-strata annotations back to full length
         # using the decomposition map stored on the group-membership Table.
-        leaf_indices = hl.eval(freq_ht.freq_leaf_indices)
-        decomposition_serialized = hl.eval(freq_ht.freq_group_decomposition)
-        freq_meta_full = hl.eval(freq_ht.freq_meta_full)
-        freq_meta_sample_count_full = hl.eval(freq_ht.freq_meta_sample_count_full)
-        n_full = len(freq_meta_full)
-        decomposition = {
-            i: list(children)
-            for i, children in enumerate(decomposition_serialized)
-            if children
-        }
-
-        expansion_exprs = {
-            "freq": expand_strata_array_from_leaves(
-                freq_ht.freq,
-                leaf_indices,
-                decomposition,
-                n_full,
-                is_freq_struct=True,
-            )
-        }
-        if entry_agg_funcs is not None:
-            for ann in entry_agg_funcs:
-                expansion_exprs[ann] = expand_strata_array_from_leaves(
-                    freq_ht[ann],
-                    leaf_indices,
-                    decomposition,
-                    n_full,
-                    is_freq_struct=False,
+        r = _read_reduction_globals(freq_ht.globals)
+        annotation_names = ["freq"] + (
+            list(entry_agg_funcs) if entry_agg_funcs is not None else []
+        )
+        freq_ht = freq_ht.annotate(
+            **{
+                ann: expand_strata_array_from_leaves(
+                    freq_ht[ann], r["leaf_indices"], r["decomposition"], r["n_full"]
                 )
-        freq_ht = freq_ht.annotate(**expansion_exprs)
+                for ann in annotation_names
+            }
+        )
 
         # Restore the original full freq_meta / freq_meta_sample_count and
         # drop the now-redundant reduction-tracking globals.
         freq_ht = freq_ht.annotate_globals(
-            freq_meta=freq_meta_full,
-            freq_meta_sample_count=freq_meta_sample_count_full,
+            freq_meta=r["freq_meta_full"],
+            freq_meta_sample_count=r["freq_meta_sample_count_full"],
         )
         freq_ht = freq_ht.drop(
             "freq_meta_full",
             "freq_meta_sample_count_full",
             "freq_leaf_indices",
             "freq_group_decomposition",
+            "freq_reduced",
         )
 
     if annotate_mt:
@@ -2111,8 +2089,44 @@ def build_freq_stratification_list(
     return strata_expr
 
 
+def _read_reduction_globals(
+    globals_source: hl.expr.StructExpression,
+) -> Dict[str, Any]:
+    """
+    Eval the four reduction-tracking globals and build a Python decomposition map.
+
+    Used by both `annotate_freq` and `compute_stats_per_ref_site` to recover
+    the leaf-decomposition information from a `group_membership_ht` (or a
+    Table that has it on its globals) in a single round-trip.
+
+    :param globals_source: Hail globals struct that contains
+        `freq_leaf_indices`, `freq_group_decomposition`, `freq_meta_full`, and
+        `freq_meta_sample_count_full`.
+    :return: Dict with keys `leaf_indices`, `decomposition`, `freq_meta_full`,
+        `freq_meta_sample_count_full`, and `n_full`.
+    """
+    g = hl.eval(
+        globals_source.select(
+            "freq_leaf_indices",
+            "freq_group_decomposition",
+            "freq_meta_full",
+            "freq_meta_sample_count_full",
+        )
+    )
+    return {
+        "leaf_indices": list(g.freq_leaf_indices),
+        "decomposition": {
+            i: list(c) for i, c in enumerate(g.freq_group_decomposition) if c
+        },
+        "freq_meta_full": list(g.freq_meta_full),
+        "freq_meta_sample_count_full": list(g.freq_meta_sample_count_full),
+        "n_full": len(g.freq_meta_full),
+    }
+
+
 def find_minimal_strata_groups(
     freq_meta: List[Dict[str, str]],
+    freq_meta_sample_count: List[int],
     non_summable_axes: Optional[Set[str]] = None,
 ) -> Tuple[List[int], Dict[int, List[int]]]:
     """
@@ -2120,11 +2134,11 @@ def find_minimal_strata_groups(
 
     A "leaf" group is one that cannot be derived by summing other groups in
     `freq_meta`. The remaining ("non-leaf") groups can be reconstructed by
-    element-wise summation of leaves with matching values on the parent's keys
-    and matching non-summable axes (e.g., same `downsampling` value). This is
-    the basis for an opt-in optimization that computes per-variant call stats
-    only on the leaves and reconstructs the rest by summation in a cheap
-    post-processing step (see `expand_strata_array_from_leaves`).
+    element-wise summation of leaves whose sample counts partition the
+    parent's. This is the basis for an opt-in optimization that computes
+    per-variant call stats only on the leaves and reconstructs the rest by
+    summation in a cheap post-processing step (see
+    `expand_strata_array_from_leaves`).
 
     The algorithm partitions `freq_meta` by the value of the `"group"` key
     (typically `"adj"` and `"raw"`) and runs leaf detection independently in
@@ -2137,11 +2151,20 @@ def find_minimal_strata_groups(
     Within each partition, an entry's "summable axes" are the keys of its
     metadata dict excluding `"group"` and excluding any axis listed in
     `non_summable_axes`. The leaves are the entries whose summable-axes set is
-    maximal-by-inclusion within the partition. A non-leaf is decomposed into
-    every leaf in the same partition that (a) has the same non-summable axes
-    (e.g., same `downsampling` value) and (b) agrees with the parent on every
-    key the parent has. If a non-leaf cannot be decomposed (no matching
-    leaves), it is kept as a leaf as a no-op fallback.
+    maximal-by-inclusion within the partition.
+
+    For each non-leaf, candidate leaves (same non-summable axes, agreeing on
+    every key the parent has) are grouped by their full summable-axes set so
+    that each candidate decomposition lives in a single axis-family. A
+    candidate is *valid* iff its leaves' sample counts sum to the parent's.
+    If multiple candidates are valid, the smallest (fewest leaves) is chosen.
+    If none are valid, the parent is promoted to a leaf and computed
+    directly.
+
+    The sample-count check is what makes this safe when `freq_meta` has
+    multiple non-comparable axis families (e.g., `{gen_anc, sex}` and
+    `{gatk_version, gen_anc}`): without it, a parent like the all-adj entry
+    would silently sum across both families and double-count samples.
 
     `non_summable_axes` defaults to `{"downsampling"}` because gnomAD's
     `{downsampling: N, gen_anc: X}` groups select the first N samples of the
@@ -2151,6 +2174,8 @@ def find_minimal_strata_groups(
 
     :param freq_meta: List of `freq_meta` dicts as produced by
         `generate_freq_group_membership_array`.
+    :param freq_meta_sample_count: Per-entry sample counts aligned with
+        `freq_meta`. Used to validate candidate decompositions.
     :param non_summable_axes: Axis names that should never be summed across.
         Default is `{"downsampling"}`.
     :return: Tuple of `(leaf_indices, decomposition)` where `leaf_indices` is
@@ -2158,6 +2183,12 @@ def find_minimal_strata_groups(
         order, and `decomposition` maps each non-leaf index to the list of
         leaf indices that sum to it.
     """
+    if len(freq_meta_sample_count) != len(freq_meta):
+        raise ValueError(
+            "freq_meta_sample_count must be aligned with freq_meta "
+            f"(got {len(freq_meta_sample_count)} vs {len(freq_meta)})."
+        )
+
     if non_summable_axes is None:
         non_summable_axes = {"downsampling"}
     else:
@@ -2197,22 +2228,32 @@ def find_minimal_strata_groups(
             e = freq_meta[i]
             e_keys = {k: v for k, v in e.items() if k != "group"}
             e_non_summable = non_summable_of(e)
-            matches = []
+            parent_count = freq_meta_sample_count[i]
+
+            # Group candidate leaves by their full summable-axes set so each
+            # candidate decomposition lives in a single axis-family.
+            by_axis: Dict[frozenset, List[int]] = {}
             for j in leaf_indices_in_partition:
                 f = freq_meta[j]
                 if non_summable_of(f) != e_non_summable:
                     continue
                 if any(f.get(k) != v for k, v in e_keys.items()):
                     continue
-                matches.append(j)
-            if matches:
-                decomposition[i] = matches
+                by_axis.setdefault(summable_axes_of(f), []).append(j)
+
+            valid = [
+                cand
+                for cand in by_axis.values()
+                if sum(freq_meta_sample_count[j] for j in cand) == parent_count
+            ]
+            if valid:
+                decomposition[i] = min(valid, key=len)
             else:
-                # Cannot decompose — keep as a leaf so the result is still
-                # computed directly.
+                # No candidate axis-family fully covers the parent — compute
+                # this entry directly to keep the output correct.
                 logger.info(
-                    "Non-leaf entry at index %d (%s) could not be decomposed;"
-                    " promoting to leaf.",
+                    "Non-leaf entry at index %d (%s) has no sample-count-valid "
+                    "decomposition; promoting to leaf.",
                     i,
                     freq_meta[i],
                 )
@@ -2227,7 +2268,6 @@ def expand_strata_array_from_leaves(
     leaf_indices: List[int],
     decomposition: Dict[int, List[int]],
     n_full: int,
-    is_freq_struct: bool = False,
 ) -> hl.expr.ArrayExpression:
     """
     Reconstruct a full-length per-strata array from a leaf-only array.
@@ -2240,14 +2280,14 @@ def expand_strata_array_from_leaves(
       - Otherwise, the values at the positions corresponding to
         `decomposition[i]` are summed element-wise.
 
-    For `is_freq_struct=True`, each element is treated as a struct with `AC`,
-    `AN`, and `homozygote_count` int fields; AF is recomputed after summation
-    as `or_missing(AN > 0, AC / AN)`. Otherwise, the element type is
-    inspected: integer arrays are summed with `_sum_or_diff_values`, and
-    struct arrays have each int field summed independently.
+    The element type is inspected to decide how to sum: integers are summed
+    directly, and structs have each numeric field summed independently. As a
+    special case, struct elements with an `"AF"` field are treated as freq
+    structs — `AF` is dropped before summing and recomputed at the end as
+    `or_missing(AN > 0, AC / AN)`.
 
     The expansion is encoded as a compact Hail IR operation
-    (`hl.range(n_full).map(...)`) with lookup tables for leaf positions and
+    (`hl_children.map(...)`) with lookup tables for leaf positions and
     child-index lists, so the serialized IR size is O(n_full) regardless of
     how many groups there are. This avoids Jackson's JSON string-length limit
     that would be hit if each group's expression were inlined as a separate
@@ -2260,9 +2300,6 @@ def expand_strata_array_from_leaves(
     :param decomposition: Map from non-leaf original index to list of original
         leaf indices that sum to it.
     :param n_full: Length of the original (full) `freq_meta`.
-    :param is_freq_struct: If True, treat each element as a freq struct
-        (`AC`, `AF`, `AN`, `homozygote_count`) and recompute `AF` after
-        summing. Default False.
     :return: Hail array expression of length `n_full`.
     """
     # Map original-freq_meta index → position in the reduced leaf_array.
@@ -2270,7 +2307,7 @@ def expand_strata_array_from_leaves(
 
     element_type = leaf_array.dtype.element_type
     is_struct = isinstance(element_type, hl.tstruct)
-
+    is_freq_struct = is_struct and "AF" in element_type.fields
     if is_freq_struct:
         struct_fields = ["AC", "AN", "homozygote_count"]
     elif is_struct:
@@ -2293,49 +2330,35 @@ def expand_strata_array_from_leaves(
                 f"Index {i} is neither a leaf nor in the decomposition map."
             )
 
-    # Encode as a Hail literal: array<array<int32>>.
     hl_children = hl.literal(children_per_group)
 
-    # If we need to drop fields (e.g. AF from freq structs) before summing,
-    # project the leaf_array once up front so every element has the same type.
-    if struct_fields is not None:
+    # Drop AF before summing so every element has the same numeric-only type;
+    # AF is recomputed below from the summed AC/AN.
+    if is_freq_struct:
         projected = leaf_array.map(lambda x: x.select(*struct_fields))
     else:
         projected = leaf_array
 
-    # Build the expanded array via a single Hail-side map. For each group
-    # position, look up its child indices and fold-sum over them.
     if struct_fields is not None:
 
-        def _sum_struct_children(child_indices):
-            return child_indices[1:].fold(
-                lambda acc, idx: acc.annotate(
-                    **{
-                        f: hl.or_else(acc[f], 0) + hl.or_else(projected[idx][f], 0)
-                        for f in struct_fields
-                    }
-                ),
-                projected[child_indices[0]],
+        def _sum_at(child_indices):
+            return hl.struct(
+                **{
+                    f: hl.sum(
+                        child_indices.map(lambda idx: hl.or_else(projected[idx][f], 0))
+                    )
+                    for f in struct_fields
+                }
             )
 
-        expanded = hl_children.map(
-            lambda child_indices: _sum_struct_children(child_indices)
-        )
     else:
 
-        def _sum_scalar_children(child_indices):
-            return child_indices[1:].fold(
-                lambda acc, idx: hl.or_else(acc, 0) + hl.or_else(projected[idx], 0),
-                projected[child_indices[0]],
-            )
+        def _sum_at(child_indices):
+            return hl.sum(child_indices.map(lambda idx: hl.or_else(projected[idx], 0)))
 
-        expanded = hl_children.map(
-            lambda child_indices: _sum_scalar_children(child_indices)
-        )
+    expanded = hl_children.map(_sum_at)
 
     if is_freq_struct:
-        # Recompute AF from the summed AC/AN, and select the canonical field
-        # order used elsewhere in the codebase.
         expanded = expanded.map(
             lambda x: x.annotate(AF=hl.or_missing(x.AN > 0, x.AC / x.AN)).select(
                 "AC", "AF", "AN", "homozygote_count"
@@ -2354,6 +2377,7 @@ def generate_freq_group_membership_array(
     no_raw_group: bool = False,
     reduce_to_minimal_groups: bool = False,
     non_summable_axes: Optional[Set[str]] = None,
+    group_label: str = "adj",
 ) -> hl.Table:
     """
     Generate a Table with a 'group_membership' array for each sample indicating whether the sample belongs to specific stratification groups.
@@ -2414,6 +2438,10 @@ def generate_freq_group_membership_array(
         is False.
     :param non_summable_axes: Axis names that should never be summed across
         when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
+    :param group_label: Value to use for the `"group"` key on every constructed
+        freq_meta entry. Default is `"adj"`. Set to `"raw"` for callers that
+        don't apply any genotype-level filtering (e.g.,
+        `compute_stats_per_ref_site`).
     :return: Table with the 'group_membership' array annotation.
     """
     errors = []
@@ -2530,7 +2558,8 @@ def generate_freq_group_membership_array(
 
     # Create and annotate global expression with meta and sample count information.
     freq_meta = [
-        dict(**sample_group[0], group="adj") for sample_group in sample_group_filters
+        dict(**sample_group[0], group=group_label)
+        for sample_group in sample_group_filters
     ]
 
     if not no_raw_group:
@@ -2557,14 +2586,16 @@ def generate_freq_group_membership_array(
         # is wrapped in `hl.array(...).extend(...)` above when raw is
         # prepended). Materialize it back to a Python list so we can slice
         # both arrays in Python.
-        if not isinstance(freq_meta_sample_count, list):
-            freq_meta_sample_count_full = list(hl.eval(freq_meta_sample_count))
-        else:
+        if isinstance(freq_meta_sample_count, list):
             freq_meta_sample_count_full = list(freq_meta_sample_count)
+        else:
+            freq_meta_sample_count_full = list(hl.eval(freq_meta_sample_count))
 
         freq_meta_full = [dict(m) for m in freq_meta]
         leaf_indices, decomposition = find_minimal_strata_groups(
-            freq_meta_full, non_summable_axes=non_summable_axes
+            freq_meta_full,
+            freq_meta_sample_count_full,
+            non_summable_axes=non_summable_axes,
         )
 
         n_full = len(freq_meta_full)
@@ -2593,6 +2624,7 @@ def generate_freq_group_membership_array(
         global_expr["freq_meta_sample_count_full"] = freq_meta_sample_count_full
         global_expr["freq_leaf_indices"] = leaf_indices
         global_expr["freq_group_decomposition"] = freq_group_decomposition
+        global_expr["freq_reduced"] = True
 
     if downsamplings is not None:
         global_expr["downsamplings"] = downsamplings

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2246,6 +2246,13 @@ def expand_strata_array_from_leaves(
     inspected: integer arrays are summed with `_sum_or_diff_values`, and
     struct arrays have each int field summed independently.
 
+    The expansion is encoded as a compact Hail IR operation
+    (`hl.range(n_full).map(...)`) with lookup tables for leaf positions and
+    child-index lists, so the serialized IR size is O(n_full) regardless of
+    how many groups there are. This avoids Jackson's JSON string-length limit
+    that would be hit if each group's expression were inlined as a separate
+    Python-side Hail expression literal.
+
     :param leaf_array: Hail array expression of length `len(leaf_indices)`
         produced by aggregating only the leaf groups.
     :param leaf_indices: Original-`freq_meta` indices of the leaves, in the
@@ -2271,51 +2278,60 @@ def expand_strata_array_from_leaves(
     else:
         struct_fields = None
 
-    def _select_struct(elem: hl.expr.Expression) -> hl.expr.Expression:
-        """Project a struct element down to the fields used for summation.
-
-        For freq structs, this drops `AF` (it will be recomputed at the
-        end). For other struct types, it's a no-op.
-        """
-        if struct_fields is None:
-            return elem
-        return elem.select(*struct_fields)
-
-    def _sum_elements(positions: List[int]) -> hl.expr.Expression:
-        """Element-wise sum of leaf_array at the given reduced positions."""
-        first = _select_struct(leaf_array[positions[0]])
-        if struct_fields is None:
-            acc = first
-            for p in positions[1:]:
-                acc = _sum_or_diff_values(acc, leaf_array[p], "sum")
-            return acc
-        # Struct path: sum each numeric field independently.
-        acc_fields = {f: first[f] for f in struct_fields}
-        for p in positions[1:]:
-            nxt = leaf_array[p]
-            acc_fields = {
-                f: _sum_or_diff_values(acc_fields[f], nxt[f], "sum")
-                for f in struct_fields
-            }
-        return hl.struct(**acc_fields)
-
-    full = []
+    # Build a Hail-side lookup: for each position in the full array, store
+    # the list of leaf-array positions whose values should be summed. For
+    # leaves this is a single-element list; for non-leaves it's the list of
+    # child positions in the leaf array.
+    children_per_group: List[List[int]] = []
     for i in range(n_full):
         if i in leaf_pos:
-            # Project leaf elements to the same field shape as the summed
-            # non-leaf elements so the resulting array has a uniform element
-            # type (Hail's `hl.array` requires this).
-            full.append(_select_struct(leaf_array[leaf_pos[i]]))
+            children_per_group.append([leaf_pos[i]])
         elif i in decomposition:
-            child_positions = [leaf_pos[j] for j in decomposition[i]]
-            full.append(_sum_elements(child_positions))
+            children_per_group.append([leaf_pos[j] for j in decomposition[i]])
         else:
-            # Should not happen — every non-leaf must be in `decomposition`.
             raise ValueError(
                 f"Index {i} is neither a leaf nor in the decomposition map."
             )
 
-    expanded = hl.array(full)
+    # Encode as a Hail literal: array<array<int32>>.
+    hl_children = hl.literal(children_per_group)
+
+    # If we need to drop fields (e.g. AF from freq structs) before summing,
+    # project the leaf_array once up front so every element has the same type.
+    if struct_fields is not None:
+        projected = leaf_array.map(lambda x: x.select(*struct_fields))
+    else:
+        projected = leaf_array
+
+    # Build the expanded array via a single Hail-side map. For each group
+    # position, look up its child indices and fold-sum over them.
+    if struct_fields is not None:
+
+        def _sum_struct_children(child_indices):
+            return child_indices[1:].fold(
+                lambda acc, idx: acc.annotate(
+                    **{
+                        f: hl.or_else(acc[f], 0) + hl.or_else(projected[idx][f], 0)
+                        for f in struct_fields
+                    }
+                ),
+                projected[child_indices[0]],
+            )
+
+        expanded = hl_children.map(
+            lambda child_indices: _sum_struct_children(child_indices)
+        )
+    else:
+
+        def _sum_scalar_children(child_indices):
+            return child_indices[1:].fold(
+                lambda acc, idx: hl.or_else(acc, 0) + hl.or_else(projected[idx], 0),
+                projected[child_indices[0]],
+            )
+
+        expanded = hl_children.map(
+            lambda child_indices: _sum_scalar_children(child_indices)
+        )
 
     if is_freq_struct:
         # Recompute AF from the summed AC/AN, and select the canonical field

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -1833,7 +1833,7 @@ def annotate_freq(
         non-summable values such as means or medians. Default is False.
     :param non_summable_strata: Strata names that should never be summed
         across their values when `reduce_to_minimal_groups` is True.
-        Default is `{"downsampling"}`.
+        Default is None, which resolves to `{"downsampling"}`.
     :return: MatrixTable or Table with `freq` annotation.
     """
     errors = []
@@ -2094,7 +2094,7 @@ def _read_reduction_globals(
     globals_source: hl.expr.StructExpression,
 ) -> Dict[str, Any]:
     """
-    Materialize the reduction-tracking globals into Python in a single round-trip.
+    Materialize the reduction-tracking globals into Python in a single hl.eval call.
 
     Used by both `annotate_freq` and `compute_stats_per_ref_site` to recover
     the leaf-decomposition information needed to expand leaf-only
@@ -2116,6 +2116,9 @@ def _read_reduction_globals(
     )
     return {
         "leaf_indices": list(g.freq_leaf_indices),
+        # freq_group_decomposition is stored as a dense array indexed by
+        # original group position, with empty lists for leaves. Convert back
+        # to the sparse {parent_idx: child_indices} representation.
         "decomposition": {
             i: list(c) for i, c in enumerate(g.freq_group_decomposition) if c
         },
@@ -2449,7 +2452,7 @@ def generate_freq_group_membership_array(
         aggregation. Default is False.
     :param non_summable_strata: Strata names that should never be summed
         across their values when `reduce_to_minimal_groups` is True.
-        Default is `{"downsampling"}`.
+        Default is None, which resolves to`{"downsampling"}`.
     :param group_label: Value to use for the `"group"` key on every
         constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
         for callers that don't apply any genotype-level filtering (e.g.,

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2196,76 +2196,91 @@ def find_minimal_strata_groups(
     else:
         non_summable_strata = set(non_summable_strata)
 
-    def summable_strata_of(e: Dict[str, str]) -> frozenset:
+    def summable_strata_of(entry: Dict[str, str]) -> frozenset:
         return frozenset(
-            k for k in e.keys() if k != "group" and k not in non_summable_strata
+            k for k in entry.keys() if k != "group" and k not in non_summable_strata
         )
 
-    def non_summable_strata_of(e: Dict[str, str]) -> frozenset:
+    def non_summable_strata_of(entry: Dict[str, str]) -> frozenset:
         return frozenset(
-            k for k in e.keys() if k != "group" and k in non_summable_strata
+            k for k in entry.keys() if k != "group" and k in non_summable_strata
         )
 
     # Partition indices by group value (e.g., "adj" vs "raw").
     partitions: Dict[Optional[str], List[int]] = {}
-    for i, e in enumerate(freq_meta):
-        partitions.setdefault(e.get("group"), []).append(i)
+    for idx, entry in enumerate(freq_meta):
+        partitions.setdefault(entry.get("group"), []).append(idx)
 
     is_leaf = [False] * len(freq_meta)
     decomposition: Dict[int, List[int]] = {}
 
-    for indices in partitions.values():
+    for partition_indices in partitions.values():
         # Within this partition, determine the maximal-by-inclusion summable
         # strata sets — those are the leaf strata sets.
-        strata_sets = {summable_strata_of(freq_meta[i]) for i in indices}
+        all_strata_sets = {
+            summable_strata_of(freq_meta[idx]) for idx in partition_indices
+        }
         leaf_strata_sets = {
-            s for s in strata_sets if not any(s < s2 for s2 in strata_sets)
+            strata_set
+            for strata_set in all_strata_sets
+            if not any(strata_set < other for other in all_strata_sets)
         }
 
-        for i in indices:
-            if summable_strata_of(freq_meta[i]) in leaf_strata_sets:
-                is_leaf[i] = True
+        for idx in partition_indices:
+            if summable_strata_of(freq_meta[idx]) in leaf_strata_sets:
+                is_leaf[idx] = True
 
         # Decompose non-leaves using only same-partition leaves.
-        leaf_indices_in_partition = [i for i in indices if is_leaf[i]]
-        for i in indices:
-            if is_leaf[i]:
+        leaf_indices_in_partition = [idx for idx in partition_indices if is_leaf[idx]]
+        for parent_idx in partition_indices:
+            if is_leaf[parent_idx]:
                 continue
-            e = freq_meta[i]
-            e_keys = {k: v for k, v in e.items() if k != "group"}
-            e_non_summable = non_summable_strata_of(e)
-            parent_count = freq_meta_sample_count[i]
+
+            parent_entry = freq_meta[parent_idx]
+            parent_keys = {k: v for k, v in parent_entry.items() if k != "group"}
+            parent_non_summable = non_summable_strata_of(parent_entry)
+            parent_count = freq_meta_sample_count[parent_idx]
 
             # Group candidate leaves by their full summable-strata set so
             # each candidate decomposition lives in a single strata-family.
-            by_strata: Dict[frozenset, List[int]] = {}
-            for j in leaf_indices_in_partition:
-                f = freq_meta[j]
-                if non_summable_strata_of(f) != e_non_summable:
-                    continue
-                if any(f.get(k) != v for k, v in e_keys.items()):
-                    continue
-                by_strata.setdefault(summable_strata_of(f), []).append(j)
+            candidates_by_strata_family: Dict[frozenset, List[int]] = {}
+            for leaf_idx in leaf_indices_in_partition:
+                leaf_entry = freq_meta[leaf_idx]
 
-            valid = [
-                cand
-                for cand in by_strata.values()
-                if sum(freq_meta_sample_count[j] for j in cand) == parent_count
+                # Non-summable strata must match exactly (e.g. same downsampling
+                # cohort) — never sum across them.
+                if non_summable_strata_of(leaf_entry) != parent_non_summable:
+                    continue
+
+                # Leaf must be a specialisation of the parent — it must agree on
+                # every key the parent carries.
+                if any(leaf_entry.get(k) != v for k, v in parent_keys.items()):
+                    continue
+
+                candidates_by_strata_family.setdefault(
+                    summable_strata_of(leaf_entry), []
+                ).append(leaf_idx)
+
+            valid_decompositions = [
+                leaf_group
+                for leaf_group in candidates_by_strata_family.values()
+                if sum(freq_meta_sample_count[leaf_idx] for leaf_idx in leaf_group)
+                == parent_count
             ]
-            if valid:
-                decomposition[i] = min(valid, key=len)
+            if valid_decompositions:
+                decomposition[parent_idx] = min(valid_decompositions, key=len)
             else:
                 # No candidate strata-family fully covers the parent — compute
                 # this entry directly to keep the output correct.
                 logger.info(
                     "Non-leaf entry at index %d (%s) has no sample-count-valid "
                     "decomposition; promoting to leaf.",
-                    i,
-                    freq_meta[i],
+                    parent_idx,
+                    freq_meta[parent_idx],
                 )
-                is_leaf[i] = True
+                is_leaf[parent_idx] = True
 
-    leaf_indices = [i for i, leaf in enumerate(is_leaf) if leaf]
+    leaf_indices = [idx for idx, leaf in enumerate(is_leaf) if leaf]
     return leaf_indices, decomposition
 
 
@@ -2450,7 +2465,7 @@ def generate_freq_group_membership_array(
         aggregation. Default is False.
     :param non_summable_strata: Strata names that should never be summed
         across their values when `reduce_to_minimal_groups` is True.
-        Default is None, which resolves to`{"downsampling"}`.
+        Default is None, which resolves to `{"downsampling"}`.
     :param group_label: Value to use for the `"group"` key on every
         constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
         for callers that don't apply any genotype-level filtering (e.g.,
@@ -2631,13 +2646,20 @@ def generate_freq_group_membership_array(
             group_membership=hl.array([ht.group_membership[i] for i in leaf_indices])
         )
 
+        # Replace freq_meta and sample counts with their leaf-only versions.
         global_expr["freq_meta"] = freq_meta
         global_expr["freq_meta_sample_count"] = freq_meta_sample_count
-        global_expr["freq_meta_full"] = freq_meta_full
-        global_expr["freq_meta_sample_count_full"] = freq_meta_sample_count_full
-        global_expr["freq_leaf_indices"] = leaf_indices
-        global_expr["freq_group_decomposition"] = freq_group_decomposition
-        global_expr["freq_reduced"] = True
+
+        # Add reduction-tracking globals for later restoration and expansion.
+        global_expr.update(
+            {
+                "freq_meta_full": freq_meta_full,
+                "freq_meta_sample_count_full": freq_meta_sample_count_full,
+                "freq_leaf_indices": leaf_indices,
+                "freq_group_decomposition": freq_group_decomposition,
+                "freq_reduced": True,
+            }
+        )
 
     if downsamplings is not None:
         global_expr["downsamplings"] = downsamplings
@@ -2864,7 +2886,7 @@ def agg_by_strata(
             target = dict(target_dict)
             for i, m in enumerate(freq_meta_py):
                 if m == target:
-                    return ("leaf", i, target.get("group", "NA") == "adj")
+                    return ("leaf", i, target.get("group") == "adj")
             if not is_reduced_for_lookup:
                 raise ValueError(
                     f"`entry_agg_group_membership` target {target} is not in"
@@ -2895,7 +2917,7 @@ def agg_by_strata(
                     return (
                         "parent",
                         children_leaf_pos,
-                        target.get("group", "NA") == "adj",
+                        target.get("group") == "adj",
                     )
             raise ValueError(
                 f"`entry_agg_group_membership` target {target} is not in"

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -4,8 +4,6 @@ import itertools
 import logging
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
-import ga4gh.core as ga4gh_core
-import ga4gh.vrs as ga4gh_vrs
 import hail as hl
 
 import gnomad.utils.filtering as filter_utils
@@ -3198,6 +3196,10 @@ def add_gks_vrs(
     :param input_vrs: VRS struct (such as from a ht.info.vrs field).
     :return: List of Python dictionaries conforming to GA4GH GKS VRS Allele structure.
     """
+    # Imported lazily so the rest of this module loads without ga4gh.vrs installed.
+    import ga4gh.core as ga4gh_core
+    import ga4gh.vrs as ga4gh_vrs
+
     build_in = input_locus.reference_genome.name
     chr_in = input_locus.contig
 

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -7,6 +7,7 @@ import hail as hl
 
 from gnomad.sample_qc.sex import adjusted_sex_ploidy_expr
 from gnomad.utils.annotations import (
+    _read_reduction_globals,
     agg_by_strata,
     annotate_adj,
     expand_strata_array_from_leaves,
@@ -1098,10 +1099,9 @@ def compute_stats_per_ref_site(
           inside the in-function call to `generate_freq_group_membership_array`.
         - When a pre-built `group_membership_ht` is supplied, this function
           honors any reduction that was already performed on it (detected by
-          the presence of the `freq_meta_full`, `freq_leaf_indices`, and
-          `freq_group_decomposition` globals on `group_membership_ht`).
-          Setting `reduce_to_minimal_groups=True` while passing a
-          non-reduced `group_membership_ht` is a no-op.
+          the `freq_reduced=True` global on `group_membership_ht`). Setting
+          `reduce_to_minimal_groups=True` while passing a non-reduced
+          `group_membership_ht` is a no-op.
 
     :param mtds: Input sparse Matrix Table or VariantDataset.
     :param reference_ht: Table of reference sites.
@@ -1227,47 +1227,18 @@ def compute_stats_per_ref_site(
 
         # Use 'generate_freq_group_membership_array' to create a group_membership Table
         # that gives stratification group membership info based on 'strata_expr'. The
-        # returned Table has the following annotations: 'freq_meta',
-        # 'freq_meta_sample_count', and 'group_membership'. By default, this
-        # function returns annotations where the second element is a placeholder for the
-        # "raw" frequency of all samples, where the first 2 elements are the same sample
-        # set, but 'freq_meta' starts with [{"group": "adj", "group": "raw", ...]. Use
-        # `no_raw_group` to exclude the "raw" group so there is a single annotation
-        # representing the full samples set. Update all 'freq_meta' entries' "group"
-        # to "raw" because `generate_freq_group_membership_array` will return them all
-        # as "adj" since it was built for frequency computation, but for the coverage
-        # computation we don't want to do any filtering.
+        # The per-ref-site stats path does no genotype-level filtering, so
+        # label every freq_meta entry as "raw" rather than the default "adj".
+        # `no_raw_group=True` skips the inserted raw-only entry; the
+        # remaining entries cover all samples.
         group_membership_ht = generate_freq_group_membership_array(
             ht,
             strata_expr,
             no_raw_group=True,
             reduce_to_minimal_groups=reduce_to_minimal_groups,
             non_summable_axes=non_summable_axes,
+            group_label="raw",
         )
-        # Rewrite all `freq_meta` entries' "group" key to "raw" because
-        # `generate_freq_group_membership_array` always labels them "adj"
-        # (it was built for frequency computation), but for the per-ref-site
-        # stats path we don't do any genotype-level filtering. Apply the
-        # same rewrite to the full freq_meta when reduction is in effect, so
-        # the post-aggregation expansion uses consistent labels.
-        rewrite_globals = {
-            "freq_meta": group_membership_ht.freq_meta.map(
-                lambda x: hl.dict(
-                    x.items().map(
-                        lambda m: hl.if_else(m[0] == "group", ("group", "raw"), m)
-                    )
-                )
-            )
-        }
-        if reduce_to_minimal_groups:
-            rewrite_globals["freq_meta_full"] = group_membership_ht.freq_meta_full.map(
-                lambda x: hl.dict(
-                    x.items().map(
-                        lambda m: hl.if_else(m[0] == "group", ("group", "raw"), m)
-                    )
-                )
-            )
-        group_membership_ht = group_membership_ht.annotate_globals(**rewrite_globals)
 
     if is_vds:
         rmt = mtds.reference_data
@@ -1316,35 +1287,19 @@ def compute_stats_per_ref_site(
 
     group_globals = group_membership_ht.index_globals()
 
-    # Detect whether the upstream group_membership_ht has reduction metadata
-    # attached. If so, expand each per-strata aggregation back to the full
-    # set of groups by element-wise summation of the leaf positions.
-    membership_globals = group_membership_ht.globals
-    is_reduced = (
-        "freq_meta_full" in membership_globals
-        and "freq_leaf_indices" in membership_globals
-        and "freq_group_decomposition" in membership_globals
+    # Detect whether the upstream group_membership_ht was built with the
+    # leaf-only reduction. If so, expand each per-strata aggregation back to
+    # the full set of groups by element-wise summation of the leaf positions.
+    is_reduced = "freq_reduced" in group_membership_ht.globals and hl.eval(
+        group_globals.freq_reduced
     )
 
     if is_reduced:
-        leaf_indices = hl.eval(group_globals.freq_leaf_indices)
-        decomposition_serialized = hl.eval(group_globals.freq_group_decomposition)
-        full_meta = hl.eval(group_globals.freq_meta_full)
-        full_sample_count = hl.eval(group_globals.freq_meta_sample_count_full)
-        n_full = len(full_meta)
-        decomposition = {
-            i: list(children)
-            for i, children in enumerate(decomposition_serialized)
-            if children
-        }
+        r = _read_reduction_globals(group_globals)
         ht = ht.annotate(
             **{
                 ann: expand_strata_array_from_leaves(
-                    ht[ann],
-                    leaf_indices,
-                    decomposition,
-                    n_full,
-                    is_freq_struct=False,
+                    ht[ann], r["leaf_indices"], r["decomposition"], r["n_full"]
                 )
                 for ann in entry_agg_funcs
             }
@@ -1356,17 +1311,14 @@ def compute_stats_per_ref_site(
         # level.
         ht = ht.select(**{ann: ht[ann][0] for ann in entry_agg_funcs})
         global_expr["sample_count"] = group_globals.freq_meta_sample_count[0]
-    else:
-        # If there was stratification, add the metadata and sample count info for
-        # the stratification to the globals. When reduction was applied above,
-        # use the original (full) freq_meta and sample counts so the output is
+    elif is_reduced:
+        # Use the original (full) freq_meta/sample counts so the output is
         # indistinguishable from a non-reduced run.
-        if is_reduced:
-            global_expr["strata_meta"] = full_meta
-            global_expr["strata_sample_count"] = full_sample_count
-        else:
-            global_expr["strata_meta"] = group_globals.freq_meta
-            global_expr["strata_sample_count"] = group_globals.freq_meta_sample_count
+        global_expr["strata_meta"] = r["freq_meta_full"]
+        global_expr["strata_sample_count"] = r["freq_meta_sample_count_full"]
+    else:
+        global_expr["strata_meta"] = group_globals.freq_meta
+        global_expr["strata_sample_count"] = group_globals.freq_meta_sample_count
 
     ht = ht.annotate_globals(**global_expr)
 

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1076,6 +1076,7 @@ def compute_stats_per_ref_site(
     sex_karyotype_field: Optional[str] = None,
     reduce_to_minimal_groups: bool = False,
     non_summable_strata: Optional[Set[str]] = None,
+    reducible_aggs: Optional[Set[str]] = None,
 ) -> hl.Table:
     """
     Compute stats per site in a reference Table.
@@ -1090,11 +1091,22 @@ def compute_stats_per_ref_site(
     `reduce_to_minimal_groups=False` output. This is purely a cost
     optimization for large stratifications.
 
-    The reduction assumes every annotation produced by `entry_agg_funcs`
-    is summable (integers or struct-of-integers). Do not enable when
-    `entry_agg_funcs` returns non-summable values such as means or
-    medians (e.g., it must not be used with `compute_coverage_stats`'s
-    default coverage aggregation).
+    The reduction assumes that the annotations subject to leaf expansion
+    are summable (integers or struct-of-integers). By default every
+    annotation in `entry_agg_funcs` is treated as reducible. Pass
+    `reducible_aggs={...}` to opt only specific annotations into the
+    expansion; the others must be narrowed via
+    `entry_agg_group_membership` (otherwise their per-row arrays would
+    have leaf shape, inconsistent with the full `strata_meta` global
+    that the function emits). When leaf reduction is in effect, every
+    entry in `entry_agg_funcs` must therefore appear in either
+    `reducible_aggs` or as a key of `entry_agg_group_membership` —
+    `compute_stats_per_ref_site` raises `ValueError` early in that case
+    so no aggregation cost is wasted on a call whose output would be
+    shape-inconsistent. This split lets a single call mix summable
+    aggregations (e.g., AN) with non-summable ones (e.g., a coverage
+    mean or a qual histogram restricted to a single global group via
+    `entry_agg_group_membership`).
 
     Reduction is supported on both supplied paths:
 
@@ -1144,6 +1156,12 @@ def compute_stats_per_ref_site(
     :param non_summable_strata: Strata names that should never be summed
         across their values when `reduce_to_minimal_groups` is True.
         Default is `{"downsampling"}`.
+    :param reducible_aggs: Optional set of annotation names from
+        `entry_agg_funcs` that are summable and should be expanded from
+        leaf shape to full shape via element-wise summation when leaf
+        reduction is in effect. Defaults to all of `entry_agg_funcs`.
+        Must be disjoint from the keys of `entry_agg_group_membership`.
+        Ignored when no leaf reduction is in effect.
     :return: Table of stats per site.
     """
     is_vds = isinstance(mtds, hl.vds.VariantDataset)
@@ -1169,6 +1187,77 @@ def compute_stats_per_ref_site(
             "The 'freq_meta' annotation must be present in 'group_membership_ht' if "
             "'entry_agg_group_membership' is specified."
         )
+
+    # Determine reduction status from inputs so we can validate the
+    # shape of `entry_agg_funcs` before any aggregation runs. Both
+    # signals are inspectable without densify or aggregation:
+    #   - When `group_membership_ht` is supplied, reduction is recorded
+    #     by `generate_freq_group_membership_array` as the
+    #     `freq_reduced` global on that table.
+    #   - When `strata_expr` is supplied, the table is built later in
+    #     this function with `reduce_to_minimal_groups` forwarded into
+    #     `generate_freq_group_membership_array`, so the parameter
+    #     directly determines reduction status. The pre-built case's
+    #     "no-op when flag set but table not reduced" carve-out applies
+    #     only to the supplied-table path.
+    if group_membership_ht is not None:
+        is_reduced = "freq_reduced" in group_membership_ht.globals and hl.eval(
+            group_membership_ht.freq_reduced
+        )
+    else:
+        is_reduced = reduce_to_minimal_groups
+
+    if reducible_aggs is not None:
+        if not reducible_aggs:
+            raise ValueError(
+                "`reducible_aggs` is empty; pass `None` to default to all of "
+                "`entry_agg_funcs` or list at least one annotation."
+            )
+        unknown = set(reducible_aggs) - set(entry_agg_funcs)
+        if unknown:
+            raise ValueError(
+                "`reducible_aggs` contains names not in `entry_agg_funcs`: "
+                f"{sorted(unknown)}."
+            )
+        if entry_agg_group_membership is not None:
+            overlap = set(reducible_aggs) & set(entry_agg_group_membership)
+            if overlap:
+                raise ValueError(
+                    "`reducible_aggs` and `entry_agg_group_membership` must"
+                    f" be disjoint; got overlap: {sorted(overlap)}. A"
+                    " reducible annotation is computed on the leaf set and"
+                    " reconstructed by summation, while"
+                    " `entry_agg_group_membership` narrows an annotation to"
+                    " a specific subset; the two are mutually exclusive for"
+                    " the same annotation."
+                )
+
+    # When leaf reduction is in effect every annotation in
+    # `entry_agg_funcs` must be accounted for: either it is reducible
+    # (gets expanded leaf -> full post-aggregation) or it is narrowed
+    # via `entry_agg_group_membership` to a specific subset of strata.
+    # Anything in neither bucket would silently emit a leaf-shape
+    # array against a full-shape `strata_meta` global, which is a
+    # latent shape mismatch in downstream consumers; raise so the
+    # caller fixes the call before paying the densify+aggregation cost.
+    if is_reduced:
+        accounted_for = (
+            set(entry_agg_funcs) if reducible_aggs is None else set(reducible_aggs)
+        )
+        if entry_agg_group_membership is not None:
+            accounted_for |= set(entry_agg_group_membership)
+        unaccounted = set(entry_agg_funcs) - accounted_for
+        if unaccounted:
+            raise ValueError(
+                "Leaf reduction is in effect but the following entries of"
+                f" `entry_agg_funcs` have no shape designation:"
+                f" {sorted(unaccounted)}. Each annotation must be either"
+                " (a) listed in `reducible_aggs` if its values are summable"
+                " across strata, or (b) a key of"
+                " `entry_agg_group_membership` to restrict it to a specific"
+                " subset of groups; otherwise its per-row array would have"
+                " leaf shape while `strata_meta` is emitted at full shape."
+            )
 
     # Determine if the adj annotation is needed. It is only needed if "adj_groups" is
     # in the globals of the group_membership_ht and any entry is True, or "freq_meta"
@@ -1293,21 +1382,20 @@ def compute_stats_per_ref_site(
 
     group_globals = group_membership_ht.index_globals()
 
-    # Detect whether the upstream group_membership_ht was built with the
-    # leaf-only reduction. If so, expand each per-strata aggregation back to
-    # the full set of groups by element-wise summation of the leaf positions.
-    is_reduced = "freq_reduced" in group_membership_ht.globals and hl.eval(
-        group_globals.freq_reduced
-    )
-
+    # `is_reduced` was determined from the inputs above. If True, expand
+    # each reducible per-strata aggregation back to the full set of
+    # groups by element-wise summation of the leaf positions.
     if is_reduced:
         r = _read_reduction_globals(group_globals)
+        anns_to_expand = (
+            set(entry_agg_funcs) if reducible_aggs is None else set(reducible_aggs)
+        )
         ht = ht.annotate(
             **{
                 ann: expand_strata_array_from_leaves(
                     ht[ann], r["leaf_indices"], r["decomposition"], r["n_full"]
                 )
-                for ann in entry_agg_funcs
+                for ann in anns_to_expand
             }
         )
 

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -9,6 +9,7 @@ from gnomad.sample_qc.sex import adjusted_sex_ploidy_expr
 from gnomad.utils.annotations import (
     agg_by_strata,
     annotate_adj,
+    expand_strata_array_from_leaves,
     fs_from_sb,
     generate_freq_group_membership_array,
     get_adj_expr,
@@ -1072,9 +1073,35 @@ def compute_stats_per_ref_site(
     strata_expr: Optional[List[Dict[str, hl.expr.StringExpression]]] = None,
     group_membership_ht: Optional[hl.Table] = None,
     sex_karyotype_field: Optional[str] = None,
+    reduce_to_minimal_groups: bool = False,
+    non_summable_axes: Optional[Set[str]] = None,
 ) -> hl.Table:
     """
     Compute stats per site in a reference Table.
+
+    .. rubric:: The `reduce_to_minimal_groups` parameter
+
+    When True, the per-strata aggregation runs only on a minimal "leaf"
+    subset of stratification groups (those that cannot be derived by summing
+    other groups). The remaining groups are reconstructed by element-wise
+    summation of leaves as a cheap post-processing step, so the returned
+    `strata_meta` and per-site arrays are identical to the
+    `reduce_to_minimal_groups=False` output. This is purely a cost
+    optimization for large stratifications. The reduction **assumes every
+    annotation produced by `entry_agg_funcs` is summable** (integers or
+    struct-of-integers). Do **not** enable this when `entry_agg_funcs`
+    returns non-summable values such as means or medians (e.g., it must not
+    be used with `compute_coverage_stats`'s default coverage aggregation).
+
+    Reduction is supported on both supplied paths:
+        - When `strata_expr` is provided, the leaf reduction is performed
+          inside the in-function call to `generate_freq_group_membership_array`.
+        - When a pre-built `group_membership_ht` is supplied, this function
+          honors any reduction that was already performed on it (detected by
+          the presence of the `freq_meta_full`, `freq_leaf_indices`, and
+          `freq_group_decomposition` globals on `group_membership_ht`).
+          Setting `reduce_to_minimal_groups=True` while passing a
+          non-reduced `group_membership_ht` is a no-op.
 
     :param mtds: Input sparse Matrix Table or VariantDataset.
     :param reference_ht: Table of reference sites.
@@ -1106,6 +1133,11 @@ def compute_stats_per_ref_site(
         the columns of `mtds` (variant_data MT if `mtds` is a VDS) and use "XX" and
         "XY" as values. If not provided, no sex karyotype adjustment is performed.
         Default is None.
+    :param reduce_to_minimal_groups: Whether to compute stats only on the
+        minimal leaf set of stratification groups and reconstruct the rest
+        by element-wise summation. See the rubric above. Default is False.
+    :param non_summable_axes: Axis names that should never be summed across
+        when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
     :return: Table of stats per site.
     """
     is_vds = isinstance(mtds, hl.vds.VariantDataset)
@@ -1206,17 +1238,36 @@ def compute_stats_per_ref_site(
         # as "adj" since it was built for frequency computation, but for the coverage
         # computation we don't want to do any filtering.
         group_membership_ht = generate_freq_group_membership_array(
-            ht, strata_expr, no_raw_group=True
+            ht,
+            strata_expr,
+            no_raw_group=True,
+            reduce_to_minimal_groups=reduce_to_minimal_groups,
+            non_summable_axes=non_summable_axes,
         )
-        group_membership_ht = group_membership_ht.annotate_globals(
-            freq_meta=group_membership_ht.freq_meta.map(
+        # Rewrite all `freq_meta` entries' "group" key to "raw" because
+        # `generate_freq_group_membership_array` always labels them "adj"
+        # (it was built for frequency computation), but for the per-ref-site
+        # stats path we don't do any genotype-level filtering. Apply the
+        # same rewrite to the full freq_meta when reduction is in effect, so
+        # the post-aggregation expansion uses consistent labels.
+        rewrite_globals = {
+            "freq_meta": group_membership_ht.freq_meta.map(
                 lambda x: hl.dict(
                     x.items().map(
                         lambda m: hl.if_else(m[0] == "group", ("group", "raw"), m)
                     )
                 )
             )
-        )
+        }
+        if reduce_to_minimal_groups:
+            rewrite_globals["freq_meta_full"] = group_membership_ht.freq_meta_full.map(
+                lambda x: hl.dict(
+                    x.items().map(
+                        lambda m: hl.if_else(m[0] == "group", ("group", "raw"), m)
+                    )
+                )
+            )
+        group_membership_ht = group_membership_ht.annotate_globals(**rewrite_globals)
 
     if is_vds:
         rmt = mtds.reference_data
@@ -1264,6 +1315,41 @@ def compute_stats_per_ref_site(
     ht = ht.select_globals().checkpoint(hl.utils.new_temp_file("agg_stats", "ht"))
 
     group_globals = group_membership_ht.index_globals()
+
+    # Detect whether the upstream group_membership_ht has reduction metadata
+    # attached. If so, expand each per-strata aggregation back to the full
+    # set of groups by element-wise summation of the leaf positions.
+    membership_globals = group_membership_ht.globals
+    is_reduced = (
+        "freq_meta_full" in membership_globals
+        and "freq_leaf_indices" in membership_globals
+        and "freq_group_decomposition" in membership_globals
+    )
+
+    if is_reduced:
+        leaf_indices = hl.eval(group_globals.freq_leaf_indices)
+        decomposition_serialized = hl.eval(group_globals.freq_group_decomposition)
+        full_meta = hl.eval(group_globals.freq_meta_full)
+        full_sample_count = hl.eval(group_globals.freq_meta_sample_count_full)
+        n_full = len(full_meta)
+        decomposition = {
+            i: list(children)
+            for i, children in enumerate(decomposition_serialized)
+            if children
+        }
+        ht = ht.annotate(
+            **{
+                ann: expand_strata_array_from_leaves(
+                    ht[ann],
+                    leaf_indices,
+                    decomposition,
+                    n_full,
+                    is_freq_struct=False,
+                )
+                for ann in entry_agg_funcs
+            }
+        )
+
     global_expr = {}
     if no_strata:
         # If there was no stratification, move aggregated annotations to the top
@@ -1271,10 +1357,16 @@ def compute_stats_per_ref_site(
         ht = ht.select(**{ann: ht[ann][0] for ann in entry_agg_funcs})
         global_expr["sample_count"] = group_globals.freq_meta_sample_count[0]
     else:
-        # If there was stratification, add the metadata and sample count info for the
-        # stratification to the globals.
-        global_expr["strata_meta"] = group_globals.freq_meta
-        global_expr["strata_sample_count"] = group_globals.freq_meta_sample_count
+        # If there was stratification, add the metadata and sample count info for
+        # the stratification to the globals. When reduction was applied above,
+        # use the original (full) freq_meta and sample counts so the output is
+        # indistinguishable from a non-reduced run.
+        if is_reduced:
+            global_expr["strata_meta"] = full_meta
+            global_expr["strata_sample_count"] = full_sample_count
+        else:
+            global_expr["strata_meta"] = group_globals.freq_meta
+            global_expr["strata_sample_count"] = group_globals.freq_meta_sample_count
 
     ht = ht.annotate_globals(**global_expr)
 
@@ -1453,6 +1545,15 @@ def compute_allele_number_per_ref_site(
 ) -> hl.Table:
     """
     Compute the allele number per reference site.
+
+    .. note::
+
+        This function supports the `reduce_to_minimal_groups` cost
+        optimization (forwarded via `**kwargs` to
+        `compute_stats_per_ref_site`). AN is a sum of per-sample integer
+        ploidies, which is summable across stratification groups, so the
+        optimization produces output identical to a non-reduced run. See
+        `compute_stats_per_ref_site` for details.
 
     :param mtds: Input sparse Matrix Table or VariantDataset.
     :param reference_ht: Table of reference sites.

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1082,24 +1082,29 @@ def compute_stats_per_ref_site(
 
     .. rubric:: The `reduce_to_minimal_groups` parameter
 
-    When True, the per-strata aggregation runs only on a minimal "leaf"
-    subset of stratification groups (those that cannot be derived by summing
-    other groups). The remaining groups are reconstructed by element-wise
+    When True, the per-strata aggregation runs only on the "leaf"
+    stratification groups (those that cannot be derived by summing other
+    groups). The remaining groups are reconstructed by element-wise
     summation of leaves as a cheap post-processing step, so the returned
     `strata_meta` and per-site arrays are identical to the
     `reduce_to_minimal_groups=False` output. This is purely a cost
-    optimization for large stratifications. The reduction **assumes every
-    annotation produced by `entry_agg_funcs` is summable** (integers or
-    struct-of-integers). Do **not** enable this when `entry_agg_funcs`
-    returns non-summable values such as means or medians (e.g., it must not
-    be used with `compute_coverage_stats`'s default coverage aggregation).
+    optimization for large stratifications.
+
+    The reduction assumes every annotation produced by `entry_agg_funcs`
+    is summable (integers or struct-of-integers). Do not enable when
+    `entry_agg_funcs` returns non-summable values such as means or
+    medians (e.g., it must not be used with `compute_coverage_stats`'s
+    default coverage aggregation).
 
     Reduction is supported on both supplied paths:
+
         - When `strata_expr` is provided, the leaf reduction is performed
-          inside the in-function call to `generate_freq_group_membership_array`.
-        - When a pre-built `group_membership_ht` is supplied, this function
-          honors any reduction that was already performed on it (detected by
-          the `freq_reduced=True` global on `group_membership_ht`). Setting
+          inside the in-function call to
+          `generate_freq_group_membership_array`.
+        - When a pre-built `group_membership_ht` is supplied, this
+          function honors any reduction already performed on it
+          (detected by the `freq_reduced=True` global on
+          `group_membership_ht`). Setting
           `reduce_to_minimal_groups=True` while passing a non-reduced
           `group_membership_ht` is a no-op.
 
@@ -1134,10 +1139,11 @@ def compute_stats_per_ref_site(
         "XY" as values. If not provided, no sex karyotype adjustment is performed.
         Default is None.
     :param reduce_to_minimal_groups: Whether to compute stats only on the
-        minimal leaf set of stratification groups and reconstruct the rest
-        by element-wise summation. See the rubric above. Default is False.
-    :param non_summable_strata: Strata names that should never be summed across
-        when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
+        leaf set of stratification groups and reconstruct the rest by
+        element-wise summation. See the rubric above. Default is False.
+    :param non_summable_strata: Strata names that should never be summed
+        across their values when `reduce_to_minimal_groups` is True.
+        Default is `{"downsampling"}`.
     :return: Table of stats per site.
     """
     is_vds = isinstance(mtds, hl.vds.VariantDataset)
@@ -1502,10 +1508,10 @@ def compute_allele_number_per_ref_site(
 
         This function supports the `reduce_to_minimal_groups` cost
         optimization (forwarded via `**kwargs` to
-        `compute_stats_per_ref_site`). AN is a sum of per-sample integer
-        ploidies, which is summable across stratification groups, so the
-        optimization produces output identical to a non-reduced run. See
-        `compute_stats_per_ref_site` for details.
+        `compute_stats_per_ref_site`). AN is summable across
+        stratification groups (it is a sum of per-sample integer
+        ploidies), so the optimization produces output identical to a
+        non-reduced run. See `compute_stats_per_ref_site` for details.
 
     :param mtds: Input sparse Matrix Table or VariantDataset.
     :param reference_ht: Table of reference sites.

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1075,7 +1075,7 @@ def compute_stats_per_ref_site(
     group_membership_ht: Optional[hl.Table] = None,
     sex_karyotype_field: Optional[str] = None,
     reduce_to_minimal_groups: bool = False,
-    non_summable_axes: Optional[Set[str]] = None,
+    non_summable_strata: Optional[Set[str]] = None,
 ) -> hl.Table:
     """
     Compute stats per site in a reference Table.
@@ -1136,7 +1136,7 @@ def compute_stats_per_ref_site(
     :param reduce_to_minimal_groups: Whether to compute stats only on the
         minimal leaf set of stratification groups and reconstruct the rest
         by element-wise summation. See the rubric above. Default is False.
-    :param non_summable_axes: Axis names that should never be summed across
+    :param non_summable_strata: Strata names that should never be summed across
         when `reduce_to_minimal_groups` is True. Default is `{"downsampling"}`.
     :return: Table of stats per site.
     """
@@ -1236,7 +1236,7 @@ def compute_stats_per_ref_site(
             strata_expr,
             no_raw_group=True,
             reduce_to_minimal_groups=reduce_to_minimal_groups,
-            non_summable_axes=non_summable_axes,
+            non_summable_strata=non_summable_strata,
             group_label="raw",
         )
 

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1155,7 +1155,7 @@ def compute_stats_per_ref_site(
         element-wise summation. See the rubric above. Default is False.
     :param non_summable_strata: Strata names that should never be summed
         across their values when `reduce_to_minimal_groups` is True.
-        Default is `{"downsampling"}`.
+        Default is None which resolves to `{"downsampling"}`.
     :param reducible_aggs: Optional set of annotation names from
         `entry_agg_funcs` that are summable and should be expanded from
         leaf shape to full shape via element-wise summation when leaf
@@ -1321,7 +1321,7 @@ def compute_stats_per_ref_site(
         strata_expr = [{k: ht[k] for k in d} for d in strata_expr]
 
         # Use 'generate_freq_group_membership_array' to create a group_membership Table
-        # that gives stratification group membership info based on 'strata_expr'. The
+        # that gives stratification group membership info based on 'strata_expr'.
         # The per-ref-site stats path does no genotype-level filtering, so
         # label every freq_meta entry as "raw" rather than the default "adj".
         # `no_raw_group=True` skips the inserted raw-only entry; the

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -1155,7 +1155,7 @@ def compute_stats_per_ref_site(
         element-wise summation. See the rubric above. Default is False.
     :param non_summable_strata: Strata names that should never be summed
         across their values when `reduce_to_minimal_groups` is True.
-        Default is None which resolves to `{"downsampling"}`.
+        Default is None, which resolves to `{"downsampling"}`.
     :param reducible_aggs: Optional set of annotation names from
         `entry_agg_funcs` that are summable and should be expanded from
         leaf shape to full shape via element-wise summation when leaf
@@ -1241,12 +1241,13 @@ def compute_stats_per_ref_site(
     # latent shape mismatch in downstream consumers; raise so the
     # caller fixes the call before paying the densify+aggregation cost.
     if is_reduced:
-        accounted_for = (
-            set(entry_agg_funcs) if reducible_aggs is None else set(reducible_aggs)
+        reducible = (
+            set(reducible_aggs) if reducible_aggs is not None else set(entry_agg_funcs)
         )
-        if entry_agg_group_membership is not None:
-            accounted_for |= set(entry_agg_group_membership)
-        unaccounted = set(entry_agg_funcs) - accounted_for
+        grouped = (
+            set(entry_agg_group_membership) if entry_agg_group_membership else set()
+        )
+        unaccounted = set(entry_agg_funcs) - (reducible | grouped)
         if unaccounted:
             raise ValueError(
                 "Leaf reduction is in effect but the following entries of"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,45 @@
 """Pytest configuration file for Hail tests."""
 
-import hail as hl
-import pytest
+import os
+
+# CRITICAL: Force the local Spark backend BEFORE anything imports Hail.
+#
+# Hail reads `~/.config/hail/config.ini` at `hl.init()` time, which on
+# developer machines is often configured to use the Hail Batch service
+# backend (`[query] backend = batch`). When pytest collects test modules
+# they `import hail as hl`, which can trigger Hail's lazy initialization
+# during module collection — *before* any pytest fixture has had a chance
+# to run. Hail then picks up the Batch backend from the global config and
+# every subsequent Hail call submits jobs to Hail Batch, even though the
+# `setup_hail` fixture below passes `backend="spark"` to `hl.init()`
+# (which becomes a no-op because Hail is already initialized).
+#
+# Setting HAIL_QUERY_BACKEND=spark in the environment overrides
+# `~/.config/hail/config.ini` at the source. Verified empirically: removing
+# this line causes the test suite to start submitting Hail Batch jobs even
+# with the explicit `backend="spark"` kwarg in the fixture.
+os.environ.setdefault("HAIL_QUERY_BACKEND", "spark")
+
+# Ensure Spark binds to a local loopback address before Hail/Spark are imported.
+# On macOS the machine's hostname often does not resolve to a routable IP, which
+# causes `sparkDriver` startup to fail with `BindException`. Setting
+# `spark.driver.bindAddress` and `spark.driver.host` to 127.0.0.1 sidesteps the
+# hostname resolution entirely. This must run before `import hail` because Hail
+# constructs its SparkContext at init time using whatever PYSPARK_SUBMIT_ARGS
+# was at process start. Verified empirically: removing this block causes
+# `sparkDriver` startup to fail with a Py4JJavaError BindException.
+_SPARK_BIND_ARGS = (
+    "--conf spark.driver.bindAddress=127.0.0.1 " "--conf spark.driver.host=127.0.0.1"
+)
+_existing_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "")
+if "spark.driver.bindAddress" not in _existing_args:
+    if _existing_args:
+        os.environ["PYSPARK_SUBMIT_ARGS"] = f"{_SPARK_BIND_ARGS} {_existing_args}"
+    else:
+        os.environ["PYSPARK_SUBMIT_ARGS"] = f"{_SPARK_BIND_ARGS} pyspark-shell"
+
+import hail as hl  # noqa: E402
+import pytest  # noqa: E402
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -9,8 +47,16 @@ def setup_hail():
     """
     Set up Hail before running tests.
 
-    This fixture will ensure that the Hail context is initialized only once per test
-    session and will be stopped after all tests are completed.
+    This fixture will ensure that the Hail context is initialized only once per
+    test session and will be stopped after all tests are completed.
+
+    Tests are forced to run on the local Spark backend so they never submit
+    jobs to Hail Batch, regardless of the developer's global `hailctl`
+    configuration. The actual backend selection is done at the top of this
+    module via `HAIL_QUERY_BACKEND=spark` (which Hail reads at init time and
+    which overrides `~/.config/hail/config.ini`). The `PYSPARK_SUBMIT_ARGS`
+    setup at the top of this module pins Spark's driver to 127.0.0.1 to avoid
+    hostname resolution issues on macOS.
     """
     if not hl.utils.java.Env.is_fully_initialized():
         hl.init(log="/dev/null")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ os.environ.setdefault("HAIL_QUERY_BACKEND", "spark")
 # was at process start. Verified empirically: removing this block causes
 # `sparkDriver` startup to fail with a Py4JJavaError BindException.
 _SPARK_BIND_ARGS = (
-    "--conf spark.driver.bindAddress=127.0.0.1 " "--conf spark.driver.host=127.0.0.1"
+    "--conf spark.driver.bindAddress=127.0.0.1" + " --conf spark.driver.host=127.0.0.1"
 )
 _existing_args = os.environ.get("PYSPARK_SUBMIT_ARGS", "")
 if "spark.driver.bindAddress" not in _existing_args:

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -2057,7 +2057,7 @@ class TestFindMinimalStrataGroups:
     """Test the find_minimal_strata_groups function."""
 
     def test_basic_adj_with_downsampling(self):
-        """Mixed adj/raw partition with gen_anc, sex, and downsampling axes."""
+        """Mixed adj/raw partition with gen_anc, sex, and downsampling strata."""
         freq_meta = [
             {"group": "adj"},
             {"group": "raw"},
@@ -2149,11 +2149,11 @@ class TestFindMinimalStrataGroups:
 
         # Every entry is a leaf:
         # - {} has no matching leaves with non_summable=={}, so falls back to leaf.
-        # - downsampling entries are non-summable axes, so they stay as their own leaves.
+        # - downsampling entries are non-summable strata, so they stay as their own leaves.
         assert leaves == [0, 1, 2, 3]
         assert decomp == {}
 
-    def test_no_summable_axes(self):
+    def test_no_summable_strata(self):
         """Trivial case: only adj/raw entries, no strata to reduce."""
         freq_meta = [{"group": "adj"}, {"group": "raw"}]
         leaves, decomp = find_minimal_strata_groups(freq_meta, [100, 100])
@@ -2178,10 +2178,10 @@ class TestFindMinimalStrataGroups:
         assert leaves == [0, 1, 2]
         assert decomp == {}
 
-    def test_multi_axis_family_uses_sample_count_validation(self):
+    def test_multi_strata_family_uses_sample_count_validation(self):
         """Mirrors the v4 generate_freq pipeline: gen_anc/sex alongside gatk_version/gen_anc.
 
-        Both families have axis set {gen_anc, sex} and {gatk_version, gen_anc}
+        Both families have strata set {gen_anc, sex} and {gatk_version, gen_anc}
         respectively — neither is a subset of the other, so both are leaf
         families. Without sample-count validation, parents like the all-adj
         entry would silently sum across both families and double-count
@@ -2211,7 +2211,7 @@ class TestFindMinimalStrataGroups:
 
         leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
 
-        # Both maximal axis-sets {gen_anc, sex} and {gatk_version, gen_anc}
+        # Both maximal strata-sets {gen_anc, sex} and {gatk_version, gen_anc}
         # contribute leaves.
         assert leaves == [5, 6, 7, 8, 11, 12, 13, 14]
 
@@ -2230,8 +2230,8 @@ class TestFindMinimalStrataGroups:
             10: [13, 14],
         }
 
-    def test_custom_non_summable_axes(self):
-        """Custom non_summable_axes treats the named axis as non-summable."""
+    def test_custom_non_summable_strata(self):
+        """Custom non_summable_strata treats the named stratum as non-summable."""
         freq_meta = [
             {"group": "adj"},
             {"group": "adj", "cohort": "A"},
@@ -2240,19 +2240,19 @@ class TestFindMinimalStrataGroups:
         # 100 total: cohort A=40, cohort B=60.
         sample_count = [100, 40, 60]
 
-        # With cohort treated as a normal summable axis, entry 0 decomposes
+        # With cohort treated as a normal summable stratum, entry 0 decomposes
         # into entries 1 and 2 (40+60 == 100).
         leaves, decomp = find_minimal_strata_groups(
-            freq_meta, sample_count, non_summable_axes=set()
+            freq_meta, sample_count, non_summable_strata=set()
         )
         assert leaves == [1, 2]
         assert decomp == {0: [1, 2]}
 
         # With cohort treated as non-summable, no decomposition is possible
-        # (entries 1 and 2 are leaves because their non_summable axes don't
-        # match entry 0's empty non_summable axes).
+        # (entries 1 and 2 are leaves because their non-summable strata don't
+        # match entry 0's empty non-summable strata).
         leaves, decomp = find_minimal_strata_groups(
-            freq_meta, sample_count, non_summable_axes={"cohort"}
+            freq_meta, sample_count, non_summable_strata={"cohort"}
         )
         assert leaves == [0, 1, 2]
         assert decomp == {}

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -12,8 +12,10 @@ from gnomad.utils.annotations import (
     add_gks_va,
     add_gks_vrs,
     annotate_downsamplings,
+    annotate_freq,
     check_annotation_missingness,
     fill_missing_key_combinations,
+    find_minimal_strata_groups,
     get_copy_state_by_sex,
     merge_array_expressions,
     merge_freq_arrays,
@@ -1614,7 +1616,8 @@ class TestGksVaFunctions:
         - `grpMaxFAF95` and `jointGrpMaxFAF95` store numeric FAF values in `frequency`
           (and use the genetic ancestry group label only for the `groupId` suffix).
         """
-        # Use a real-looking variant key with a long allele to exercise ID/groupId generation.
+        # Use a real-looking variant key with a long allele to exercise ID/groupId
+        # generation.
         contig = "chr1"
         position = 10108
         ref = "C"
@@ -1622,7 +1625,8 @@ class TestGksVaFunctions:
         gnomad_id = f"{contig}-{position}-{ref}-{alt}"
 
         # Construct a minimal Struct that satisfies the fields accessed by `add_gks_va`.
-        # Note: keep `filters` empty to avoid nondeterministic ordering from `list(set)`.
+        # Note: keep `filters` empty to avoid nondeterministic ordering from
+        # `list(set)`.
         input_struct = hl.eval(
             hl.struct(
                 locus=hl.locus(contig, position, reference_genome="GRCh38"),
@@ -1642,7 +1646,8 @@ class TestGksVaFunctions:
                     bin_edges=hl.literal(
                         [i / 20 for i in range(21)], hl.tarray(hl.tfloat64)
                     ),
-                    # Put counts in the last two bins so the skewed AB count is non-zero.
+                    # Put counts in the last two bins so the skewed AB count is
+                    # non-zero.
                     bin_freq=hl.literal([0] * 18 + [1, 2], hl.tarray(hl.tint64)),
                     n_smaller=hl.int64(0),
                     n_larger=hl.int64(0),
@@ -2046,3 +2051,309 @@ class TestCheckAnnotationMissingness:
         assert "field_a" in ht_result.row.dtype.fields
         assert "field_b" in ht_result.row.dtype.fields
         assert "field_c" in ht_result.row.dtype.fields
+
+
+class TestFindMinimalStrataGroups:
+    """Test the find_minimal_strata_groups function."""
+
+    def test_basic_adj_with_downsampling(self):
+        """Mixed adj/raw partition with gen_anc, sex, and downsampling axes."""
+        freq_meta = [
+            {"group": "adj"},
+            {"group": "raw"},
+            {"group": "adj", "gen_anc": "afr"},
+            {"group": "adj", "gen_anc": "nfe"},
+            {"group": "adj", "gen_anc": "afr", "sex": "XX"},
+            {"group": "adj", "gen_anc": "afr", "sex": "XY"},
+            {"group": "adj", "gen_anc": "nfe", "sex": "XX"},
+            {"group": "adj", "gen_anc": "nfe", "sex": "XY"},
+            {"group": "adj", "downsampling": "1000", "gen_anc": "afr"},
+            {"group": "adj", "downsampling": "1000", "gen_anc": "nfe"},
+            {
+                "group": "adj",
+                "downsampling": "1000",
+                "gen_anc": "afr",
+                "sex": "XX",
+            },
+            {
+                "group": "adj",
+                "downsampling": "1000",
+                "gen_anc": "afr",
+                "sex": "XY",
+            },
+            {
+                "group": "adj",
+                "downsampling": "1000",
+                "gen_anc": "nfe",
+                "sex": "XX",
+            },
+            {
+                "group": "adj",
+                "downsampling": "1000",
+                "gen_anc": "nfe",
+                "sex": "XY",
+            },
+        ]
+
+        leaves, decomp = find_minimal_strata_groups(freq_meta)
+
+        assert leaves == [1, 4, 5, 6, 7, 10, 11, 12, 13]
+        assert decomp == {
+            0: [4, 5, 6, 7],
+            2: [4, 5],
+            3: [6, 7],
+            8: [10, 11],
+            9: [12, 13],
+        }
+
+    def test_all_raw_partition(self):
+        """compute_stats_per_ref_site case: every entry has group='raw'."""
+        freq_meta = [
+            {"group": "raw"},
+            {"group": "raw", "gen_anc": "afr"},
+            {"group": "raw", "gen_anc": "nfe"},
+            {"group": "raw", "sex": "XX"},
+            {"group": "raw", "sex": "XY"},
+            {"group": "raw", "gen_anc": "afr", "sex": "XX"},
+            {"group": "raw", "gen_anc": "afr", "sex": "XY"},
+            {"group": "raw", "gen_anc": "nfe", "sex": "XX"},
+            {"group": "raw", "gen_anc": "nfe", "sex": "XY"},
+        ]
+
+        leaves, decomp = find_minimal_strata_groups(freq_meta)
+
+        assert leaves == [5, 6, 7, 8]
+        assert decomp == {
+            0: [5, 6, 7, 8],
+            1: [5, 6],
+            2: [7, 8],
+            3: [5, 7],
+            4: [6, 8],
+        }
+
+    def test_global_downsampling_stays_leaf(self):
+        """Downsampling-only entries stay leaves; the all-adj entry can't decompose into them."""
+        freq_meta = [
+            {"group": "adj"},
+            {"group": "adj", "downsampling": "1000", "gen_anc": "global"},
+            {"group": "adj", "downsampling": "1000", "gen_anc": "afr"},
+            {"group": "adj", "downsampling": "1000", "gen_anc": "nfe"},
+        ]
+
+        leaves, decomp = find_minimal_strata_groups(freq_meta)
+
+        # Every entry is a leaf:
+        # - {} has no matching leaves with non_summable=={}, so falls back to leaf.
+        # - downsampling entries are non-summable axes, so they stay as their own leaves.
+        assert leaves == [0, 1, 2, 3]
+        assert decomp == {}
+
+    def test_no_summable_axes(self):
+        """Trivial case: only adj/raw entries, no strata to reduce."""
+        freq_meta = [{"group": "adj"}, {"group": "raw"}]
+        leaves, decomp = find_minimal_strata_groups(freq_meta)
+
+        assert leaves == [0, 1]
+        assert decomp == {}
+
+    def test_partial_strata_falls_back_to_leaf(self):
+        """A parent that can't be fully decomposed still falls back to a single leaf match."""
+        freq_meta = [
+            {"group": "adj"},
+            {"group": "adj", "gen_anc": "afr"},
+            {"group": "adj", "gen_anc": "afr", "sex": "XX"},
+        ]
+
+        leaves, decomp = find_minimal_strata_groups(freq_meta)
+
+        # Maximal axis set is {gen_anc, sex} -> only entry 2 is a leaf.
+        # Entry 0 has e_keys={} so it matches entry 2 (single leaf in partition).
+        # Entry 1 has gen_anc=afr, also matches entry 2.
+        assert leaves == [2]
+        assert decomp == {0: [2], 1: [2]}
+
+    def test_custom_non_summable_axes(self):
+        """Custom non_summable_axes treats the named axis as non-summable."""
+        freq_meta = [
+            {"group": "adj"},
+            {"group": "adj", "cohort": "A"},
+            {"group": "adj", "cohort": "B"},
+        ]
+
+        # With cohort treated as a normal summable axis, entry 0 decomposes
+        # into entries 1 and 2.
+        leaves, decomp = find_minimal_strata_groups(freq_meta, non_summable_axes=set())
+        assert leaves == [1, 2]
+        assert decomp == {0: [1, 2]}
+
+        # With cohort treated as non-summable, no decomposition is possible
+        # (entries 1 and 2 are leaves because their non_summable axes don't
+        # match entry 0's empty non_summable axes).
+        leaves, decomp = find_minimal_strata_groups(
+            freq_meta, non_summable_axes={"cohort"}
+        )
+        assert leaves == [0, 1, 2]
+        assert decomp == {}
+
+
+class TestAnnotateFreqReduceToMinimalGroups:
+    """Test that annotate_freq with reduce_to_minimal_groups=True matches the full output."""
+
+    @pytest.fixture
+    def sample_mt(self):
+        """8 samples × 4 sites with gen_anc, sex, and per-sample-per-site adj flags."""
+        samples = [
+            ("s1", "afr", "XX"),
+            ("s2", "afr", "XY"),
+            ("s3", "afr", "XX"),
+            ("s4", "afr", "XY"),
+            ("s5", "nfe", "XX"),
+            ("s6", "nfe", "XY"),
+            ("s7", "nfe", "XX"),
+            ("s8", "nfe", "XY"),
+        ]
+        variants = [
+            (hl.locus("chr1", 1000, reference_genome="GRCh38"), ["A", "T"]),
+            (hl.locus("chr1", 2000, reference_genome="GRCh38"), ["C", "G"]),
+            (hl.locus("chr1", 3000, reference_genome="GRCh38"), ["G", "A"]),
+            (hl.locus("chr1", 4000, reference_genome="GRCh38"), ["T", "C"]),
+        ]
+        # Cycle through a few genotype patterns so we get nontrivial AC/AN.
+        gt_patterns = [
+            [(0, 0), (0, 1), (1, 1), (0, 1), (0, 0), (0, 1), (1, 1), (0, 1)],
+            [(0, 1), (1, 1), (0, 0), (0, 1), (0, 1), (1, 1), (0, 0), (0, 1)],
+            [(0, 0), (0, 0), (0, 1), (1, 1), (0, 0), (0, 0), (0, 1), (1, 1)],
+            [(1, 1), (0, 1), (0, 1), (0, 0), (1, 1), (0, 1), (0, 1), (0, 0)],
+        ]
+
+        sample_table = hl.Table.parallelize(
+            [{"s": s, "gen_anc": g, "sex": x} for s, g, x in samples],
+            hl.tstruct(s=hl.tstr, gen_anc=hl.tstr, sex=hl.tstr),
+        ).key_by("s")
+
+        entries = []
+        for v_idx, (locus, alleles) in enumerate(variants):
+            for s_idx, (sample_id, _, _) in enumerate(samples):
+                a, b = gt_patterns[v_idx][s_idx]
+                entries.append(
+                    {
+                        "locus": locus,
+                        "alleles": alleles,
+                        "s": sample_id,
+                        "GT": hl.call(a, b),
+                        # Make every other genotype "non-adj" to exercise the
+                        # adj/raw distinction.
+                        "adj": (s_idx + v_idx) % 2 == 0,
+                    }
+                )
+        mt = hl.Table.parallelize(
+            entries,
+            hl.tstruct(
+                locus=hl.tlocus("GRCh38"),
+                alleles=hl.tarray(hl.tstr),
+                s=hl.tstr,
+                GT=hl.tcall,
+                adj=hl.tbool,
+            ),
+        ).to_matrix_table(row_key=["locus", "alleles"], col_key=["s"])
+        mt = mt.annotate_cols(
+            gen_anc=sample_table[mt.s].gen_anc,
+            sex=sample_table[mt.s].sex,
+        )
+        return mt
+
+    def _run_and_index_freq(self, mt):
+        """Run annotate_freq and return a dict mapping freq_meta key tuples to per-row freq dicts."""
+        freq_meta = hl.eval(mt.freq_meta)
+        freq_meta_sample_count = hl.eval(mt.freq_meta_sample_count)
+        rows = mt.rows().select("freq").collect()
+        # Build a stable representation: list of (sorted_meta_items_tuple,
+        # [per_row_freq_dict])
+        per_meta = {}
+        for i, m in enumerate(freq_meta):
+            key = tuple(sorted(m.items()))
+            per_meta[key] = {
+                "sample_count": freq_meta_sample_count[i],
+                "freqs": [
+                    {
+                        "AC": r.freq[i].AC,
+                        "AN": r.freq[i].AN,
+                        "homozygote_count": r.freq[i].homozygote_count,
+                    }
+                    for r in rows
+                ],
+            }
+        return per_meta
+
+    def test_reduce_matches_full_with_gen_anc_and_sex(self, sample_mt):
+        """annotate_freq(reduce=True) and annotate_freq(reduce=False) match exactly."""
+        full_mt = annotate_freq(
+            sample_mt,
+            sex_expr=sample_mt.sex,
+            gen_anc_expr=sample_mt.gen_anc,
+        )
+        reduced_mt = annotate_freq(
+            sample_mt,
+            sex_expr=sample_mt.sex,
+            gen_anc_expr=sample_mt.gen_anc,
+            reduce_to_minimal_groups=True,
+        )
+
+        full_indexed = self._run_and_index_freq(full_mt)
+        reduced_indexed = self._run_and_index_freq(reduced_mt)
+
+        assert set(full_indexed.keys()) == set(reduced_indexed.keys())
+        for key in full_indexed:
+            assert (
+                full_indexed[key]["sample_count"]
+                == reduced_indexed[key]["sample_count"]
+            ), key
+            assert full_indexed[key]["freqs"] == reduced_indexed[key]["freqs"], key
+
+    def test_reduce_matches_full_with_downsampling(self, sample_mt):
+        """annotate_freq(reduce=True) matches the full output when downsamplings are used.
+
+        Downsamplings use a randomized rank, so we pre-compute the downsampling
+        annotations once via annotate_downsamplings and pass them as
+        downsampling_expr to both annotate_freq calls. This guarantees that
+        both runs see exactly the same per-sample downsampling assignments.
+        """
+        ds_mt = annotate_downsamplings(sample_mt, [4], gen_anc_expr=sample_mt.gen_anc)
+        downsamplings = hl.eval(ds_mt.downsamplings)
+        ds_gen_anc_counts = hl.eval(ds_mt.ds_gen_anc_counts)
+
+        full_mt = annotate_freq(
+            ds_mt,
+            sex_expr=ds_mt.sex,
+            gen_anc_expr=ds_mt.gen_anc,
+            downsamplings=downsamplings,
+            downsampling_expr=ds_mt.downsampling,
+            ds_gen_anc_counts=ds_gen_anc_counts,
+        )
+        reduced_mt = annotate_freq(
+            ds_mt,
+            sex_expr=ds_mt.sex,
+            gen_anc_expr=ds_mt.gen_anc,
+            downsamplings=downsamplings,
+            downsampling_expr=ds_mt.downsampling,
+            ds_gen_anc_counts=ds_gen_anc_counts,
+            reduce_to_minimal_groups=True,
+        )
+
+        full_indexed = self._run_and_index_freq(full_mt)
+        reduced_indexed = self._run_and_index_freq(reduced_mt)
+
+        # The freq_meta key sets must match exactly. In particular, the
+        # downsampling-stratified entries must survive the reduction as
+        # leaves and not be folded into other parents.
+        assert set(full_indexed.keys()) == set(reduced_indexed.keys())
+        # Sanity check: at least one downsampling-stratified group exists.
+        ds_groups = [k for k in full_indexed if any(p[0] == "downsampling" for p in k)]
+        assert ds_groups, "expected at least one downsampling-stratified group"
+
+        for key in full_indexed:
+            assert (
+                full_indexed[key]["sample_count"]
+                == reduced_indexed[key]["sample_count"]
+            ), key
+            assert full_indexed[key]["freqs"] == reduced_indexed[key]["freqs"], key

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -2424,3 +2424,69 @@ class TestAnnotateFreqReduceToMinimalGroups:
                 == reduced_indexed[key]["sample_count"]
             ), key
             assert full_indexed[key]["freqs"] == reduced_indexed[key]["freqs"], key
+
+    def test_reduce_matches_full_with_multi_family_strata(self, sample_mt):
+        """annotate_freq(reduce=True) matches the full output when freq_meta has multiple non-comparable strata families.
+
+        Mirrors the v4 generate_freq pipeline shape: a `gen_anc/sex` family
+        (from `build_freq_stratification_list`) and a `platform/gen_anc`
+        family (from `additional_strata_expr`). Both are maximal-by-inclusion
+        leaf-strata sets, and both validly decompose parents like the
+        all-adj entry. Without sample-count validation in
+        `find_minimal_strata_groups`, the parent would silently sum across
+        both families and double-count samples; this test locks that fix in.
+        """
+        # Mix platforms across gen_anc and sex so neither family perfectly
+        # correlates with the other. With this assignment, every parent
+        # entry has at least one valid single-family decomposition.
+        platforms = {
+            "s1": "A",
+            "s2": "A",
+            "s3": "B",
+            "s4": "B",
+            "s5": "A",
+            "s6": "B",
+            "s7": "A",
+            "s8": "B",
+        }
+        platform_table = hl.Table.parallelize(
+            [{"s": s, "platform": p} for s, p in platforms.items()],
+            hl.tstruct(s=hl.tstr, platform=hl.tstr),
+        ).key_by("s")
+        mt = sample_mt.annotate_cols(platform=platform_table[sample_mt.s].platform)
+
+        additional = [
+            {"platform": mt.platform},
+            {"platform": mt.platform, "gen_anc": mt.gen_anc},
+        ]
+        full_mt = annotate_freq(
+            mt,
+            sex_expr=mt.sex,
+            gen_anc_expr=mt.gen_anc,
+            additional_strata_expr=additional,
+        )
+        reduced_mt = annotate_freq(
+            mt,
+            sex_expr=mt.sex,
+            gen_anc_expr=mt.gen_anc,
+            additional_strata_expr=additional,
+            reduce_to_minimal_groups=True,
+        )
+
+        full_indexed = self._run_and_index_freq(full_mt)
+        reduced_indexed = self._run_and_index_freq(reduced_mt)
+
+        assert set(full_indexed.keys()) == set(reduced_indexed.keys())
+        # Sanity check: both families are represented, otherwise the
+        # multi-family scenario isn't actually being exercised.
+        platform_groups = [
+            k for k in full_indexed if any(p[0] == "platform" for p in k)
+        ]
+        assert platform_groups, "expected at least one platform-stratified group"
+
+        for key in full_indexed:
+            assert (
+                full_indexed[key]["sample_count"]
+                == reduced_indexed[key]["sample_count"]
+            ), key
+            assert full_indexed[key]["freqs"] == reduced_indexed[key]["freqs"], key

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -2094,8 +2094,11 @@ class TestFindMinimalStrataGroups:
                 "sex": "XY",
             },
         ]
+        # 100 samples total: 40 afr (20 XX, 20 XY) + 60 nfe (30 XX, 30 XY).
+        # 13 in the downsampling=1000 cohort: 5 afr (2 XX, 3 XY) + 8 nfe (4 XX, 4 XY).
+        sample_count = [100, 100, 40, 60, 20, 20, 30, 30, 5, 8, 2, 3, 4, 4]
 
-        leaves, decomp = find_minimal_strata_groups(freq_meta)
+        leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
 
         assert leaves == [1, 4, 5, 6, 7, 10, 11, 12, 13]
         assert decomp == {
@@ -2119,8 +2122,9 @@ class TestFindMinimalStrataGroups:
             {"group": "raw", "gen_anc": "nfe", "sex": "XX"},
             {"group": "raw", "gen_anc": "nfe", "sex": "XY"},
         ]
+        sample_count = [100, 40, 60, 50, 50, 20, 20, 30, 30]
 
-        leaves, decomp = find_minimal_strata_groups(freq_meta)
+        leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
 
         assert leaves == [5, 6, 7, 8]
         assert decomp == {
@@ -2139,8 +2143,9 @@ class TestFindMinimalStrataGroups:
             {"group": "adj", "downsampling": "1000", "gen_anc": "afr"},
             {"group": "adj", "downsampling": "1000", "gen_anc": "nfe"},
         ]
+        sample_count = [100, 13, 5, 8]
 
-        leaves, decomp = find_minimal_strata_groups(freq_meta)
+        leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
 
         # Every entry is a leaf:
         # - {} has no matching leaves with non_summable=={}, so falls back to leaf.
@@ -2151,26 +2156,79 @@ class TestFindMinimalStrataGroups:
     def test_no_summable_axes(self):
         """Trivial case: only adj/raw entries, no strata to reduce."""
         freq_meta = [{"group": "adj"}, {"group": "raw"}]
-        leaves, decomp = find_minimal_strata_groups(freq_meta)
+        leaves, decomp = find_minimal_strata_groups(freq_meta, [100, 100])
 
         assert leaves == [0, 1]
         assert decomp == {}
 
-    def test_partial_strata_falls_back_to_leaf(self):
-        """A parent that can't be fully decomposed still falls back to a single leaf match."""
+    def test_partial_strata_promotes_uncoverable_parents_to_leaves(self):
+        """When the only candidate decomposition's sample counts don't sum to the parent's, promote to leaf."""
         freq_meta = [
             {"group": "adj"},
             {"group": "adj", "gen_anc": "afr"},
             {"group": "adj", "gen_anc": "afr", "sex": "XX"},
         ]
+        # All-adj=100, afr=40, afr-XX=20. The {gen_anc, sex} family is the only
+        # leaf family; entry 2 alone doesn't cover entry 0 (20 ≠ 100) or
+        # entry 1 (20 ≠ 40), so both must be promoted to leaves.
+        sample_count = [100, 40, 20]
 
-        leaves, decomp = find_minimal_strata_groups(freq_meta)
+        leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
 
-        # Maximal axis set is {gen_anc, sex} -> only entry 2 is a leaf.
-        # Entry 0 has e_keys={} so it matches entry 2 (single leaf in partition).
-        # Entry 1 has gen_anc=afr, also matches entry 2.
-        assert leaves == [2]
-        assert decomp == {0: [2], 1: [2]}
+        assert leaves == [0, 1, 2]
+        assert decomp == {}
+
+    def test_multi_axis_family_uses_sample_count_validation(self):
+        """Mirrors the v4 generate_freq pipeline: gen_anc/sex alongside gatk_version/gen_anc.
+
+        Both families have axis set {gen_anc, sex} and {gatk_version, gen_anc}
+        respectively — neither is a subset of the other, so both are leaf
+        families. Without sample-count validation, parents like the all-adj
+        entry would silently sum across both families and double-count
+        samples. With validation, each non-leaf is decomposed against exactly
+        one family.
+        """
+        freq_meta = [
+            {"group": "adj"},
+            {"group": "adj", "gen_anc": "afr"},
+            {"group": "adj", "gen_anc": "nfe"},
+            {"group": "adj", "sex": "XX"},
+            {"group": "adj", "sex": "XY"},
+            {"group": "adj", "gen_anc": "afr", "sex": "XX"},
+            {"group": "adj", "gen_anc": "afr", "sex": "XY"},
+            {"group": "adj", "gen_anc": "nfe", "sex": "XX"},
+            {"group": "adj", "gen_anc": "nfe", "sex": "XY"},
+            {"group": "adj", "gatk_version": "v1"},
+            {"group": "adj", "gatk_version": "v2"},
+            {"group": "adj", "gatk_version": "v1", "gen_anc": "afr"},
+            {"group": "adj", "gatk_version": "v1", "gen_anc": "nfe"},
+            {"group": "adj", "gatk_version": "v2", "gen_anc": "afr"},
+            {"group": "adj", "gatk_version": "v2", "gen_anc": "nfe"},
+        ]
+        # 100 samples: 40 afr (20 XX, 20 XY) + 60 nfe (30 XX, 30 XY).
+        # gatk_version split: v1=30 (15 afr + 15 nfe), v2=70 (25 afr + 45 nfe).
+        sample_count = [100, 40, 60, 50, 50, 20, 20, 30, 30, 30, 70, 15, 15, 25, 45]
+
+        leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
+
+        # Both maximal axis-sets {gen_anc, sex} and {gatk_version, gen_anc}
+        # contribute leaves.
+        assert leaves == [5, 6, 7, 8, 11, 12, 13, 14]
+
+        # Sex parents (3, 4) only match the {gen_anc, sex} family. gatk
+        # parents (9, 10) only match the {gatk_version, gen_anc} family. For
+        # parents 0/1/2 both families would sum correctly; the smaller
+        # candidate wins, with insertion order breaking ties — the
+        # {gen_anc, sex} family is encountered first.
+        assert decomp == {
+            0: [5, 6, 7, 8],
+            1: [5, 6],
+            2: [7, 8],
+            3: [5, 7],
+            4: [6, 8],
+            9: [11, 12],
+            10: [13, 14],
+        }
 
     def test_custom_non_summable_axes(self):
         """Custom non_summable_axes treats the named axis as non-summable."""
@@ -2179,10 +2237,14 @@ class TestFindMinimalStrataGroups:
             {"group": "adj", "cohort": "A"},
             {"group": "adj", "cohort": "B"},
         ]
+        # 100 total: cohort A=40, cohort B=60.
+        sample_count = [100, 40, 60]
 
         # With cohort treated as a normal summable axis, entry 0 decomposes
-        # into entries 1 and 2.
-        leaves, decomp = find_minimal_strata_groups(freq_meta, non_summable_axes=set())
+        # into entries 1 and 2 (40+60 == 100).
+        leaves, decomp = find_minimal_strata_groups(
+            freq_meta, sample_count, non_summable_axes=set()
+        )
         assert leaves == [1, 2]
         assert decomp == {0: [1, 2]}
 
@@ -2190,10 +2252,15 @@ class TestFindMinimalStrataGroups:
         # (entries 1 and 2 are leaves because their non_summable axes don't
         # match entry 0's empty non_summable axes).
         leaves, decomp = find_minimal_strata_groups(
-            freq_meta, non_summable_axes={"cohort"}
+            freq_meta, sample_count, non_summable_axes={"cohort"}
         )
         assert leaves == [0, 1, 2]
         assert decomp == {}
+
+    def test_misaligned_sample_count_raises(self):
+        """Length-mismatched sample_count is a programmer error."""
+        with pytest.raises(ValueError, match="aligned"):
+            find_minimal_strata_groups([{"group": "adj"}], [1, 2])
 
 
 class TestAnnotateFreqReduceToMinimalGroups:

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -2302,7 +2302,7 @@ class TestFindMinimalStrataGroups:
 
 
 class TestExpandStrataArrayFromLeaves:
-    """Test the expand_strata_array_from_leaves function directly.
+    """Test the expand_strata_array_from_leaves function.
 
     These cover the per-element-type paths and edge cases that the
     integration tests in `TestAnnotateFreqReduceToMinimalGroups` and
@@ -2329,7 +2329,7 @@ class TestExpandStrataArrayFromLeaves:
         assert result == [100, 10, 20, 70, 30, 40]
 
     def test_plain_struct_sums_each_field_independently(self):
-        """Multi-field structs without AF sum each numeric field independently."""
+        """Multi-field structs sum each numeric field independently."""
         element_type = hl.tstruct(x=hl.tint32, y=hl.tint32)
         leaf_array = hl.literal(
             [{"x": 1, "y": 10}, {"x": 2, "y": 20}, {"x": 3, "y": 30}],

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -14,6 +14,7 @@ from gnomad.utils.annotations import (
     annotate_downsamplings,
     annotate_freq,
     check_annotation_missingness,
+    expand_strata_array_from_leaves,
     fill_missing_key_combinations,
     find_minimal_strata_groups,
     get_copy_state_by_sex,
@@ -2298,6 +2299,125 @@ class TestFindMinimalStrataGroups:
         """Length-mismatched sample_count is a programmer error."""
         with pytest.raises(ValueError, match="aligned"):
             find_minimal_strata_groups([{"group": "adj"}], [1, 2])
+
+
+class TestExpandStrataArrayFromLeaves:
+    """Test the expand_strata_array_from_leaves function directly.
+
+    These cover the per-element-type paths and edge cases that the
+    integration tests in `TestAnnotateFreqReduceToMinimalGroups` and
+    `TestComputeAlleleNumberPerRefSiteReduceToMinimalGroups` exercise
+    only transitively.
+    """
+
+    def test_scalar_array_expands_leaves_and_sums_parents(self):
+        """Scalar leaf values pass through; parents sum their leaves element-wise."""
+        # Original freq_meta has 6 positions; indices 1, 2, 4, 5 are leaves
+        # and 0 and 3 are non-leaves with explicit decompositions.
+        leaf_array = hl.literal([10, 20, 30, 40], dtype=hl.tarray(hl.tint32))
+        leaf_indices = [1, 2, 4, 5]
+        decomposition = {0: [1, 2, 4, 5], 3: [4, 5]}
+        n_full = 6
+
+        result = hl.eval(
+            expand_strata_array_from_leaves(
+                leaf_array, leaf_indices, decomposition, n_full
+            )
+        )
+        # 0: all four leaves summed; 1,2,4,5: leaves pass through;
+        # 3: leaves at original indices 4 and 5 summed.
+        assert result == [100, 10, 20, 70, 30, 40]
+
+    def test_plain_struct_sums_each_field_independently(self):
+        """Multi-field structs without AF sum each numeric field independently."""
+        element_type = hl.tstruct(x=hl.tint32, y=hl.tint32)
+        leaf_array = hl.literal(
+            [{"x": 1, "y": 10}, {"x": 2, "y": 20}, {"x": 3, "y": 30}],
+            dtype=hl.tarray(element_type),
+        )
+        leaf_indices = [0, 1, 2]
+        decomposition = {3: [0, 1, 2]}
+        n_full = 4
+
+        result = hl.eval(
+            expand_strata_array_from_leaves(
+                leaf_array, leaf_indices, decomposition, n_full
+            )
+        )
+        assert result == [
+            hl.Struct(x=1, y=10),
+            hl.Struct(x=2, y=20),
+            hl.Struct(x=3, y=30),
+            hl.Struct(x=6, y=60),
+        ]
+
+    def test_freq_struct_drops_and_recomputes_af(self):
+        """Freq structs (with AF) drop AF before summing and recompute AF=AC/AN."""
+        freq_type = hl.tstruct(
+            AC=hl.tint32, AF=hl.tfloat64, AN=hl.tint32, homozygote_count=hl.tint32
+        )
+        leaf_array = hl.literal(
+            [
+                {"AC": 2, "AF": 0.04, "AN": 50, "homozygote_count": 0},
+                {"AC": 3, "AF": 0.06, "AN": 50, "homozygote_count": 1},
+                # Zero-sample leaves: AN=0 must produce missing AF after expand.
+                {"AC": 0, "AF": None, "AN": 0, "homozygote_count": 0},
+                {"AC": 0, "AF": None, "AN": 0, "homozygote_count": 0},
+            ],
+            dtype=hl.tarray(freq_type),
+        )
+        leaf_indices = [1, 2, 4, 5]
+        # Parent 0 sums two AN>0 leaves; parent 3 sums two AN=0 leaves.
+        decomposition = {0: [1, 2], 3: [4, 5]}
+        n_full = 6
+
+        result = hl.eval(
+            expand_strata_array_from_leaves(
+                leaf_array, leaf_indices, decomposition, n_full
+            )
+        )
+        # Parent of AN>0 leaves: AC=5, AN=100, AF recomputed to 5/100.
+        assert result[0] == hl.Struct(AC=5, AF=0.05, AN=100, homozygote_count=1)
+        # Leaves with AN>0 are passed through with AF recomputed from AC/AN.
+        assert result[1] == hl.Struct(AC=2, AF=0.04, AN=50, homozygote_count=0)
+        assert result[2] == hl.Struct(AC=3, AF=0.06, AN=50, homozygote_count=1)
+        # Parent of AN=0 leaves: AF must be missing, not divide-by-zero.
+        assert result[3] == hl.Struct(AC=0, AF=None, AN=0, homozygote_count=0)
+        # Zero-sample leaves: AF stays missing after recompute.
+        assert result[4] == hl.Struct(AC=0, AF=None, AN=0, homozygote_count=0)
+        assert result[5] == hl.Struct(AC=0, AF=None, AN=0, homozygote_count=0)
+        # Field order must match the contract: AC, AF, AN, homozygote_count.
+        assert list(result[0].keys()) == ["AC", "AF", "AN", "homozygote_count"]
+
+    def test_missing_leaf_values_treated_as_zero(self):
+        """`hl.or_else(..., 0)` zeros out missing leaf values before summing."""
+        leaf_array = hl.literal([10, None, 30], dtype=hl.tarray(hl.tint32))
+        leaf_indices = [0, 1, 2]
+        decomposition = {3: [0, 1, 2]}
+        n_full = 4
+
+        result = hl.eval(
+            expand_strata_array_from_leaves(
+                leaf_array, leaf_indices, decomposition, n_full
+            )
+        )
+        # Leaf position 1 is missing — passes through as 0 because the
+        # single-element sum path also applies `or_else(..., 0)`. Parent at
+        # position 3 sums 10 + 0 + 30 = 40.
+        assert result == [10, 0, 30, 40]
+
+    def test_unaccounted_index_raises(self):
+        """Any full-array index that's neither a leaf nor in `decomposition` raises ValueError."""
+        leaf_array = hl.literal([1, 2], dtype=hl.tarray(hl.tint32))
+        leaf_indices = [0, 1]
+        decomposition = {2: [0, 1]}
+        # Index 3 is neither in `leaf_indices` nor in `decomposition`.
+        n_full = 4
+
+        with pytest.raises(ValueError, match="neither a leaf nor in the decomposition"):
+            expand_strata_array_from_leaves(
+                leaf_array, leaf_indices, decomposition, n_full
+            )
 
 
 class TestAnnotateFreqReduceToMinimalGroups:

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -2093,16 +2093,22 @@ class TestFindMinimalStrataGroups:
                 "gen_anc": "nfe",
                 "sex": "XY",
             },
+            # Extra raw entries so the raw partition is non-trivial: the
+            # bare {"group": "raw"} parent decomposes into the per-gen_anc
+            # raw leaves, exercising the adj/raw partition boundary.
+            {"group": "raw", "gen_anc": "afr"},
+            {"group": "raw", "gen_anc": "nfe"},
         ]
         # 100 samples total: 40 afr (20 XX, 20 XY) + 60 nfe (30 XX, 30 XY).
         # 13 in the downsampling=1000 cohort: 5 afr (2 XX, 3 XY) + 8 nfe (4 XX, 4 XY).
-        sample_count = [100, 100, 40, 60, 20, 20, 30, 30, 5, 8, 2, 3, 4, 4]
+        sample_count = [100, 100, 40, 60, 20, 20, 30, 30, 5, 8, 2, 3, 4, 4, 40, 60]
 
         leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
 
-        assert leaves == [1, 4, 5, 6, 7, 10, 11, 12, 13]
+        assert leaves == [4, 5, 6, 7, 10, 11, 12, 13, 14, 15]
         assert decomp == {
             0: [4, 5, 6, 7],
+            1: [14, 15],
             2: [4, 5],
             3: [6, 7],
             8: [10, 11],
@@ -2229,6 +2235,37 @@ class TestFindMinimalStrataGroups:
             9: [11, 12],
             10: [13, 14],
         }
+
+    def test_fewest_leaves_wins_when_multiple_decompositions_valid(self):
+        """When multiple strata families validly cover a parent, the one with the fewest leaves is chosen.
+
+        Two non-comparable leaf families both sum to the parent's sample count:
+        `{sex, gatk_version}` with 4 leaves and `{gen_anc}` with 2 leaves. The
+        4-leaf family is inserted first, so an insertion-order policy would
+        pick it; `min(valid, key=len)` picks the 2-leaf family instead.
+        """
+        freq_meta = [
+            {"group": "adj"},
+            # {sex, gatk_version} family — inserted first into the candidate
+            # map because its entries have lower indices than the {gen_anc}
+            # entries below.
+            {"group": "adj", "sex": "XX", "gatk_version": "v1"},
+            {"group": "adj", "sex": "XX", "gatk_version": "v2"},
+            {"group": "adj", "sex": "XY", "gatk_version": "v1"},
+            {"group": "adj", "sex": "XY", "gatk_version": "v2"},
+            # {gen_anc} family — fewer leaves, should win.
+            {"group": "adj", "gen_anc": "afr"},
+            {"group": "adj", "gen_anc": "nfe"},
+        ]
+        # 100 total. {sex, gatk_version}: 23+27+25+25=100. {gen_anc}: 40+60=100.
+        sample_count = [100, 23, 27, 25, 25, 40, 60]
+
+        leaves, decomp = find_minimal_strata_groups(freq_meta, sample_count)
+
+        # Both families are leaves (neither set is a subset of the other).
+        assert leaves == [1, 2, 3, 4, 5, 6]
+        # The 2-leaf {gen_anc} family wins despite being inserted second.
+        assert decomp == {0: [5, 6]}
 
     def test_custom_non_summable_strata(self):
         """Custom non_summable_strata treats the named stratum as non-summable."""

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -3,8 +3,12 @@
 import logging
 
 import hail as hl
+import pytest
 
-from gnomad.utils.sparse_mt import get_coverage_agg_func
+from gnomad.utils.sparse_mt import (
+    compute_allele_number_per_ref_site,
+    get_coverage_agg_func,
+)
 
 # Set up logger for tests.
 logger = logging.getLogger(__name__)
@@ -336,3 +340,159 @@ class TestGetCoverageAggFunc:
         assert result.mean == 27.5  # 275/10.
         # Values 35, 40, 45, 50 should be capped to 30, plus the original 30.
         assert result.coverage_counter.get(30, 0) == 5  # 4 capped + 1 original.
+
+
+class TestComputeAlleleNumberPerRefSiteReduceToMinimalGroups:
+    """Test that the reduce_to_minimal_groups optimization preserves AN values."""
+
+    @pytest.fixture
+    def synthetic_vds(self):
+        """Build a tiny VDS with 8 samples × 4 sites for AN testing.
+
+        The VDS has:
+          - 8 samples annotated with `gen_anc` (afr/nfe) and `sex` (XX/XY).
+          - 4 variant sites with explicit GT calls (some missing) for every
+            sample.
+          - A reference_data MT with 1-base ref blocks at the same loci, so
+            densification is essentially a no-op (we test the reduction
+            machinery, not the densification machinery).
+        """
+        samples = [
+            ("s1", "afr", "XX"),
+            ("s2", "afr", "XY"),
+            ("s3", "afr", "XX"),
+            ("s4", "afr", "XY"),
+            ("s5", "nfe", "XX"),
+            ("s6", "nfe", "XY"),
+            ("s7", "nfe", "XX"),
+            ("s8", "nfe", "XY"),
+        ]
+        positions = [1000, 2000, 3000, 4000]
+        variants = [
+            (hl.locus("chr1", p, reference_genome="GRCh38"), ["A", "T"])
+            for p in positions
+        ]
+        # Mix of called and missing genotypes so AN varies across sites and
+        # strata. Missing genotypes contribute 0 to AN; called diploid
+        # genotypes contribute 2.
+        gt_patterns = [
+            [(0, 0), (0, 1), (1, 1), (0, 1), (0, 0), (0, 1), (1, 1), (0, 1)],
+            [(0, 1), None, (0, 0), (0, 1), (0, 1), (1, 1), None, (0, 1)],
+            [None, (0, 0), (0, 1), (1, 1), (0, 0), (0, 0), (0, 1), (1, 1)],
+            [(1, 1), (0, 1), (0, 1), None, (1, 1), (0, 1), (0, 1), (0, 0)],
+        ]
+
+        sample_table = hl.Table.parallelize(
+            [{"s": s, "gen_anc": g, "sex": x} for s, g, x in samples],
+            hl.tstruct(s=hl.tstr, gen_anc=hl.tstr, sex=hl.tstr),
+        ).key_by("s")
+
+        # Build the variant_data MT.
+        vd_entries = []
+        for v_idx, (locus, alleles) in enumerate(variants):
+            for s_idx, (sample_id, _, _) in enumerate(samples):
+                gt = gt_patterns[v_idx][s_idx]
+                vd_entries.append(
+                    {
+                        "locus": locus,
+                        "alleles": alleles,
+                        "s": sample_id,
+                        "GT": hl.call(*gt) if gt is not None else hl.missing(hl.tcall),
+                    }
+                )
+        vd = hl.Table.parallelize(
+            vd_entries,
+            hl.tstruct(
+                locus=hl.tlocus("GRCh38"),
+                alleles=hl.tarray(hl.tstr),
+                s=hl.tstr,
+                GT=hl.tcall,
+            ),
+        ).to_matrix_table(row_key=["locus", "alleles"], col_key=["s"])
+        vd = vd.annotate_cols(
+            gen_anc=sample_table[vd.s].gen_anc,
+            sex=sample_table[vd.s].sex,
+        )
+
+        # Build the reference_data MT: 1-base ref blocks at every variant
+        # locus. END = locus.position means the block covers exactly one
+        # position.
+        rd_entries = []
+        for locus, _ in variants:
+            for sample_id, _, _ in samples:
+                rd_entries.append(
+                    {
+                        "locus": locus,
+                        "s": sample_id,
+                        "END": locus.position,
+                        "LEN": 1,
+                    }
+                )
+        rd = hl.Table.parallelize(
+            rd_entries,
+            hl.tstruct(
+                locus=hl.tlocus("GRCh38"),
+                s=hl.tstr,
+                END=hl.tint32,
+                LEN=hl.tint32,
+            ),
+        ).to_matrix_table(row_key=["locus"], col_key=["s"])
+
+        return hl.vds.VariantDataset(reference_data=rd, variant_data=vd)
+
+    @pytest.fixture
+    def reference_ht(self):
+        """Return a reference HT covering the four variant loci."""
+        positions = [1000, 2000, 3000, 4000]
+        return hl.Table.parallelize(
+            [
+                {"locus": hl.locus("chr1", p, reference_genome="GRCh38")}
+                for p in positions
+            ],
+            hl.tstruct(locus=hl.tlocus("GRCh38")),
+        ).key_by("locus")
+
+    @staticmethod
+    def _index_an(ht):
+        """Return a dict mapping sorted strata items to lists of per-row AN."""
+        strata_meta = hl.eval(ht.strata_meta)
+        rows = ht.collect()
+        out = {}
+        for i, m in enumerate(strata_meta):
+            key = tuple(sorted(m.items()))
+            out[key] = [r.AN[i] for r in rows]
+        return out
+
+    def test_reduce_matches_full_with_gen_anc_and_sex(
+        self, synthetic_vds, reference_ht
+    ):
+        """compute_allele_number_per_ref_site(reduce=True) matches the full output."""
+        vd = synthetic_vds.variant_data
+        strata_expr = [
+            {"gen_anc": vd.gen_anc},
+            {"sex": vd.sex},
+            {"gen_anc": vd.gen_anc, "sex": vd.sex},
+        ]
+
+        full_ht = compute_allele_number_per_ref_site(
+            synthetic_vds, reference_ht, strata_expr=strata_expr
+        )
+        reduced_ht = compute_allele_number_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            strata_expr=strata_expr,
+            reduce_to_minimal_groups=True,
+        )
+
+        full_indexed = self._index_an(full_ht)
+        reduced_indexed = self._index_an(reduced_ht)
+
+        # The strata_meta key sets must match exactly — reduction is
+        # transparent to callers.
+        assert set(full_indexed.keys()) == set(reduced_indexed.keys())
+        # Sanity check: the parent {raw} entry must be present and was
+        # decomposed into the gen_anc-by-sex leaves.
+        assert (("group", "raw"),) in full_indexed
+
+        for key in full_indexed:
+            assert full_indexed[key] == reduced_indexed[key], key

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -5,8 +5,10 @@ import logging
 import hail as hl
 import pytest
 
+from gnomad.utils.annotations import generate_freq_group_membership_array
 from gnomad.utils.sparse_mt import (
     compute_allele_number_per_ref_site,
+    compute_stats_per_ref_site,
     get_coverage_agg_func,
 )
 
@@ -496,3 +498,295 @@ class TestComputeAlleleNumberPerRefSiteReduceToMinimalGroups:
 
         for key in full_indexed:
             assert full_indexed[key] == reduced_indexed[key], key
+
+
+class TestComputeStatsPerRefSiteReducibleAggs:
+    """Test `reducible_aggs` mixes summable and non-summable aggregations under leaf reduction."""
+
+    @pytest.fixture
+    def synthetic_vds(self):
+        """8 samples × 4 sites VDS — same shape as the AN reduction test."""
+        samples = [
+            ("s1", "afr", "XX"),
+            ("s2", "afr", "XY"),
+            ("s3", "afr", "XX"),
+            ("s4", "afr", "XY"),
+            ("s5", "nfe", "XX"),
+            ("s6", "nfe", "XY"),
+            ("s7", "nfe", "XX"),
+            ("s8", "nfe", "XY"),
+        ]
+        positions = [1000, 2000, 3000, 4000]
+        variants = [
+            (hl.locus("chr1", p, reference_genome="GRCh38"), ["A", "T"])
+            for p in positions
+        ]
+        gt_patterns = [
+            [(0, 0), (0, 1), (1, 1), (0, 1), (0, 0), (0, 1), (1, 1), (0, 1)],
+            [(0, 1), None, (0, 0), (0, 1), (0, 1), (1, 1), None, (0, 1)],
+            [None, (0, 0), (0, 1), (1, 1), (0, 0), (0, 0), (0, 1), (1, 1)],
+            [(1, 1), (0, 1), (0, 1), None, (1, 1), (0, 1), (0, 1), (0, 0)],
+        ]
+
+        sample_table = hl.Table.parallelize(
+            [{"s": s, "gen_anc": g, "sex": x} for s, g, x in samples],
+            hl.tstruct(s=hl.tstr, gen_anc=hl.tstr, sex=hl.tstr),
+        ).key_by("s")
+
+        vd_entries = []
+        for v_idx, (locus, alleles) in enumerate(variants):
+            for s_idx, (sample_id, _, _) in enumerate(samples):
+                gt = gt_patterns[v_idx][s_idx]
+                vd_entries.append(
+                    {
+                        "locus": locus,
+                        "alleles": alleles,
+                        "s": sample_id,
+                        "GT": hl.call(*gt) if gt is not None else hl.missing(hl.tcall),
+                        # `adj=True` for every (variant, sample) so we can build
+                        # group_membership_hts with `group_label="adj"` (the
+                        # default) and exercise non-leaf parent targets like
+                        # `{"group": "adj"}` without needing the AD/DP/GQ
+                        # fields the auto-adj path would otherwise demand.
+                        "adj": True,
+                    }
+                )
+        vd = hl.Table.parallelize(
+            vd_entries,
+            hl.tstruct(
+                locus=hl.tlocus("GRCh38"),
+                alleles=hl.tarray(hl.tstr),
+                s=hl.tstr,
+                GT=hl.tcall,
+                adj=hl.tbool,
+            ),
+        ).to_matrix_table(row_key=["locus", "alleles"], col_key=["s"])
+        vd = vd.annotate_cols(
+            gen_anc=sample_table[vd.s].gen_anc,
+            sex=sample_table[vd.s].sex,
+        )
+
+        rd_entries = []
+        for locus, _ in variants:
+            for sample_id, _, _ in samples:
+                rd_entries.append(
+                    {"locus": locus, "s": sample_id, "END": locus.position, "LEN": 1}
+                )
+        rd = hl.Table.parallelize(
+            rd_entries,
+            hl.tstruct(
+                locus=hl.tlocus("GRCh38"),
+                s=hl.tstr,
+                END=hl.tint32,
+                LEN=hl.tint32,
+            ),
+        ).to_matrix_table(row_key=["locus"], col_key=["s"])
+
+        return hl.vds.VariantDataset(reference_data=rd, variant_data=vd)
+
+    @pytest.fixture
+    def reference_ht(self):
+        """Return a reference HT covering the four variant loci."""
+        return hl.Table.parallelize(
+            [
+                {"locus": hl.locus("chr1", p, reference_genome="GRCh38")}
+                for p in [1000, 2000, 3000, 4000]
+            ],
+            hl.tstruct(locus=hl.tlocus("GRCh38")),
+        ).key_by("locus")
+
+    @staticmethod
+    def _index(ht, ann):
+        meta = hl.eval(ht.strata_meta)
+        rows = ht.collect()
+        return {
+            tuple(sorted(m.items())): [r[ann][i] for r in rows]
+            for i, m in enumerate(meta)
+        }
+
+    def _build_group_membership_ht(self, vd, *, reduce: bool):
+        """Pre-build a group_membership_ht with `group_label="raw"` and `no_raw_group=True` to match the per-ref-site internal pattern (no adj filtering needed on entries — the test fixture's variant_data only has GT)."""
+        cols_ht = vd.cols()
+        strata_expr = [
+            {"gen_anc": cols_ht.gen_anc},
+            {"sex": cols_ht.sex},
+            {"gen_anc": cols_ht.gen_anc, "sex": cols_ht.sex},
+        ]
+        return generate_freq_group_membership_array(
+            cols_ht,
+            strata_expr,
+            no_raw_group=True,
+            reduce_to_minimal_groups=reduce,
+            group_label="raw",
+        )
+
+    # A fully-stratified leaf — survives reduction, so the
+    # `freq_meta.index(...)` lookup in agg_by_strata works against
+    # both the un-reduced and reduced freq_meta.
+    LEAF_TARGET = {"group": "raw", "gen_anc": "afr", "sex": "XX"}
+
+    def test_mixed_reducible_and_restricted_aggs_match_full(
+        self, synthetic_vds, reference_ht
+    ):
+        """AN goes through the leaf reduction; max_called is restricted to a leaf via entry_agg_group_membership; both match the full-fanout baseline.
+
+        The restriction target is a fully-stratified leaf so the
+        `freq_meta.index(...)` lookup succeeds against both the
+        un-reduced and the reduced `freq_meta`. Restricting a
+        non-summable aggregation to a non-leaf parent (e.g.
+        `{"group": "adj"}` against a gen_anc×sex stratification) is a
+        separate limitation of `agg_by_strata`'s lookup against the
+        reduced `freq_meta` — independent of the `reducible_aggs`
+        plumbing under test here.
+        """
+        vd = synthetic_vds.variant_data
+        full_gmh = self._build_group_membership_ht(vd, reduce=False)
+        reduced_gmh = self._build_group_membership_ht(vd, reduce=True)
+
+        entry_agg_funcs = {
+            "AN": (lambda t: t.GT.ploidy, hl.agg.sum),
+            "max_called": (lambda t: hl.int32(hl.is_defined(t.GT)), hl.agg.max),
+        }
+
+        full_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=full_gmh,
+            entry_agg_group_membership={"max_called": [self.LEAF_TARGET]},
+        )
+        reduced_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=reduced_gmh,
+            reducible_aggs={"AN"},
+            entry_agg_group_membership={"max_called": [self.LEAF_TARGET]},
+        )
+
+        full_an = self._index(full_ht, "AN")
+        reduced_an = self._index(reduced_ht, "AN")
+        assert set(full_an) == set(reduced_an)
+        for k in full_an:
+            assert full_an[k] == reduced_an[k], k
+
+        # max_called: same target leaf on both runs, so per-row length-1
+        # arrays should match element-for-element.
+        full_max = [r.max_called for r in full_ht.collect()]
+        reduced_max = [r.max_called for r in reduced_ht.collect()]
+        assert all(len(v) == 1 for v in full_max)
+        assert all(len(v) == 1 for v in reduced_max)
+        assert full_max == reduced_max
+
+    def test_reducible_aggs_overlap_with_entry_agg_group_membership_raises(
+        self, synthetic_vds, reference_ht
+    ):
+        """An annotation in BOTH reducible_aggs and entry_agg_group_membership raises."""
+        vd = synthetic_vds.variant_data
+        gmh = self._build_group_membership_ht(vd, reduce=True)
+        with pytest.raises(ValueError, match="disjoint"):
+            compute_stats_per_ref_site(
+                synthetic_vds,
+                reference_ht,
+                {"AN": (lambda t: t.GT.ploidy, hl.agg.sum)},
+                group_membership_ht=gmh,
+                reducible_aggs={"AN"},
+                entry_agg_group_membership={"AN": [self.LEAF_TARGET]},
+            )
+
+    def test_unaccounted_annotation_under_reduction_raises(
+        self, synthetic_vds, reference_ht
+    ):
+        """An annotation that is neither reducible nor restricted via entry_agg_group_membership raises when reduction is in effect."""
+        vd = synthetic_vds.variant_data
+        gmh = self._build_group_membership_ht(vd, reduce=True)
+        entry_agg_funcs = {
+            "AN": (lambda t: t.GT.ploidy, hl.agg.sum),
+            "max_called": (lambda t: hl.int32(hl.is_defined(t.GT)), hl.agg.max),
+        }
+        with pytest.raises(ValueError, match="no shape designation"):
+            compute_stats_per_ref_site(
+                synthetic_vds,
+                reference_ht,
+                entry_agg_funcs,
+                group_membership_ht=gmh,
+                reducible_aggs={"AN"},
+                # `max_called` is missing from BOTH reducible_aggs and
+                # entry_agg_group_membership — the guard should fire.
+            )
+
+    def _build_group_membership_ht_with_adj(self, vd, *, reduce: bool):
+        """Like `_build_group_membership_ht` but with `group_label='adj'` (the default) so freq_meta entries carry `group:adj` and a non-leaf parent like `{group:adj}` exists in `freq_meta_full`. Requires the variant_data MT to have an `adj` field."""
+        cols_ht = vd.cols()
+        strata_expr = [
+            {"gen_anc": cols_ht.gen_anc},
+            {"sex": cols_ht.sex},
+            {"gen_anc": cols_ht.gen_anc, "sex": cols_ht.sex},
+        ]
+        return generate_freq_group_membership_array(
+            cols_ht,
+            strata_expr,
+            reduce_to_minimal_groups=reduce,
+        )
+
+    def test_non_leaf_parent_target_under_reduction_matches_full(
+        self, synthetic_vds, reference_ht
+    ):
+        """`entry_agg_group_membership` target `{"group": "adj"}` is a non-leaf parent under reduction; the parent-resolution path in `agg_by_strata` synthesizes its sample-set as the union of its leaf-children and produces the same per-row values as the un-reduced run.
+
+        This is the gnomad_qc compute_coverage.py call shape: AN goes
+        through the reducible-aggs path; a non-summable annotation
+        (here `max_called`) is restricted to the global adj group via
+        `entry_agg_group_membership`. Under reduction the parent
+        `{"group": "adj"}` lives only in `freq_meta_full`; the
+        decomposition reconstructs its sample-set from the
+        gen_anc-by-sex leaves.
+        """
+        vd = synthetic_vds.variant_data
+        full_gmh = self._build_group_membership_ht_with_adj(vd, reduce=False)
+        reduced_gmh = self._build_group_membership_ht_with_adj(vd, reduce=True)
+
+        # Sanity-check the structural shape so a future regression in
+        # find_minimal_strata_groups (e.g., promoting the root to a
+        # leaf) is caught here rather than as a silent value mismatch.
+        reduced_freq_meta = hl.eval(reduced_gmh.freq_meta)
+        reduced_freq_meta_full = hl.eval(reduced_gmh.freq_meta_full)
+        assert {"group": "adj"} in [dict(m) for m in reduced_freq_meta_full]
+        assert {"group": "adj"} not in [dict(m) for m in reduced_freq_meta]
+
+        entry_agg_funcs = {
+            "AN": (lambda t: t.GT.ploidy, hl.agg.sum),
+            "max_called": (lambda t: hl.int32(hl.is_defined(t.GT)), hl.agg.max),
+        }
+        adj_target = {"group": "adj"}
+
+        full_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=full_gmh,
+            entry_agg_group_membership={"max_called": [adj_target]},
+        )
+        reduced_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=reduced_gmh,
+            reducible_aggs={"AN"},
+            entry_agg_group_membership={"max_called": [adj_target]},
+        )
+
+        # AN: full strata_meta and per-strata values match.
+        full_an = self._index(full_ht, "AN")
+        reduced_an = self._index(reduced_ht, "AN")
+        assert set(full_an) == set(reduced_an)
+        for k in full_an:
+            assert full_an[k] == reduced_an[k], k
+
+        # max_called: a single value per row, matching the {group:adj}
+        # entry from the un-reduced run.
+        full_max = [r.max_called for r in full_ht.collect()]
+        reduced_max = [r.max_called for r in reduced_ht.collect()]
+        assert all(len(v) == 1 for v in full_max)
+        assert all(len(v) == 1 for v in reduced_max)
+        assert full_max == reduced_max

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -499,6 +499,17 @@ class TestComputeAlleleNumberPerRefSiteReduceToMinimalGroups:
         for key in full_indexed:
             assert full_indexed[key] == reduced_indexed[key], key
 
+        # Direct invariant check: the all-samples AN must equal the
+        # element-wise sum of the gen_anc-by-sex leaf ANs. This catches
+        # the case where both the full and reduced paths agree but the
+        # underlying math is wrong.
+        leaf_keys = [
+            k for k in full_indexed if "gen_anc" in dict(k) and "sex" in dict(k)
+        ]
+        leaf_values = [full_indexed[k] for k in leaf_keys]
+        leaf_sums = [sum(vals) for vals in zip(*leaf_values)]
+        assert full_indexed[(("group", "raw"),)] == leaf_sums
+
 
 class TestComputeStatsPerRefSiteReducibleAggs:
     """Test `reducible_aggs` mixes summable and non-summable aggregations under leaf reduction."""

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -681,7 +681,7 @@ class TestComputeStatsPerRefSiteReducibleAggs:
     def test_reducible_aggs_overlap_with_entry_agg_group_membership_raises(
         self, synthetic_vds, reference_ht
     ):
-        """An annotation in BOTH reducible_aggs and entry_agg_group_membership raises."""
+        """An annotation in BOTH reducible_aggs and entry_agg_group_membership raises ValueError."""
         vd = synthetic_vds.variant_data
         gmh = self._build_group_membership_ht(vd, reduce=True)
         with pytest.raises(ValueError, match="disjoint"):


### PR DESCRIPTION
Adds reduce_to_minimal_groups=True, which aggregates per-variant call stats only on the "leaf" freq_meta groups and reconstructs the rest by element-wise summation. Off by default; output is identical to a non-reduced run.

New helpers find_minimal_strata_groups and expand_strata_array_from_leaves. Leaf detection validates each candidate decomposition by sample count, which avoids double-counting in multi-family freq_meta shapes (e.g., gen_anc × sex alongside gatk_version × gen_anc).

Adds non_summable_strata (default {"downsampling"}) and a group_label param on generate_freq_group_membership_array.