### PR TITLE
Fix reduced parent hist lowering by forcing groups to be leafs

### DIFF
--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2489,9 +2489,9 @@ def generate_freq_group_membership_array(
         Default is None, which resolves to `{"downsampling"}`.
     :param force_leaf_groups: Optional list of `freq_meta` dicts to keep
         as leaves under `reduce_to_minimal_groups` (see
-        `find_minimal_strata_groups`). Pass the groups a downstream caller
-        pins non-reducible aggregations to so they stay directly computed
-        rather than reconstructed per row. Default is None.
+        `find_minimal_strata_groups`). Use this for groups that downstream
+    code accesses directly, so they remain explicitly computed instead
+    of being reconstructed per row from child groups
     :param group_label: Value to use for the `"group"` key on every
         constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
         for callers that don't apply any genotype-level filtering (e.g.,

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -3012,8 +3012,20 @@ def agg_by_strata(
                 s_indices_per_target.append(ht.indices_by_group[payload])
                 adj_per_target.append(ht.adj_groups[payload])
             else:  # parent
+                # Reconstruct the parent's sample set as a single flat
+                # index array (OR of its disjoint leaf-children's
+                # per-sample membership) instead of flattening an
+                # array-of-index-arrays. The flat form matches the leaf
+                # path's shape, so aggregators like `hl.agg.hist` lower
+                # correctly; the array-of-arrays flatten does not.
                 s_indices_per_target.append(
-                    hl.flatten(hl.array([ht.indices_by_group[lp] for lp in payload]))
+                    hl.range(hl.len(ht.cols)).filter(
+                        lambda s_i: hl.any(
+                            hl.array(
+                                [ht.cols[s_i].group_membership[lp] for lp in payload]
+                            )
+                        )
+                    )
                 )
                 adj_per_target.append(hl.literal(adj))
         return hl.array(s_indices_per_target), hl.array(adj_per_target)

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -3039,12 +3039,14 @@ def agg_by_strata(
                 s_indices_per_target.append(ht.indices_by_group[payload])
                 adj_per_target.append(ht.adj_groups[payload])
             else:  # parent
-                # Reconstruct the parent's sample set as a single flat
-                # index array (OR of its disjoint leaf-children's
-                # per-sample membership) instead of flattening an
-                # array-of-index-arrays. The flat form matches the leaf
-                # path's shape, so aggregators like `hl.agg.hist` lower
-                # correctly; the array-of-arrays flatten does not.
+# Reconstruct the parent's sample set as a single flat
+# index array (OR of its disjoint leaf-children's
+# per-sample membership) instead of flattening an
+# array-of-index-arrays. The flat form matches the IR shape of
+# the leaf path, which lets aggregators like `hl.agg.hist` lower
+# correctly. The previous approach — hl.flatten(array of per-leaf
+# index arrays) — has the same values but a different IR shape
+# that Hail cannot lower for these aggregators.
                 s_indices_per_target.append(
                     hl.range(hl.len(ht.cols)).filter(
                         lambda s_i: hl.any(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2489,8 +2489,8 @@ def generate_freq_group_membership_array(
     :param force_leaf_groups: Optional list of `freq_meta` dicts to keep
         as leaves under `reduce_to_minimal_groups` (see
         `find_minimal_strata_groups`). Use this for groups that downstream
-    code accesses directly, so they remain explicitly computed instead
-    of being reconstructed per row from child groups
+        code accesses directly, so they remain explicitly computed instead
+        of being reconstructed per row from child groups.
     :param group_label: Value to use for the `"group"` key on every
         constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
         for callers that don't apply any genotype-level filtering (e.g.,

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2130,6 +2130,7 @@ def find_minimal_strata_groups(
     freq_meta: List[Dict[str, str]],
     freq_meta_sample_count: List[int],
     non_summable_strata: Optional[Set[str]] = None,
+    force_leaf_groups: Optional[List[Dict[str, str]]] = None,
 ) -> Tuple[List[int], Dict[int, List[int]]]:
     """
     Identify the minimal "leaf" set of stratification groups in a `freq_meta`.
@@ -2180,6 +2181,16 @@ def find_minimal_strata_groups(
         `freq_meta`. Used to validate candidate decompositions.
     :param non_summable_strata: Strata names that should never be summed
         across their values. Default is `{"downsampling"}`.
+    :param force_leaf_groups: Optional list of `freq_meta` dicts to retain
+        as leaves even if they would otherwise be reconstructed as the
+        sum of other groups. Use this for groups that a downstream caller
+        pins a non-reducible aggregation to (via
+        `entry_agg_group_membership`): keeping them as leaves means they
+        are computed directly (a cheap index lookup) rather than rebuilt
+        per row from their leaf-children, which both avoids the
+        reconstruction cost and keeps the aggregation lowerable. Matched
+        by exact dict equality against `freq_meta` entries. Default is
+        None (no forced leaves).
     :return: Tuple of `(leaf_indices, decomposition)`. `leaf_indices` is a
         list of indices into `freq_meta` marking the leaves, in ascending
         order. `decomposition` maps each non-leaf index to the list of
@@ -2195,6 +2206,8 @@ def find_minimal_strata_groups(
         non_summable_strata = {"downsampling"}
     else:
         non_summable_strata = set(non_summable_strata)
+
+    force_leaf_set = {frozenset(d.items()) for d in (force_leaf_groups or [])}
 
     def summable_strata_of(entry: Dict[str, str]) -> frozenset:
         return frozenset(
@@ -2229,6 +2242,13 @@ def find_minimal_strata_groups(
         for idx in partition_indices:
             if summable_strata_of(freq_meta[idx]) in leaf_strata_sets:
                 is_leaf[idx] = True
+
+        # Retain caller-requested groups as leaves so they are computed
+        # directly instead of reconstructed from their leaf-children.
+        if force_leaf_set:
+            for idx in partition_indices:
+                if frozenset(freq_meta[idx].items()) in force_leaf_set:
+                    is_leaf[idx] = True
 
         # Decompose non-leaves using only same-partition leaves.
         leaf_indices_in_partition = [idx for idx in partition_indices if is_leaf[idx]]
@@ -2400,6 +2420,7 @@ def generate_freq_group_membership_array(
     no_raw_group: bool = False,
     reduce_to_minimal_groups: bool = False,
     non_summable_strata: Optional[Set[str]] = None,
+    force_leaf_groups: Optional[List[Dict[str, str]]] = None,
     group_label: str = "adj",
 ) -> hl.Table:
     """
@@ -2466,6 +2487,11 @@ def generate_freq_group_membership_array(
     :param non_summable_strata: Strata names that should never be summed
         across their values when `reduce_to_minimal_groups` is True.
         Default is None, which resolves to `{"downsampling"}`.
+    :param force_leaf_groups: Optional list of `freq_meta` dicts to keep
+        as leaves under `reduce_to_minimal_groups` (see
+        `find_minimal_strata_groups`). Pass the groups a downstream caller
+        pins non-reducible aggregations to so they stay directly computed
+        rather than reconstructed per row. Default is None.
     :param group_label: Value to use for the `"group"` key on every
         constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
         for callers that don't apply any genotype-level filtering (e.g.,
@@ -2624,6 +2650,7 @@ def generate_freq_group_membership_array(
             freq_meta_full,
             freq_meta_sample_count_full,
             non_summable_strata=non_summable_strata,
+            force_leaf_groups=force_leaf_groups,
         )
 
         n_full = len(freq_meta_full)

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2181,16 +2181,15 @@ def find_minimal_strata_groups(
         `freq_meta`. Used to validate candidate decompositions.
     :param non_summable_strata: Strata names that should never be summed
         across their values. Default is `{"downsampling"}`.
-    :param force_leaf_groups: Optional list of `freq_meta` dicts to retain
-        as leaves even if they would otherwise be reconstructed as the
-        sum of other groups. Use this for groups that a downstream caller
-        pins a non-reducible aggregation to (via
-        `entry_agg_group_membership`): keeping them as leaves means they
-        are computed directly (a cheap index lookup) rather than rebuilt
-        per row from their leaf-children, which both avoids the
-        reconstruction cost and keeps the aggregation lowerable. Matched
-        by exact dict equality against `freq_meta` entries. Default is
-        None (no forced leaves).
+    :param force_leaf_groups: :param force_leaf_groups: Optional list of `freq_meta` dicts to retain
+    as leaf groups even if they would otherwise be reconstructed from
+    other groups under `reduce_to_minimal_groups`. Use this for groups
+    that downstream code accesses directly via
+    `entry_agg_group_membership`, so they remain directly materialized
+    instead of being rebuilt per row from their leaf children. This
+    avoids repeated reconstruction overhead for frequently accessed
+    groups. Entries are matched by exact dict equality against
+    `freq_meta` entries. Default is None (no forced leaves).
     :return: Tuple of `(leaf_indices, decomposition)`. `leaf_indices` is a
         list of indices into `freq_meta` marking the leaves, in ascending
         order. `decomposition` maps each non-leaf index to the list of

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -3038,14 +3038,14 @@ def agg_by_strata(
                 s_indices_per_target.append(ht.indices_by_group[payload])
                 adj_per_target.append(ht.adj_groups[payload])
             else:  # parent
-# Reconstruct the parent's sample set as a single flat
-# index array (OR of its disjoint leaf-children's
-# per-sample membership) instead of flattening an
-# array-of-index-arrays. The flat form matches the IR shape of
-# the leaf path, which lets aggregators like `hl.agg.hist` lower
-# correctly. The previous approach — hl.flatten(array of per-leaf
-# index arrays) — has the same values but a different IR shape
-# that Hail cannot lower for these aggregators.
+                # Reconstruct the parent's sample set as a single flat
+                # index array (OR of its disjoint leaf-children's
+                # per-sample membership) instead of flattening an
+                # array-of-index-arrays. The flat form matches the IR shape of
+                # the leaf path, which lets aggregators like `hl.agg.hist` lower
+                # correctly. The previous approach — hl.flatten(array of per-leaf
+                # index arrays) — has the same values but a different IR shape
+                # that Hail cannot lower for these aggregators.
                 s_indices_per_target.append(
                     hl.range(hl.len(ht.cols)).filter(
                         lambda s_i: hl.any(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2181,15 +2181,15 @@ def find_minimal_strata_groups(
         `freq_meta`. Used to validate candidate decompositions.
     :param non_summable_strata: Strata names that should never be summed
         across their values. Default is `{"downsampling"}`.
-    :param force_leaf_groups: :param force_leaf_groups: Optional list of `freq_meta` dicts to retain
-    as leaf groups even if they would otherwise be reconstructed from
-    other groups under `reduce_to_minimal_groups`. Use this for groups
-    that downstream code accesses directly via
-    `entry_agg_group_membership`, so they remain directly materialized
-    instead of being rebuilt per row from their leaf children. This
-    avoids repeated reconstruction overhead for frequently accessed
-    groups. Entries are matched by exact dict equality against
-    `freq_meta` entries. Default is None (no forced leaves).
+    :param force_leaf_groups: Optional list of `freq_meta` dicts to retain
+        as leaf groups even if they would otherwise be reconstructed from
+        other groups under `reduce_to_minimal_groups`. Use this for groups
+        that downstream code accesses directly via
+        `entry_agg_group_membership`, so they remain directly materialized
+        instead of being rebuilt per row from their leaf children. This
+        avoids repeated reconstruction overhead for frequently accessed
+        groups. Entries are matched by exact dict equality against
+        `freq_meta` entries. Default is None (no forced leaves).
     :return: Tuple of `(leaf_indices, decomposition)`. `leaf_indices` is a
         list of indices into `freq_meta` marking the leaves, in ascending
         order. `decomposition` maps each non-leaf index to the list of

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -2142,6 +2142,44 @@ class TestFindMinimalStrataGroups:
             4: [6, 8],
         }
 
+    def test_force_leaf_groups_retains_pinned_overall_group(self):
+        """A group in force_leaf_groups stays a leaf instead of being decomposed.
+
+        Without force_leaf_groups the bare {"group": "raw"} entry (index
+        0) is a parent that decomposes into the gen_anc×sex leaves (see
+        test_all_raw_partition). Pinning it via force_leaf_groups keeps
+        it directly computed — what compute_coverage needs so its
+        coverage_stats/qual_hists targets stay cheap index lookups under
+        leaf reduction instead of per-row parent reconstruction.
+        """
+        freq_meta = [
+            {"group": "raw"},
+            {"group": "raw", "gen_anc": "afr"},
+            {"group": "raw", "gen_anc": "nfe"},
+            {"group": "raw", "sex": "XX"},
+            {"group": "raw", "sex": "XY"},
+            {"group": "raw", "gen_anc": "afr", "sex": "XX"},
+            {"group": "raw", "gen_anc": "afr", "sex": "XY"},
+            {"group": "raw", "gen_anc": "nfe", "sex": "XX"},
+            {"group": "raw", "gen_anc": "nfe", "sex": "XY"},
+        ]
+        sample_count = [100, 40, 60, 50, 50, 20, 20, 30, 30]
+
+        leaves, decomp = find_minimal_strata_groups(
+            freq_meta, sample_count, force_leaf_groups=[{"group": "raw"}]
+        )
+
+        # Index 0 is now a leaf and absent from the decomposition; the
+        # other parents decompose exactly as before.
+        assert leaves == [0, 5, 6, 7, 8]
+        assert 0 not in decomp
+        assert decomp == {
+            1: [5, 6],
+            2: [7, 8],
+            3: [5, 7],
+            4: [6, 8],
+        }
+
     def test_global_downsampling_stays_leaf(self):
         """Downsampling-only entries stay leaves; the all-adj entry can't decompose into them."""
         freq_meta = [

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -643,12 +643,10 @@ class TestComputeStatsPerRefSiteReducibleAggs:
 
         The restriction target is a fully-stratified leaf so the
         `freq_meta.index(...)` lookup succeeds against both the
-        un-reduced and the reduced `freq_meta`. Restricting a
-        non-summable aggregation to a non-leaf parent (e.g.
-        `{"group": "adj"}` against a gen_anc×sex stratification) is a
-        separate limitation of `agg_by_strata`'s lookup against the
-        reduced `freq_meta` — independent of the `reducible_aggs`
-        plumbing under test here.
+        un-reduced and the reduced `freq_meta`. The non-leaf parent
+        target case (e.g. `{"group": "raw", "gen_anc": "afr"}` against a
+        gen_anc×sex stratification) is covered separately by
+        `test_hist_restricted_to_nonleaf_parent_matches_full`.
         """
         vd = synthetic_vds.variant_data
         full_gmh = self._build_group_membership_ht(vd, reduce=False)
@@ -688,6 +686,71 @@ class TestComputeStatsPerRefSiteReducibleAggs:
         assert all(len(v) == 1 for v in full_max)
         assert all(len(v) == 1 for v in reduced_max)
         assert full_max == reduced_max
+
+    # A non-leaf parent under the gen_anc×sex stratification: it
+    # decomposes to the {afr,XX} and {afr,XY} leaves. Exercises the
+    # parent-reconstruction path in agg_by_strata that previously
+    # produced an un-lowerable IR for `hl.agg.hist`.
+    PARENT_TARGET = {"group": "raw", "gen_anc": "afr"}
+
+    def test_hist_restricted_to_nonleaf_parent_matches_full(
+        self, synthetic_vds, reference_ht
+    ):
+        """A `hl.agg.hist` non-reducible agg pinned to a non-leaf parent target matches the full-fanout baseline under leaf reduction.
+
+        Regression test for the Hail lowering failure where a parent
+        target's sample set was reconstructed as a flattened
+        array-of-index-arrays; `hl.agg.hist` over that form failed to
+        lower. The parent set is now built as a single flat index array
+        (OR of its disjoint leaf-children's membership), matching the
+        leaf path's shape.
+        """
+        vd = synthetic_vds.variant_data
+        full_gmh = self._build_group_membership_ht(vd, reduce=False)
+        reduced_gmh = self._build_group_membership_ht(vd, reduce=True)
+
+        entry_agg_funcs = {
+            "AN": (lambda t: t.GT.ploidy, hl.agg.sum),
+            "alt_hist": (
+                lambda t: t.GT.n_alt_alleles(),
+                lambda x: hl.agg.hist(x, 0, 2, 2),
+            ),
+        }
+
+        full_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=full_gmh,
+            entry_agg_group_membership={"alt_hist": [self.PARENT_TARGET]},
+        )
+        reduced_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=reduced_gmh,
+            reducible_aggs={"AN"},
+            entry_agg_group_membership={"alt_hist": [self.PARENT_TARGET]},
+        )
+
+        full_an = self._index(full_ht, "AN")
+        reduced_an = self._index(reduced_ht, "AN")
+        assert set(full_an) == set(reduced_an)
+        for k in full_an:
+            assert full_an[k] == reduced_an[k], k
+
+        # The parent-restricted hist must be identical between the
+        # full-fanout and reduced runs (same afr sample set, same bins).
+        full_hist = [r.alt_hist for r in full_ht.collect()]
+        reduced_hist = [r.alt_hist for r in reduced_ht.collect()]
+        assert all(len(v) == 1 for v in full_hist)
+        assert all(len(v) == 1 for v in reduced_hist)
+        for f_row, r_row in zip(full_hist, reduced_hist):
+            f, r = f_row[0], r_row[0]
+            assert f.bin_edges == r.bin_edges
+            assert f.bin_freq == r.bin_freq
+            assert f.n_smaller == r.n_smaller
+            assert f.n_larger == r.n_larger
 
     def test_reducible_aggs_overlap_with_entry_agg_group_membership_raises(
         self, synthetic_vds, reference_ht


### PR DESCRIPTION
Hail couldn't handle this function when applied to hists. This will be passed onto the hail team. This is a work around that should have been a feature to start. Essentially it forces groups to be leafs, like 'raw', if you do not want to use the other groups sum as their value. 