### PR TITLE
Update hadoop to hailtop after hail's hadoop deprecation

### DIFF
--- a/gnomad/assessment/parse_validity_logs.py
+++ b/gnomad/assessment/parse_validity_logs.py
@@ -2,7 +2,7 @@
 
 import re
 
-import hail as hl
+import hailtop.fs as hfs
 
 
 def parse_log_file(log_file):
@@ -38,7 +38,7 @@ def parse_log_file(log_file):
         "load_gnomad_data": "load gnomAD data",
     }
 
-    with hl.hadoop_open(log_file, "r") as f:
+    with hfs.open(log_file, "r") as f:
         current_message = ""
         current_table = []
         current_metadata = None  # Stores log metadata before a table appears.
@@ -288,5 +288,5 @@ def generate_html_report(parsed_logs, output_file):
 
     html_template += "</table></body></html>"
 
-    with hl.hadoop_open(output_file, "w") as f:
+    with hfs.open(output_file, "w") as f:
         f.write(html_template)

--- a/gnomad/utils/file_utils.py
+++ b/gnomad/utils/file_utils.py
@@ -9,6 +9,7 @@ import uuid
 from typing import List, Optional, Tuple, Union
 
 import hail as hl
+import hailtop.fs as hfs
 
 from gnomad.resources.resource_utils import DataException
 
@@ -36,14 +37,8 @@ def file_exists(fname: str) -> bool:
     else:
         paths = [fname]
 
-    if fname.startswith("gs://"):
-        exists_func = hl.hadoop_exists
-    else:
-        exists_func = os.path.isfile
-
-    exists = all([exists_func(p) for p in paths])
-
-    return exists
+    # hfs.exists handles local, gs://, and other cloud schemes uniformly.
+    return all(hfs.exists(p) for p in paths)
 
 
 def check_file_exists_raise_error(
@@ -177,7 +172,7 @@ def read_list_data(input_file_path: str) -> List[str]:
     :return: List of lines
     """
     if input_file_path.startswith("gs://"):
-        hl.hadoop_copy(input_file_path, "file:///" + input_file_path.split("/")[-1])
+        hfs.copy(input_file_path, "file:///" + input_file_path.split("/")[-1])
         f = (
             gzip.open("/" + os.path.basename(input_file_path), encoding="utf-8")
             if input_file_path.endswith("gz")

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -353,9 +353,12 @@ def _ls(path: str) -> List[Dict]:
     """
     List a path via `hailtop.fs`, mirroring the deprecated `hl.hadoop_ls`.
 
-    Unlike `hl.hadoop_ls`, `hfs.ls` lists hidden files (e.g. the local
-    filesystem's `.crc` checksum files). Hidden entries (basename starting with
-    `.`) are dropped so downstream `part-*` parsing matches the prior behavior.
+    Hidden entries (basename starting with `.`) are dropped as a defensive
+    measure so downstream `part-*` parsing matches the prior behavior. In
+    practice this chiefly affects the local filesystem's `.crc` checksum files,
+    which the Spark backend's JVM Hadoop FS hides from `hl.hadoop_ls` but
+    `hfs.ls` does not. For GCS paths (and on the Batch backend, where
+    `hl.hadoop_ls` and `hfs.ls` share the same filesystem) this is a no-op.
 
     :param path: Path to list.
     :return: List of legacy `hl.hadoop_ls`-style dicts (with `path`,

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List, Optional, Union
 
 import bokeh
 import hail as hl
+import hailtop.fs as hfs
 import numpy as np
 import pandas as pd
 from bokeh.layouts import gridplot
@@ -358,7 +359,7 @@ def plot_hail_file_metadata(
     panel_size = 600
     subpanel_size = 150
 
-    files = hl.hadoop_ls(t_path)
+    files = [x.to_legacy_dict() for x in hfs.ls(t_path)]
     rows_file = [x["path"] for x in files if x["path"].endswith("rows")]
     entries_file = [x["path"] for x in files if x["path"].endswith("entries")]
     # cols_file = [x['path'] for x in files if x['path'].endswith('cols')]
@@ -373,19 +374,19 @@ def plot_hail_file_metadata(
         logger.warning("No metadata file found. Exiting...")
         return None
 
-    with hl.hadoop_open(metadata_file[0], "rb") as f:
+    with hfs.open(metadata_file[0], "rb") as f:
         overall_meta = json.loads(f.read())
         rows_per_partition = overall_meta["components"]["partition_counts"]["counts"]
 
     if not rows_file:
         logger.warning("No rows directory found. Exiting...")
         return None
-    rows_files = hl.hadoop_ls(rows_file[0])
+    rows_files = [x.to_legacy_dict() for x in hfs.ls(rows_file[0])]
 
     if entries_file:
         data_type = "MatrixTable"
         rows_file = [x["path"] for x in rows_files if x["path"].endswith("rows")]
-        rows_files = hl.hadoop_ls(rows_file[0])
+        rows_files = [x.to_legacy_dict() for x in hfs.ls(rows_file[0])]
     row_partition_bounds, row_file_sizes = get_rows_data(rows_files)
 
     total_file_size, row_file_sizes, row_scale = scale_file_sizes(row_file_sizes)
@@ -425,12 +426,12 @@ def plot_hail_file_metadata(
     }
 
     if entries_file:
-        entries_rows_files = hl.hadoop_ls(entries_file[0])
+        entries_rows_files = [x.to_legacy_dict() for x in hfs.ls(entries_file[0])]
         entries_rows_file = [
             x["path"] for x in entries_rows_files if x["path"].endswith("rows")
         ]
         if entries_rows_file:
-            entries_files = hl.hadoop_ls(entries_rows_file[0])
+            entries_files = [x.to_legacy_dict() for x in hfs.ls(entries_rows_file[0])]
             entry_partition_bounds, entry_file_sizes = get_rows_data(entries_files)
             total_entry_file_size, entry_file_sizes, entry_scale = scale_file_sizes(
                 entry_file_sizes
@@ -611,7 +612,7 @@ def get_rows_data(rows_files):  # noqa: D103
     partition_bounds = []
     parts_file = [x["path"] for x in rows_files if x["path"].endswith("parts")]
     if parts_file:
-        parts = hl.hadoop_ls(parts_file[0])
+        parts = [x.to_legacy_dict() for x in hfs.ls(parts_file[0])]
         for i, x in enumerate(parts):
             index = x["path"].split(f"{parts_file[0]}/part-")[1].split("-")[0]
             if i < len(parts) - 1:
@@ -627,7 +628,7 @@ def get_rows_data(rows_files):  # noqa: D103
         x["path"] for x in rows_files if x["path"].endswith("metadata.json.gz")
     ]
     if metadata_file:
-        with hl.hadoop_open(metadata_file[0], "rb") as f:
+        with hfs.open(metadata_file[0], "rb") as f:
             rows_meta = json.loads(f.read())
             try:
                 partition_bounds = [

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -353,21 +353,23 @@ def _ls(path: str) -> List[Dict]:
     """
     List a path via `hailtop.fs`, mirroring the deprecated `hl.hadoop_ls`.
 
-    Hidden entries (basename starting with `.`) are dropped as a defensive
-    measure so downstream `part-*` parsing matches the prior behavior. In
-    practice this chiefly affects the local filesystem's `.crc` checksum files,
-    which the Spark backend's JVM Hadoop FS hides from `hl.hadoop_ls` but
-    `hfs.ls` does not. For GCS paths (and on the Batch backend, where
-    `hl.hadoop_ls` and `hfs.ls` share the same filesystem) this is a no-op.
+    `.crc` checksum files are dropped so downstream `part-*` parsing matches the
+    prior behavior. On the Spark backend's JVM Hadoop FS, `hl.hadoop_ls` lists
+    other hidden dotfiles but hides `.crc` checksum files, whereas `hfs.ls`
+    lists `.crc` files too; dropping only `.crc` here mirrors the old behavior.
+    For GCS paths (and on the Batch backend, where `hl.hadoop_ls` and `hfs.ls`
+    share the same filesystem) there are no `.crc` files, so this is a no-op.
+
+    See https://github.com/hail-is/hail/pull/15182 for the deprecation.
 
     :param path: Path to list.
     :return: List of legacy `hl.hadoop_ls`-style dicts (with `path`,
-        `size_bytes`, `modification_time`, etc.) for non-hidden entries.
+        `size_bytes`, `modification_time`, etc.), excluding `.crc` files.
     """
     return [
         entry.to_legacy_dict()
         for entry in hfs.ls(path)
-        if not os.path.basename(entry.path).startswith(".")
+        if not os.path.basename(entry.path).endswith(".crc")
     ]
 
 
@@ -399,7 +401,8 @@ def plot_hail_file_metadata(
         return None
 
     # `hfs.open` does not auto-decompress gzipped files (unlike the deprecated
-    # `hl.hadoop_open`), so decompress the gzipped metadata explicitly.
+    # `hl.hadoop_open`), so decompress the gzipped metadata explicitly. See
+    # https://github.com/hail-is/hail/pull/15182 for the deprecation.
     with hfs.open(metadata_file[0], "rb") as raw_f, gzip.open(raw_f) as f:
         overall_meta = json.loads(f.read())
         rows_per_partition = overall_meta["components"]["partition_counts"]["counts"]
@@ -655,6 +658,7 @@ def get_rows_data(rows_files):  # noqa: D103
     ]
     if metadata_file:
         # `hfs.open` does not auto-decompress gzipped files, so decompress here.
+        # See https://github.com/hail-is/hail/pull/15182 for the deprecation.
         with hfs.open(metadata_file[0], "rb") as raw_f, gzip.open(raw_f) as f:
             rows_meta = json.loads(f.read())
             try:

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -349,14 +349,17 @@ def linear_and_log_tabs(plot_func: Callable, **kwargs) -> Tabs:  # noqa: D103
     return Tabs(tabs=panels)
 
 
-def _ls(path: str) -> List[dict]:
-    """List `path` via hailtop.fs, mirroring the deprecated `hl.hadoop_ls`.
+def _ls(path: str) -> List[Dict]:
+    """
+    List a path via `hailtop.fs`, mirroring the deprecated `hl.hadoop_ls`.
 
     Unlike `hl.hadoop_ls`, `hfs.ls` lists hidden files (e.g. the local
     filesystem's `.crc` checksum files). Hidden entries (basename starting with
     `.`) are dropped so downstream `part-*` parsing matches the prior behavior.
-    The returned dicts use the legacy `hl.hadoop_ls` schema (`path`,
-    `size_bytes`, `modification_time`, ...).
+
+    :param path: Path to list.
+    :return: List of legacy `hl.hadoop_ls`-style dicts (with `path`,
+        `size_bytes`, `modification_time`, etc.) for non-hidden entries.
     """
     return [
         entry.to_legacy_dict()

--- a/gnomad/utils/plotting.py
+++ b/gnomad/utils/plotting.py
@@ -1,7 +1,9 @@
 # noqa: D100
 
+import gzip
 import json
 import logging
+import os
 from typing import Callable, Dict, List, Optional, Union
 
 import bokeh
@@ -347,6 +349,22 @@ def linear_and_log_tabs(plot_func: Callable, **kwargs) -> Tabs:  # noqa: D103
     return Tabs(tabs=panels)
 
 
+def _ls(path: str) -> List[dict]:
+    """List `path` via hailtop.fs, mirroring the deprecated `hl.hadoop_ls`.
+
+    Unlike `hl.hadoop_ls`, `hfs.ls` lists hidden files (e.g. the local
+    filesystem's `.crc` checksum files). Hidden entries (basename starting with
+    `.`) are dropped so downstream `part-*` parsing matches the prior behavior.
+    The returned dicts use the legacy `hl.hadoop_ls` schema (`path`,
+    `size_bytes`, `modification_time`, ...).
+    """
+    return [
+        entry.to_legacy_dict()
+        for entry in hfs.ls(path)
+        if not os.path.basename(entry.path).startswith(".")
+    ]
+
+
 def plot_hail_file_metadata(
     t_path: str,
 ) -> Optional[Union[Grid, Tabs, bokeh.plotting.figure]]:
@@ -359,7 +377,7 @@ def plot_hail_file_metadata(
     panel_size = 600
     subpanel_size = 150
 
-    files = [x.to_legacy_dict() for x in hfs.ls(t_path)]
+    files = _ls(t_path)
     rows_file = [x["path"] for x in files if x["path"].endswith("rows")]
     entries_file = [x["path"] for x in files if x["path"].endswith("entries")]
     # cols_file = [x['path'] for x in files if x['path'].endswith('cols')]
@@ -374,19 +392,21 @@ def plot_hail_file_metadata(
         logger.warning("No metadata file found. Exiting...")
         return None
 
-    with hfs.open(metadata_file[0], "rb") as f:
+    # `hfs.open` does not auto-decompress gzipped files (unlike the deprecated
+    # `hl.hadoop_open`), so decompress the gzipped metadata explicitly.
+    with hfs.open(metadata_file[0], "rb") as raw_f, gzip.open(raw_f) as f:
         overall_meta = json.loads(f.read())
         rows_per_partition = overall_meta["components"]["partition_counts"]["counts"]
 
     if not rows_file:
         logger.warning("No rows directory found. Exiting...")
         return None
-    rows_files = [x.to_legacy_dict() for x in hfs.ls(rows_file[0])]
+    rows_files = _ls(rows_file[0])
 
     if entries_file:
         data_type = "MatrixTable"
         rows_file = [x["path"] for x in rows_files if x["path"].endswith("rows")]
-        rows_files = [x.to_legacy_dict() for x in hfs.ls(rows_file[0])]
+        rows_files = _ls(rows_file[0])
     row_partition_bounds, row_file_sizes = get_rows_data(rows_files)
 
     total_file_size, row_file_sizes, row_scale = scale_file_sizes(row_file_sizes)
@@ -426,12 +446,12 @@ def plot_hail_file_metadata(
     }
 
     if entries_file:
-        entries_rows_files = [x.to_legacy_dict() for x in hfs.ls(entries_file[0])]
+        entries_rows_files = _ls(entries_file[0])
         entries_rows_file = [
             x["path"] for x in entries_rows_files if x["path"].endswith("rows")
         ]
         if entries_rows_file:
-            entries_files = [x.to_legacy_dict() for x in hfs.ls(entries_rows_file[0])]
+            entries_files = _ls(entries_rows_file[0])
             entry_partition_bounds, entry_file_sizes = get_rows_data(entries_files)
             total_entry_file_size, entry_file_sizes, entry_scale = scale_file_sizes(
                 entry_file_sizes
@@ -612,7 +632,7 @@ def get_rows_data(rows_files):  # noqa: D103
     partition_bounds = []
     parts_file = [x["path"] for x in rows_files if x["path"].endswith("parts")]
     if parts_file:
-        parts = [x.to_legacy_dict() for x in hfs.ls(parts_file[0])]
+        parts = _ls(parts_file[0])
         for i, x in enumerate(parts):
             index = x["path"].split(f"{parts_file[0]}/part-")[1].split("-")[0]
             if i < len(parts) - 1:
@@ -628,7 +648,8 @@ def get_rows_data(rows_files):  # noqa: D103
         x["path"] for x in rows_files if x["path"].endswith("metadata.json.gz")
     ]
     if metadata_file:
-        with hfs.open(metadata_file[0], "rb") as f:
+        # `hfs.open` does not auto-decompress gzipped files, so decompress here.
+        with hfs.open(metadata_file[0], "rb") as raw_f, gzip.open(raw_f) as f:
             rows_meta = json.loads(f.read())
             try:
                 partition_bounds = [

--- a/gnomad/utils/vep.py
+++ b/gnomad/utils/vep.py
@@ -9,6 +9,7 @@ import subprocess
 from typing import Callable, List, Optional, Union
 
 import hail as hl
+import hailtop.fs as hfs
 
 from gnomad.resources.resource_utils import VersionedTableResource
 
@@ -188,7 +189,7 @@ def get_vep_help(vep_config_path: Optional[str] = None):
     if vep_config_path is None:
         vep_config_path = os.environ["VEP_CONFIG_URI"]
 
-    with hl.hadoop_open(vep_config_path) as vep_config_file:
+    with hfs.open(vep_config_path) as vep_config_file:
         vep_config = json.load(vep_config_file)
         vep_command = vep_config["command"]
         vep_help = subprocess.check_output([vep_command[0]]).decode("utf-8")
@@ -242,7 +243,7 @@ def vep_or_lookup_vep(
 
     vep_help = get_vep_help(vep_config_path)
 
-    with hl.hadoop_open(vep_config_path) as vep_config_file:
+    with hfs.open(vep_config_path) as vep_config_file:
         vep_config = vep_config_file.read()
 
     if reference_vep_ht is None:

--- a/gnomad/variant_qc/random_forest.py
+++ b/gnomad/variant_qc/random_forest.py
@@ -7,6 +7,7 @@ from pprint import pformat
 from typing import Dict, List, Optional, Tuple
 
 import hail as hl
+import hailtop.fs as hfs
 import pandas as pd
 import pyspark.sql
 from pyspark.ml import Pipeline
@@ -525,7 +526,7 @@ def get_rf_runs(rf_json_fp: str) -> Dict:
     :return: Dictionary containing the content of the JSON file, or an empty dictionary if the file wasn't found.
     """
     if file_exists(rf_json_fp):
-        with hl.hadoop_open(rf_json_fp) as f:
+        with hfs.open(rf_json_fp) as f:
             return json.load(f)
     else:
         logger.warning(

--- a/tests/assessment/test_parse_validity_logs.py
+++ b/tests/assessment/test_parse_validity_logs.py
@@ -1,0 +1,182 @@
+"""Tests for the parse_validity_logs module."""
+
+from gnomad.assessment.parse_validity_logs import generate_html_report, parse_log_file
+
+
+def _write_log(tmp_path, text):
+    """Write log text to a file and return its path."""
+    path = str(tmp_path / "validity.log")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    return path
+
+
+def _read_file(path):
+    """Read and return the full contents of a file."""
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+class TestParseLogFile:
+    """Test the parse_log_file function."""
+
+    def test_categorizes_levels_and_maps_function(self, tmp_path):
+        """Test log-level/keyword categorization and function-name mapping."""
+        log = "\n".join(
+            [
+                "INFO (gnomad.x.check_sex_chr_metrics 1): passed the check",
+                "INFO (gnomad.x.check_missingness 2): this check failed",
+                "INFO (gnomad.x.some_other_func 3): just an update",
+                "WARNING (gnomad.x.check_missingness 4): heads up",
+                "ERROR (gnomad.x.check_missingness 5): broke",
+            ]
+        )
+        parsed = parse_log_file(_write_log(tmp_path, log))
+
+        # (validity_check, category, source, message, table)
+        categories = [(p[0], p[1]) for p in parsed]
+        assert categories == [
+            ("XY check", "pass"),
+            ("missingness", "fail"),
+            ("some_other_func", "info"),  # unmapped name passes through
+            ("missingness", "warn"),
+            ("missingness", "fail"),
+        ]
+        assert parsed[0][2] == "gnomad.x.check_sex_chr_metrics 1"
+
+    def test_associates_table_with_preceding_log(self, tmp_path):
+        """Test that an ASCII table is captured with its preceding log entry."""
+        log = "\n".join(
+            [
+                "INFO (gnomad.x.check_missingness 10): found issues",
+                "+-------+",
+                "| locus |",
+                "+-------+",
+            ]
+        )
+        parsed = parse_log_file(_write_log(tmp_path, log))
+
+        assert len(parsed) == 1
+        message, table = parsed[0][3], parsed[0][4]
+        assert message == "found issues"
+        assert "| locus |" in table
+
+    def test_accumulates_multiline_message(self, tmp_path):
+        """Test that continuation lines are joined into one entry's message."""
+        log = "\n".join(
+            [
+                "INFO (gnomad.x.main 1): first line",
+                "second line",
+                "third line",
+                "INFO (gnomad.x.main 2): next entry",
+            ]
+        )
+        parsed = parse_log_file(_write_log(tmp_path, log))
+
+        assert len(parsed) == 2
+        assert parsed[0][3] == "first line\nsecond line\nthird line"
+        assert parsed[1][3] == "next entry"
+
+    def test_fail_keyword_uses_word_boundaries(self, tmp_path):
+        """Test that 'fail' matches only as a word and 'passed' takes precedence."""
+        log = "\n".join(
+            [
+                "INFO (gnomad.x.main 1): no failures detected",
+                "INFO (gnomad.x.main 2): check failed but later passed",
+                "INFO (gnomad.x.main 3): the check failed",
+            ]
+        )
+        parsed = parse_log_file(_write_log(tmp_path, log))
+
+        categories = [p[1] for p in parsed]
+        # "failures" is not the word "fail"/"failed"; "passed" wins over "failed".
+        assert categories == ["info", "pass", "fail"]
+
+    def test_empty_file_returns_empty_list(self, tmp_path):
+        """Test that an empty log file yields no parsed entries."""
+        assert parse_log_file(_write_log(tmp_path, "")) == []
+
+    def test_ignores_lines_before_first_entry(self, tmp_path):
+        """Test that non-matching lines before any log entry are dropped."""
+        log = "\n".join(
+            [
+                "preamble noise that is not a log line",
+                "another stray line",
+                "INFO (gnomad.x.main 1): real entry",
+            ]
+        )
+        parsed = parse_log_file(_write_log(tmp_path, log))
+
+        assert len(parsed) == 1
+        assert parsed[0][3] == "real entry"
+
+    def test_table_associated_with_non_final_entry(self, tmp_path):
+        """Test that a table is captured for an entry followed by another entry.
+
+        This exercises the in-loop flush path (a new match closing out a prior
+        entry that had a table), distinct from the end-of-file flush.
+        """
+        log = "\n".join(
+            [
+                "INFO (gnomad.x.check_missingness 1): found issues",
+                "+-------+",
+                "| locus |",
+                "+-------+",
+                "INFO (gnomad.x.main 2): all done",
+            ]
+        )
+        parsed = parse_log_file(_write_log(tmp_path, log))
+
+        assert len(parsed) == 2
+        # First entry keeps its message and captures the table.
+        assert parsed[0][3] == "found issues"
+        assert "| locus |" in parsed[0][4]
+        # The trailing entry has no table.
+        assert parsed[1][3] == "all done"
+        assert parsed[1][4] == ""
+
+
+class TestGenerateHtmlReport:
+    """Test the generate_html_report function."""
+
+    def test_escapes_content_and_builds_filters(self, tmp_path):
+        """Test HTML escaping of messages and per-column filter options."""
+        parsed_logs = [
+            (
+                "missingness",
+                "fail",
+                "gnomad.x.check_missingness 1",
+                "broke <b> & died",
+                "",
+            ),
+            ("XY check", "pass", "gnomad.x.check_sex_chr_metrics 2", "all good", ""),
+        ]
+        out = str(tmp_path / "report.html")
+        generate_html_report(parsed_logs, out)
+        html_out = _read_file(out)
+
+        # Message content is HTML-escaped, not injected raw.
+        assert "broke &lt;b&gt; &amp; died" in html_out
+        assert "broke <b>" not in html_out
+        # Filter dropdowns list each validity check and status.
+        assert '<option value="missingness">missingness</option>' in html_out
+        assert '<option value="XY check">XY check</option>' in html_out
+        assert '<option value="fail">FAIL</option>' in html_out
+        assert '<option value="pass">PASS</option>' in html_out
+        # Category drives the row CSS class.
+        assert '<tr class="fail">' in html_out
+
+    def test_view_table_button_only_when_table_present(self, tmp_path):
+        """Test that a "View Table" toggle is rendered only for entries with tables."""
+        parsed_logs = [
+            ("missingness", "fail", "src 1", "has table", "+---+\n| x |\n+---+"),
+            ("XY check", "pass", "src 2", "no table", ""),
+        ]
+        out = str(tmp_path / "report.html")
+        generate_html_report(parsed_logs, out)
+        html_out = _read_file(out)
+
+        # Exactly one toggle button/table div, for the single entry with a table.
+        assert html_out.count('class="toggle-btn"') == 1
+        assert '<div id="table_0" class="hidden-table">' in html_out
+        assert 'id="table_1"' not in html_out

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -38,9 +38,10 @@ class TestFileExists:
 
         assert file_exists(path) is False
 
+    # No network needed for mock gs:// paths
     @patch("gnomad.utils.file_utils.hfs.exists")
     def test_gcs_hail_table_checks_success_path(self, mock_exists):
-        """Test the `_SUCCESS` path built for a gs:// Hail Table (no network)."""
+        """Test the `_SUCCESS` path built for a gs:// Hail Table."""
         mock_exists.return_value = True
 
         assert file_exists("gs://my-bucket/t.ht") is True

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -1,0 +1,85 @@
+"""Tests for the file_utils utility module."""
+
+import os
+from unittest.mock import patch
+
+import hail as hl
+
+from gnomad.utils.file_utils import file_exists, read_list_data
+
+
+class TestFileExists:
+    """Test the file_exists function."""
+
+    def test_plain_file_exists(self, tmp_path):
+        """Test that an existing plain file is detected."""
+        path = str(tmp_path / "data.txt")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("content")
+
+        assert file_exists(path) is True
+
+    def test_missing_file(self, tmp_path):
+        """Test that a missing path is reported as absent."""
+        assert file_exists(str(tmp_path / "missing.txt")) is False
+
+    def test_hail_table_checks_success_file(self, tmp_path):
+        """Test that a written `.ht` is detected via its `_SUCCESS` file."""
+        path = str(tmp_path / "t.ht")
+        hl.utils.range_table(10).write(path)
+
+        assert file_exists(path) is True
+
+    def test_hail_table_missing_success_file(self, tmp_path):
+        """Test that an `.ht` directory without `_SUCCESS` is not detected."""
+        path = str(tmp_path / "t.ht")
+        hl.utils.range_table(10).write(path)
+        os.remove(os.path.join(path, "_SUCCESS"))
+
+        assert file_exists(path) is False
+
+    @patch("gnomad.utils.file_utils.hfs.exists")
+    def test_gcs_hail_table_checks_success_path(self, mock_exists):
+        """Test the `_SUCCESS` path built for a gs:// Hail Table (no network)."""
+        mock_exists.return_value = True
+
+        assert file_exists("gs://my-bucket/t.ht") is True
+        mock_exists.assert_called_once_with("gs://my-bucket/t.ht/_SUCCESS")
+
+    @patch("gnomad.utils.file_utils.hfs.exists")
+    def test_gcs_vds_checks_both_success_paths(self, mock_exists):
+        """Test that a gs:// VDS checks both component `_SUCCESS` files."""
+        mock_exists.return_value = True
+
+        assert file_exists("gs://my-bucket/data.vds") is True
+        assert mock_exists.call_count == 2
+        mock_exists.assert_any_call("gs://my-bucket/data.vds/reference_data/_SUCCESS")
+        mock_exists.assert_any_call("gs://my-bucket/data.vds/variant_data/_SUCCESS")
+
+    @patch("gnomad.utils.file_utils.hfs.exists")
+    def test_gcs_vds_missing_one_component_is_false(self, mock_exists):
+        """Test that a VDS missing one component `_SUCCESS` is reported absent."""
+        # reference_data present, variant_data missing -> overall False via all().
+        mock_exists.side_effect = lambda p: p.endswith("reference_data/_SUCCESS")
+
+        assert file_exists("gs://my-bucket/data.vds") is False
+
+    @patch("gnomad.utils.file_utils.hfs.exists")
+    def test_gcs_plain_path_checked_directly(self, mock_exists):
+        """Test that a gs:// non-Hail path is checked as-is (no `_SUCCESS`)."""
+        mock_exists.return_value = False
+
+        assert file_exists("gs://my-bucket/list.txt") is False
+        mock_exists.assert_called_once_with("gs://my-bucket/list.txt")
+
+
+class TestReadListData:
+    """Test the read_list_data function."""
+
+    def test_reads_lines_stripped(self, tmp_path):
+        """Test that each line is read into a list with whitespace stripped."""
+        path = str(tmp_path / "list.txt")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("a\nb \n c\n")
+
+        assert read_list_data(path) == ["a", "b", "c"]

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -4,8 +4,14 @@ import os
 from unittest.mock import patch
 
 import hail as hl
+import pytest
 
-from gnomad.utils.file_utils import file_exists, read_list_data
+from gnomad.resources.resource_utils import DataException
+from gnomad.utils.file_utils import (
+    check_file_exists_raise_error,
+    file_exists,
+    read_list_data,
+)
 
 
 class TestFileExists:
@@ -84,3 +90,76 @@ class TestReadListData:
             f.write("a\nb \n c\n")
 
         assert read_list_data(path) == ["a", "b", "c"]
+
+
+class TestCheckFileExistsRaiseError:
+    """Test the check_file_exists_raise_error function."""
+
+    @patch("gnomad.utils.file_utils.file_exists")
+    def test_returns_all_exist_without_error_flags(self, mock_exists):
+        """Test the all-exist boolean is returned (and a str path is one file)."""
+        mock_exists.return_value = True
+        assert check_file_exists_raise_error("a.ht") is True
+
+        mock_exists.return_value = False
+        assert check_file_exists_raise_error(["a.ht", "b.ht"]) is False
+
+    @patch("gnomad.utils.file_utils.file_exists")
+    def test_raises_when_existing_file_and_error_if_exists(self, mock_exists):
+        """Test that an existing file raises, naming only the offending file."""
+        mock_exists.side_effect = lambda f: f == "exists.ht"
+        with pytest.raises(DataException, match="already exist") as exc_info:
+            check_file_exists_raise_error(
+                ["exists.ht", "missing.ht"], error_if_exists=True
+            )
+        assert "exists.ht" in str(exc_info.value)
+        assert "missing.ht" not in str(exc_info.value)
+
+    @patch("gnomad.utils.file_utils.file_exists")
+    def test_raises_when_missing_file_and_error_if_not_exists(self, mock_exists):
+        """Test that a missing file raises when error_if_not_exists is set."""
+        mock_exists.return_value = False
+        with pytest.raises(DataException, match="do not exist.*a.ht"):
+            check_file_exists_raise_error("a.ht", error_if_not_exists=True)
+
+    @patch("gnomad.utils.file_utils.file_exists")
+    def test_raises_with_both_messages_when_both_flags_set(self, mock_exists):
+        """Test that both flags together report existing and missing files in one error."""
+        mock_exists.side_effect = lambda f: f == "exists.ht"
+        with pytest.raises(DataException) as exc_info:
+            check_file_exists_raise_error(
+                ["exists.ht", "missing.ht"],
+                error_if_exists=True,
+                error_if_not_exists=True,
+            )
+        msg = str(exc_info.value)
+        # Both halves of the combined message are present, each naming its file.
+        assert "already exist" in msg and "exists.ht" in msg
+        assert "do not exist" in msg and "missing.ht" in msg
+
+    @patch("gnomad.utils.file_utils.file_exists")
+    def test_no_raise_when_flag_set_but_condition_not_met(self, mock_exists):
+        """Test that a set flag only raises when its condition is actually triggered."""
+        # error_if_exists is set but nothing exists: no raise, returns False.
+        mock_exists.return_value = False
+        assert (
+            check_file_exists_raise_error(["a.ht", "b.ht"], error_if_exists=True)
+            is False
+        )
+        # error_if_not_exists is set but everything exists: no raise, returns True.
+        mock_exists.return_value = True
+        assert (
+            check_file_exists_raise_error(["a.ht", "b.ht"], error_if_not_exists=True)
+            is True
+        )
+
+    @patch("gnomad.utils.file_utils.file_exists")
+    def test_custom_error_messages_are_used(self, mock_exists):
+        """Test that caller-supplied error message prefixes are honored."""
+        mock_exists.return_value = True
+        with pytest.raises(DataException, match="CUSTOM EXISTS: a.ht"):
+            check_file_exists_raise_error(
+                "a.ht",
+                error_if_exists=True,
+                error_if_exists_msg="CUSTOM EXISTS: ",
+            )

--- a/tests/utils/test_plotting.py
+++ b/tests/utils/test_plotting.py
@@ -1,0 +1,57 @@
+"""Tests for the plotting utility module."""
+
+import os
+
+import hail as hl
+
+from gnomad.utils.plotting import _ls, get_rows_data
+
+
+class TestLs:
+    """Test the _ls helper, which mirrors the deprecated hl.hadoop_ls."""
+
+    def test_excludes_hidden_dotfiles(self, tmp_path):
+        """Test that dot-prefixed files (e.g. local `.crc`) are excluded.
+
+        `hfs.ls` lists hidden files that `hl.hadoop_ls` did not; writing a Hail
+        Table on the local filesystem creates `.crc` checksum files, which must
+        not leak through `_ls`.
+        """
+        path = str(tmp_path / "t.ht")
+        hl.utils.range_table(50, n_partitions=3).write(path)
+        parts = os.path.join(path, "rows", "parts")
+
+        names = [os.path.basename(e["path"]) for e in _ls(parts)]
+
+        assert names, "expected part files to be listed"
+        assert all(not n.startswith(".") for n in names)
+        assert not any(n.endswith(".crc") for n in names)
+
+    def test_keeps_underscore_success(self, tmp_path):
+        """Test that `_SUCCESS` (underscore-prefixed) is retained, like hl.hadoop_ls."""
+        path = str(tmp_path / "t.ht")
+        hl.utils.range_table(50, n_partitions=3).write(path)
+
+        names = [os.path.basename(e["path"]) for e in _ls(path)]
+
+        assert "_SUCCESS" in names
+
+
+class TestGetRowsData:
+    """Test get_rows_data partition-file parsing."""
+
+    def test_returns_one_size_per_partition(self, tmp_path):
+        """Test that part files are parsed without tripping on hidden `.crc` files.
+
+        Regression guard: when `ls` includes `.crc` files, the `part-` parsing
+        raised IndexError and file-size counts were inflated.
+        """
+        path = str(tmp_path / "t.ht")
+        hl.utils.range_table(100, n_partitions=5).write(path)
+        rows_files = _ls(os.path.join(path, "rows"))
+
+        _, file_sizes = get_rows_data(rows_files)
+
+        # Exactly one size per partition; the `.crc` files were not counted.
+        assert len(file_sizes) == 5
+        assert all(s > 0 for s in file_sizes)

--- a/tests/utils/test_plotting.py
+++ b/tests/utils/test_plotting.py
@@ -10,13 +10,24 @@ from gnomad.utils.plotting import _ls, get_rows_data
 class TestLs:
     """Test the _ls helper, which mirrors the deprecated hl.hadoop_ls."""
 
-    def test_excludes_hidden_dotfiles(self, tmp_path):
-        """Test that dot-prefixed files (e.g. local `.crc`) are excluded.
+    def test_excludes_crc_keeps_other_entries(self, tmp_path):
+        """Test that only `.crc` files are dropped, mirroring `hl.hadoop_ls`.
 
-        `hfs.ls` lists hidden files that `hl.hadoop_ls` did not; writing a Hail
-        Table on the local filesystem creates `.crc` checksum files, which must
-        not leak through `_ls`.
+        On the Spark backend, `hl.hadoop_ls` hides `.crc` checksum files but
+        still lists other hidden dotfiles; `hfs.ls` lists `.crc` files too.
+        `_ls` drops only `.crc` so its output matches the old behavior, so
+        non-`.crc` dotfiles and `_SUCCESS` must be retained.
         """
+        for name in ["part-0", ".part-0.crc", ".foo.crc", ".hidden", "_SUCCESS"]:
+            with open(os.path.join(tmp_path, name), "w", encoding="utf-8") as fh:
+                fh.write("x")
+
+        names = {os.path.basename(e["path"]) for e in _ls(str(tmp_path))}
+
+        assert names == {"part-0", ".hidden", "_SUCCESS"}
+
+    def test_excludes_crc_from_hail_table(self, tmp_path):
+        """Test that the `.crc` files a local Hail Table write creates are dropped."""
         path = str(tmp_path / "t.ht")
         hl.utils.range_table(50, n_partitions=3).write(path)
         parts = os.path.join(path, "rows", "parts")
@@ -24,7 +35,6 @@ class TestLs:
         names = [os.path.basename(e["path"]) for e in _ls(parts)]
 
         assert names, "expected part files to be listed"
-        assert all(not n.startswith(".") for n in names)
         assert not any(n.endswith(".crc") for n in names)
 
     def test_keeps_underscore_success(self, tmp_path):

--- a/tests/utils/test_vep.py
+++ b/tests/utils/test_vep.py
@@ -437,3 +437,50 @@ class TestVepOrLookupVep:
         assert hl.eval(result.vep_config) == "CONTEXT_CONFIG"
         # hl.vep was only ever applied to the (empty) re-VEP subset, never skipped.
         mock_vep.assert_called_once()
+
+    def test_unions_context_lookup_with_revep_of_missing_variants(self):
+        """Test the hybrid path: missing variants are re-VEPed and unioned back.
+
+        The context Table covers only a subset of the input keys, so the
+        variants absent from it must be VEPed via ``hl.vep`` and unioned with
+        the looked-up variants. ``hl.vep`` is mocked to an identity so no VEP
+        process is launched; this exercises the non-empty re-VEP/union branch
+        that ``test_uses_context_ht_when_all_variants_present`` deliberately
+        does not.
+        """
+        # Context HT holds keys {0, 1}; input has keys {0, 1, 2}, so key 2 is
+        # absent from the context and must be re-VEPed.
+        context_ht = hl.utils.range_table(2).annotate(vep=hl.struct(found=True))
+        context_ht = context_ht.annotate_globals(
+            vep_help="CONTEXT_HELP", vep_config="CONTEXT_CONFIG"
+        )
+        context = _fake_vep_context("105", {"105": context_ht})
+        ht = hl.utils.range_table(3)
+        with patch("gnomad.utils.vep.get_vep_help", return_value="CONTEXT_HELP"):
+            with patch(
+                "gnomad.utils.vep.hfs.open", _mock_open_returning("CONTEXT_CONFIG")
+            ):
+                with patch("gnomad.utils.vep.get_vep_context", return_value=context):
+                    with patch(
+                        "gnomad.utils.vep.hl.vep", side_effect=lambda t, p: t
+                    ) as mock_vep:
+                        result = vep_or_lookup_vep(
+                            ht,
+                            reference="GRCh38",
+                            vep_config_path="gs://bucket/vep.json",
+                        )
+
+        # Looked-up and re-VEPed variants are unioned back into one Table.
+        assert result.count() == 3
+        # Only the 2 context-matched variants carry the context annotation; the
+        # re-VEPed key 2 keeps a missing vep (identity-mocked hl.vep adds none).
+        assert result.aggregate(hl.agg.count_where(result.vep.found)) == 2
+        # hl.vep ran exactly once, on the single missing variant, with the config.
+        mock_vep.assert_called_once()
+        revep_subset, passed_path = mock_vep.call_args[0]
+        assert revep_subset.count() == 1
+        assert passed_path == "gs://bucket/vep.json"
+        # Globals survive the union and reflect the resolved version/help/config.
+        assert hl.eval(result.vep_version) == "v105"
+        assert hl.eval(result.vep_help) == "CONTEXT_HELP"
+        assert hl.eval(result.vep_config) == "CONTEXT_CONFIG"

--- a/tests/utils/test_vep.py
+++ b/tests/utils/test_vep.py
@@ -27,6 +27,21 @@ def _mock_open_returning(content):
     return MagicMock(return_value=ctx)
 
 
+def _fake_vep_context(default_version, versions):
+    """Build a fake VEP context resource standing in for `get_vep_context`.
+
+    `versions` maps a version string to the context Hail Table that its
+    `.ht()` should return; `default_version` is exposed as `.default_version`.
+    """
+    context = MagicMock()
+    context.default_version = default_version
+    context.versions = {
+        version: MagicMock(ht=MagicMock(return_value=ht))
+        for version, ht in versions.items()
+    }
+    return context
+
+
 class TestGetLofteeEndTruncFilterExpr:
     """Test the get_loftee_end_trunc_filter_expr function."""
 
@@ -320,3 +335,105 @@ class TestVepOrLookupVep:
                     vep_or_lookup_vep(
                         None, reference="hg99", vep_config_path="gs://bucket/vep.json"
                     )
+
+    def test_falls_back_to_full_vep_when_version_unavailable(self):
+        """Test that a missing context version VEPs all variants via `hl.vep`.
+
+        When the requested VEP version has no context Table, the function should
+        warn and return ``hl.vep(ht, vep_config_path)`` directly. ``hl.vep`` is
+        mocked so no VEP process is launched.
+        """
+        ht = hl.utils.range_table(1)
+        sentinel = hl.utils.range_table(2)
+        # default_version is set but `versions` is empty, so it is never found.
+        context = _fake_vep_context("105", {})
+        with patch("gnomad.utils.vep.get_vep_help", return_value="help"):
+            with patch("gnomad.utils.vep.hfs.open", _mock_open_returning("config")):
+                with patch("gnomad.utils.vep.get_vep_context", return_value=context):
+                    with patch(
+                        "gnomad.utils.vep.hl.vep", return_value=sentinel
+                    ) as mock_vep:
+                        result = vep_or_lookup_vep(
+                            ht,
+                            reference="GRCh38",
+                            vep_config_path="gs://bucket/vep.json",
+                        )
+
+        # The full-VEP fallback result is returned unchanged.
+        assert result is sentinel
+        mock_vep.assert_called_once_with(ht, "gs://bucket/vep.json")
+
+    def test_raises_on_vep_help_mismatch(self):
+        """Test that a VEP version mismatch between config and context HT raises."""
+        context_ht = hl.utils.range_table(1).annotate_globals(
+            vep_help="CONTEXT_HELP", vep_config="CONTEXT_CONFIG"
+        )
+        context = _fake_vep_context("105", {"105": context_ht})
+        with patch("gnomad.utils.vep.get_vep_help", return_value="DIFFERENT_HELP"):
+            with patch(
+                "gnomad.utils.vep.hfs.open", _mock_open_returning("CONTEXT_CONFIG")
+            ):
+                with patch("gnomad.utils.vep.get_vep_context", return_value=context):
+                    with pytest.raises(AssertionError, match="does not match"):
+                        vep_or_lookup_vep(
+                            hl.utils.range_table(1),
+                            reference="GRCh38",
+                            vep_config_path="gs://bucket/vep.json",
+                        )
+
+    def test_raises_on_vep_config_mismatch(self):
+        """Test that a VEP config mismatch between config file and context HT raises."""
+        context_ht = hl.utils.range_table(1).annotate_globals(
+            vep_help="CONTEXT_HELP", vep_config="CONTEXT_CONFIG"
+        )
+        context = _fake_vep_context("105", {"105": context_ht})
+        # Help matches so the first assert passes; the config read does not.
+        with patch("gnomad.utils.vep.get_vep_help", return_value="CONTEXT_HELP"):
+            with patch(
+                "gnomad.utils.vep.hfs.open", _mock_open_returning("DIFFERENT_CONFIG")
+            ):
+                with patch("gnomad.utils.vep.get_vep_context", return_value=context):
+                    with pytest.raises(AssertionError, match="configuration does"):
+                        vep_or_lookup_vep(
+                            hl.utils.range_table(1),
+                            reference="GRCh38",
+                            vep_config_path="gs://bucket/vep.json",
+                        )
+
+    def test_uses_context_ht_when_all_variants_present(self):
+        """Test the lookup path: variants found in the context HT are not re-VEPed.
+
+        All input keys exist in the context Table, so the re-VEP subset is empty
+        and the returned Table carries the context's annotations plus the VEP
+        version/help/config globals. ``hl.vep`` is mocked to an identity so no
+        VEP process is launched, and it is only applied to the (empty) subset.
+        """
+        context_ht = hl.utils.range_table(3).annotate(vep=hl.struct(found=True))
+        context_ht = context_ht.annotate_globals(
+            vep_help="CONTEXT_HELP", vep_config="CONTEXT_CONFIG"
+        )
+        context = _fake_vep_context("105", {"105": context_ht})
+        ht = hl.utils.range_table(3)
+        with patch("gnomad.utils.vep.get_vep_help", return_value="CONTEXT_HELP"):
+            with patch(
+                "gnomad.utils.vep.hfs.open", _mock_open_returning("CONTEXT_CONFIG")
+            ):
+                with patch("gnomad.utils.vep.get_vep_context", return_value=context):
+                    with patch(
+                        "gnomad.utils.vep.hl.vep", side_effect=lambda t, p: t
+                    ) as mock_vep:
+                        result = vep_or_lookup_vep(
+                            ht,
+                            reference="GRCh38",
+                            vep_config_path="gs://bucket/vep.json",
+                        )
+
+        # Every variant was annotated from the context HT.
+        assert result.count() == 3
+        assert result.aggregate(hl.agg.all(result.vep.found))
+        # Globals reflect the resolved version and the matched help/config.
+        assert hl.eval(result.vep_version) == "v105"
+        assert hl.eval(result.vep_help) == "CONTEXT_HELP"
+        assert hl.eval(result.vep_config) == "CONTEXT_CONFIG"
+        # hl.vep was only ever applied to the (empty) re-VEP subset, never skipped.
+        mock_vep.assert_called_once()

--- a/tests/utils/test_vep.py
+++ b/tests/utils/test_vep.py
@@ -1,12 +1,30 @@
 """Tests for the VEP utility module."""
 
+import io
+import json
+from unittest.mock import MagicMock, patch
+
 import hail as hl
 import pytest
 
 from gnomad.utils.vep import (
     get_loftee_end_trunc_filter_expr,
+    get_vep_help,
     update_loftee_end_trunc_filter,
+    vep_or_lookup_vep,
 )
+
+
+def _mock_open_returning(content):
+    """Build a mock for `hfs.open` whose context manager yields `content`.
+
+    `content` is wrapped in a `StringIO` so both `json.load(f)` and `f.read()`
+    work against it.
+    """
+    ctx = MagicMock()
+    ctx.__enter__.return_value = io.StringIO(content)
+    ctx.__exit__.return_value = False
+    return MagicMock(return_value=ctx)
 
 
 class TestGetLofteeEndTruncFilterExpr:
@@ -256,3 +274,49 @@ class TestUpdateLofteeEndTruncFilter:
 
         assert results[1].updated_csq.lof_filter == "END_TRUNC"
         assert results[1].updated_csq.lof == "LC"
+
+
+class TestGetVepHelp:
+    """Test the get_vep_help function."""
+
+    def test_uses_explicit_path_and_returns_help(self):
+        """Test that the given config is read and `vep --help` output returned."""
+        config = json.dumps({"command": ["/path/to/vep", "--offline"]})
+        with patch(
+            "gnomad.utils.vep.hfs.open", _mock_open_returning(config)
+        ) as mock_open:
+            with patch(
+                "gnomad.utils.vep.subprocess.check_output",
+                return_value=b"ensembl-vep 110",
+            ) as mock_check_output:
+                result = get_vep_help("gs://bucket/vep.json")
+
+        assert result == "ensembl-vep 110"
+        mock_open.assert_called_once_with("gs://bucket/vep.json")
+        # Only the command itself is invoked, not its config flags.
+        mock_check_output.assert_called_once_with(["/path/to/vep"])
+
+    def test_falls_back_to_env_var(self, monkeypatch):
+        """Test that VEP_CONFIG_URI is used when no path is supplied."""
+        monkeypatch.setenv("VEP_CONFIG_URI", "gs://env/vep.json")
+        config = json.dumps({"command": ["/path/to/vep"]})
+        with patch(
+            "gnomad.utils.vep.hfs.open", _mock_open_returning(config)
+        ) as mock_open:
+            with patch("gnomad.utils.vep.subprocess.check_output", return_value=b"vep"):
+                get_vep_help()
+
+        mock_open.assert_called_once_with("gs://env/vep.json")
+
+
+class TestVepOrLookupVep:
+    """Test the vep_or_lookup_vep function."""
+
+    def test_invalid_reference_raises(self):
+        """Test that an unrecognized reference build raises a ValueError."""
+        with patch("gnomad.utils.vep.get_vep_help", return_value="help"):
+            with patch("gnomad.utils.vep.hfs.open", _mock_open_returning("config")):
+                with pytest.raises(ValueError, match="Expected one of"):
+                    vep_or_lookup_vep(
+                        None, reference="hg99", vep_config_path="gs://bucket/vep.json"
+                    )


### PR DESCRIPTION
Hail deprecated hadoop functions in hail 0.2.137. This updates to use hailtop which does not need to initialize hail and is in general a drop in replacement as noted by Chris here: https://github.com/hail-is/hail/pull/15182. The gz exception is covered here as well as are hidden files.