### PR TITLE
Add a gnomAD & Hail institutional-knowledge reference

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(ls:*)",
+      "Bash(rg:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(python -m pytest:*)",
+      "Bash(pytest:*)",
+      "Bash(./docs/build.sh)"
+    ]
+  }
+}

--- a/.claude/skills/clean-git-history/SKILL.md
+++ b/.claude/skills/clean-git-history/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: clean-git-history
+description: Use this when the user wants to clean up a messy branch, squash commits, or tidy history before opening a PR. Rewrites local history into clean atomic commits without losing any changes.
+allowed-tools: bash, read_file
+---
+
+## Objective
+
+Rewrite a noisy branch into a clean, atomic series of commits. Every change must be preserved exactly — verified by an empty diff against a backup branch.
+
+Never use interactive rebase. Use `reset --soft` + deliberate restaging instead.
+
+## Workflow
+
+### 1. Identify the base branch
+
+**Do not run any diff or log commands spanning the branch until the base is confirmed.**
+
+1. Run `git log --oneline --graph --decorate -n 20` to see where the branch diverges.
+2. Check for stacking: find the oldest commit unique to this branch and run `git branch -a --contains <hash>`. If another non-main branch contains it, this branch is stacked on it.
+3. **Stop and ask the user:** "Is this branch stacked on another branch? I think the base is `[branch]` — confirm or correct me."
+4. After the user confirms, verify: `git merge-base <confirmed-base> HEAD` should equal the tip of the base.
+
+### 2. Understand the existing history (read-only, mutate nothing)
+
+1. `git status` — must be clean. If not, stop and ask the user to commit or stash first.
+2. `git log -p --reverse <base>..HEAD` — read every commit's diff and message.
+3. `gh pr view` if a PR exists.
+4. Write a **commit plan**: an ordered list of target commits, each with:
+   - Title (matching this repo's commit style — check `git log --oneline -10`)
+   - One-line rationale
+   - Which original commits / files it absorbs
+
+   Map every original commit into exactly one target commit.
+
+5. Present the plan to the user and ask for explicit approval before touching anything.
+
+### 3. Restructure
+
+1. Create a backup: `git branch backup-$(git branch --show-current)-$(date +%Y-%m-%d--%H-%M)`. Tell the user the backup branch name.
+2. `git reset --soft <base>` then `git reset` to unstage everything.
+3. For each planned commit:
+   - `git add <specific files>` — never `git add .` or `git add -A`
+   - `git diff --staged` — read the full diff and confirm it matches the plan before committing
+   - Commit with the planned title and an `Assisted-by: ClaudeCode:<model-id>`
+     trailer, where `<model-id>` is the model **you are actually running as**
+     (e.g. `claude-opus-5`). Do not copy the placeholder or a model name from
+     an earlier commit — a stale name defeats the point of the trailer. Match
+     the repo's existing trailer format if it differs.
+     ```bash
+     git commit -m "$(cat <<'EOF'
+     <title>
+
+     Assisted-by: ClaudeCode:<model-id>
+     EOF
+     )"
+     ```
+
+### 4. Verify
+
+1. `git diff <backup-branch> HEAD` — this diff **must be empty**. If it is not, immediately run `git reset --hard <backup-branch>` to restore the original, tell the user what happened, and re-plan.
+2. `git status` — must be clean.
+3. Show the user the new `git log --oneline <base>..HEAD`.
+
+### 5. Handoff
+
+Do NOT push. Tell the user to run `git push --force-with-lease` themselves once they are satisfied. Offer to draft a PR description using the draft-pull-request-description skill.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: commit
+description: Use this when the user wants to commit staged changes. Drafts a commit message matching the repo's style, confirms with the user, then commits.
+allowed-tools: bash, read_file
+---
+
+## Objective
+
+Draft a concise commit message matching the style of recent commits in this repository, run the repo's pre-commit hooks on the staged changes, show the user what will be committed, confirm, then run the commit.
+
+## Workflow
+
+### 1. Check staged changes
+
+Run `git diff --staged --stat` to see what is staged. If nothing is staged:
+- Run `git status` to show what is available
+- Tell the user what is unstaged and ask what to add before proceeding
+
+### 2. Run pre-commit hooks
+
+Always run the repo's pre-commit hooks on the staged files before reviewing, so the commit matches what CI enforces (black, isort, autopep8, pydocstyle, whitespace fixers, etc.). This runs even if the user has not installed the git hook.
+
+Skip this step only if the repo has no `.pre-commit-config.yaml`.
+
+Capture the staged file list first (only run hooks on staged files — never all files, to avoid reformatting unrelated code):
+```bash
+git diff --staged --name-only
+```
+
+Run the hooks scoped to those files:
+```bash
+pre-commit run --files <staged files>
+```
+- If `pre-commit` is not on PATH, try `python -m pre_commit run --files <staged files>`.
+- If pre-commit is unavailable entirely, fall back to running the tools listed in `.pre-commit-config.yaml` directly on the staged files, using the versions pinned in `requirements-dev.txt` / the config's `rev:` (a throwaway venv is fine). For this repo that means: `black`, `isort --profile black --filter-files`, `autopep8 --exit-code --in-place`, `pydocstyle`. autopep8 needs `lib2to3`, so run it under Python ≤ 3.12, not 3.13.
+- If neither pre-commit nor the individual tools can be run, tell the user the hooks could not run and why, and ask how to proceed — do NOT silently commit unformatted code.
+
+Auto-fixing hooks (black, isort, autopep8, end-of-file-fixer, trailing-whitespace) modify the working tree, which unstages those edits. Re-stage the same paths and re-run until the hooks pass cleanly:
+```bash
+git add -- <staged files>
+```
+If a non-autofixable hook fails (e.g. pydocstyle, check-yaml), stop and surface the failure to the user rather than committing.
+
+### 3. Review the diff
+
+Run `git diff --staged` and read the full diff. Look for anything that shouldn't be there: debug prints, commented-out code, unintended files, or anything that looks like a secret. If something looks wrong, stop and tell the user before proceeding.
+
+### 4. Read recent commit style
+
+Run `git log --oneline -10` to understand the repo's commit message convention (capitalization, prefix style, length, etc.).
+
+### 5. Draft a commit message
+
+Match the observed style exactly. General rules unless the repo overrides them:
+- Short imperative phrase, ≤ 72 characters
+- No conventional commit prefixes (`feat:`, `fix:`, etc.) unless the repo uses them
+- No trailing period
+- Add a blank line and a body paragraph only when the change genuinely needs more context than the subject line can carry
+
+### 6. Confirm with the user
+
+Show:
+- The list of staged files (`git diff --staged --name-only`)
+- The draft commit message
+
+Ask the user to confirm, request edits, or abort. Do not commit until they confirm.
+
+### 7. Commit
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+<message here>
+
+Assisted-by: ClaudeCode:<model-id>
+EOF
+)"
+```
+
+`<model-id>` is the model **you are actually running as** — e.g.
+`claude-opus-5`, `claude-sonnet-5`. Do not copy a model name out of this
+file or out of an earlier commit; the trailer records which model
+assisted, so a stale name makes it useless. If the repo's existing
+trailers use a different format, match the repo.
+
+Do NOT push unless the user explicitly asks.

--- a/.claude/skills/draft-pull-request-description/SKILL.md
+++ b/.claude/skills/draft-pull-request-description/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: draft-pull-request-description
+description: Use this whenever the user wants to open a pull request (PR), draft a PR, or summarize their branch for merging.
+allowed-tools: bash, read_file
+---
+
+## Objective
+
+You are a Staff Bioinformatics Engineer preparing a comprehensive, professional, and concise Pull Request description for a gnomAD pipeline codebase. Your goal is to produce a description thorough enough that the reviewer can understand:
+
+- The intent and motivation for the change
+- The specific pipeline steps or resources affected (sample QC, variant QC, frequency annotation, VDS/HT/MT operations, Dataproc cluster config, etc.)
+- The design/architecture chosen and why (especially if Hail-specific tradeoffs were involved)
+- The exact changes and any new output paths or resource names
+- What tests were added or changed (check `gnomad_qc/tests/` and `.github/workflows/ci.yml`)
+- Anything requiring specific reviewer attention (e.g. breaking changes to resource paths, schema changes to HTs, large compute cost implications)
+
+## Workflow
+
+### 1. Determine the base branch
+
+Default to `main`. Ask the user only if they indicate this is a stacked branch.
+
+### 2. Analyze the diff
+
+Run `git diff main...HEAD` to understand the full set of changes. Then read the changed files in full — especially any new or modified Python scripts, resource definitions, or config changes.
+
+### 3. Identify gnomAD-specific context
+
+Check whether the diff touches any of the following and note it in the description:
+
+- **Hail operations**: new/modified VDS, MT, HT read/write paths, aggregations, or annotations
+- **Dataproc / cluster config**: cluster size, autoscaling policy, init scripts, `hailctl dataproc submit` invocations
+- **Resource paths**: new or renamed GCS paths (especially under `gs://gnomad*/`)
+- **Pipeline step flags**: new CLI arguments, `--overwrite`, step-gating logic
+- **Privacy or release filters**: anything touching allele frequency output, sample suppression, or release HTs
+- **Test coverage**: added/changed tests under `gnomad_qc/tests/`
+
+### 4. Check for a completed code review
+
+Look for a completion marker written by the `/review` skill:
+
+```bash
+ls .code_review/*CODE_REVIEW_COMPLETED 2>/dev/null | sort | tail -1
+```
+
+If a marker exists, take its timestamp prefix (format `YYYYMMDD_HHMMSS`) and identify which models were in the roster by listing prompt files that share that prefix:
+
+```bash
+ls .code_review/YYYYMMDD_HHMMSS_PROMPT__*__*.md 2>/dev/null        # detection
+ls .code_review/YYYYMMDD_HHMMSS_PROMPT__*_validate.md 2>/dev/null  # validation
+```
+
+The suffix before `.md` is the model name (`opus`, `sonnet`, `agy`).
+
+**Check both lists — the two rosters can differ.** A reviewer that completes
+detection can still drop out of validation (an `agy` run that times out at the
+validation call, a model whose CLI invocation fails partway), and the review
+skill treats the two rosters as decided independently. Report the models that
+actually *validated*, since that is what the confidence labels rest on. If the
+two lists differ, say so rather than printing one merged roster — e.g.
+"reviewed by opus, sonnet, agy; validated by opus, sonnet".
+
+### 5. Draft the PR description
+
+Use the following template — fill every section; do not leave placeholders:
+
+```markdown
+## Summary
+
+<!-- 1-3 bullet points on what this PR does and why -->
+
+## Changes
+
+<!-- Bullet list of specific changes: functions added/modified, new CLI flags, resource paths changed, etc. -->
+
+## Hail / Compute notes
+
+<!-- Any cluster config, VDS/HT schema changes, estimated cost or runtime if significant. Write "None" if not applicable. -->
+
+## Testing
+
+<!-- How was this tested? Dataproc job IDs / log snippets if relevant, or unit test coverage. -->
+
+## Code review
+
+<!-- Emit exactly ONE of the two lines below, whichever is true, and delete the other.
+     Never emit both: an unchecked "not run" sitting above a checked "run" reads as
+     if no review happened, and a skimmer will believe the first line.
+       run:     - [x] `/review` run — models: Opus, Sonnet
+       not run: - [ ] `/review` not run
+     If a review was run, follow the line with its findings and their disposition
+     (fixed here / deferred / rejected as a false positive). -->
+- [x] `/review` run — models: <!-- e.g. Opus, Sonnet -->
+
+## Reviewer notes
+
+<!-- Anything requiring specific attention: breaking changes, schema migrations, large GCS writes, or design tradeoffs the reviewer should weigh in on. Write "None" if not applicable. -->
+```
+
+### 6. Merge strategy
+
+Specify whether this PR should be **squash-merged** (preferred for single-topic changes) or **rebased** (preferred for a clean commit stack). Default to squash unless the commit history is intentionally structured.
+
+### 7. Output
+
+Print the complete filled-out markdown. Do not add UI screenshot instructions — this codebase has no frontend.

--- a/.claude/skills/review/LICENSE
+++ b/.claude/skills/review/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 bw2
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/review/README.md
+++ b/.claude/skills/review/README.md
@@ -1,0 +1,49 @@
+# claude-code-review-skill
+
+A [Claude Code](https://claude.com/claude-code) skill that runs code review using Claude under two different models — Opus and Sonnet — plus an optional third reviewer, [agy](https://antigravity.google/) (Google Antigravity). The reviewers in the roster independently review your code in parallel, merge the results into a deduplicated list, and then do a second validation pass to see if they agree with each other's findings. At the end, you are presented with a list of all findings along with the level of agreement between reviewers (`Agreed`, `Disputed`, `Unanimous`, etc — the exact tiers depend on whether agy is in the roster), and the proposed fixes.
+
+agy is optional: the skill drops it automatically if the `agy` CLI isn't installed, and you can also ask to skip it explicitly (e.g. `/review --no-agy`) even when it is installed.
+
+## Requirements
+
+- [Claude Code](https://claude.com/claude-code) (`claude` CLI) — invoked twice per step, once pinned to Opus and once to Sonnet.
+- [`agy`](https://antigravity.google/) (Google Antigravity CLI), installed and authenticated — **optional**.
+
+## Install
+
+Clone this repo directly into your personal skills directory:
+
+```bash
+git clone https://github.com/bw2/claude-code-review-skill.git ~/.claude/skills/review
+```
+
+Restart Claude Code (or start a new session) and the `/review` command is available in any project.
+
+## Usage
+
+```
+/review
+```
+
+With no argument, reviews `git diff main...HEAD` if there is one, otherwise the whole current directory. You can also target something specific:
+
+```
+/review path/to/file.py path/to/other.py
+/review --diff main...HEAD
+/review focus on error handling in the auth module
+/review --no-agy path/to/file.py
+```
+
+## How it works
+
+1. **Setup** — creates a scratch `.code_review/` directory with one subdirectory per reviewer (`opus`, `sonnet`, `agy`). agy is included only if the CLI is found on PATH and you haven't asked to skip it.
+2. **Detect** — each reviewer in the roster reads the target from disk independently and reports findings as structured JSON (file, lines, severity, claim, evidence, suggested fix).
+3. **Consolidate** — duplicate findings across reviewers are merged; each unique finding gets a stable ID.
+4. **Validate** — every reviewer in the roster re-reads every consolidated finding and votes `agree` / `disagree` / `unsure`, under a prompt that hides which model originally flagged it and shuffles item order to defeat position bias.
+5. **Synthesize** — findings are grouped by severity, each with a confidence label derived purely from the vote split (tiers depend on whether agy is in the roster: `Unanimous`/`Agreed`/`Controversial`/`Rejected`/`Inconclusive` with 3 reviewers, `Agreed`/`Disputed`/`Rejected`/`Inconclusive` with 2), and a concrete fix.
+
+Everything under `.code_review/` is scratch state for a single run — safe to delete between reviews.
+
+## License
+
+MIT

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: review
+description: >
+  Performs code review by launching Claude twice under two different models —
+  Opus and Sonnet — plus (optionally) agy (Google Antigravity), all in
+  parallel. Then, it merges their findings into a deduplicated list and
+  launches a validation pass, asking each reviewer in the roster to agree or
+  disagree with the others' findings. Then, it gives you a final list of
+  findings so that you can choose which ones to fix.
+---
+
+# Review Skill
+
+Two Claude reviewers — one pinned to **Opus**, one pinned to **Sonnet** — plus an optional third reviewer, **agy** (Google Antigravity), detect issues in parallel by reading local files directly. Every consolidated finding is then scored by every reviewer in this run's roster (each running locally with disk access) using a deliberately neutral prompt — no reviewer attribution, no meta-framing about peer review. The prompt removes explicit authorship signals. Findings are presented with confidence labels derived purely from validator votes.
+
+agy is optional. The skill auto-detects whether the `agy` CLI is installed and drops it from the roster if not, and you can also ask to skip it explicitly (`/review --no-agy`, or "skip agy" / "without agy" anywhere in your instructions) even when it is installed. With agy in the roster there are 3 reviewers/validators (confidence tiers: Unanimous / Agreed / Controversial / Rejected / Inconclusive); without it there are 2 (Agreed / Disputed / Rejected / Inconclusive).
+
+## Requirements
+
+- `claude` CLI (this skill runs inside it, so it's already present) — invoked twice per step, once with `--model opus` and once with `--model sonnet`.
+- `agy` CLI ([Google Antigravity](https://antigravity.google/)), installed and authenticated — **optional**. If missing (or explicitly skipped), the skill runs with the two Claude reviewers only.
+
+## Workflow
+
+> **Working-directory hygiene.** Every shell command in this skill assumes the project root as cwd. Because the harness's bash cwd can drift across tool calls (a prior `cd subdir` from earlier in the session can persist), each command below anchors itself with `cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && …` (or its parametrized form). Do not strip those anchors — they're what make the skill robust to a drifted cwd. The expression is `git rev-parse --show-toplevel` for git repos (finds the project root regardless of harness cwd), falling back to `pwd` for non-git projects. **Caveat for non-git projects:** the `pwd` fallback only works if the harness cwd happens to be the project root — if it has drifted, you must `cd` back to the project root yourself first, or replace the whole `$(…)` expression with a hardcoded absolute project-root path inside each command before running it.
+
+### Step 1: Setup
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && mkdir -p .code_review/opus .code_review/sonnet .code_review/agy
+```
+
+**Decide whether agy is in this run's roster.** Include it only if BOTH:
+1. The user did not ask to skip it — scan the raw `/review` argument (before Step 2 parses it for a target) for `--no-agy`, or plain language such as "skip agy" / "without agy" / "don't use agy". If found, strip it from the argument string before Step 2 resolves the target, so it isn't mistaken for a path.
+2. `command -v agy >/dev/null 2>&1` finds it on PATH.
+
+If either check fails, proceed with the **opus + sonnet roster only** for the rest of this run. Tell the user which roster is in effect before launching anything (e.g. "agy not found on PATH — reviewing with opus + sonnet only" or "skipping agy per your request"). Unlike opus and sonnet — core to every run — agy is purely additive: if it's out, there's no stand-in to find, just a smaller, still-complete roster.
+
+Generate a unique run id `XX` as the current timestamp in the format `YYYYMMDD_HHMMSS`:
+
+```bash
+XX=$(date +%Y%m%d_%H%M%S)
+```
+
+Use this same `XX` value as the prefix for every file the skill writes under `.code_review/` during this run (prompts, the completion marker, etc.) — capture it once and reuse it so all artifacts from a single run share a stable prefix.
+
+### Step 1b: Decide whether to split into independent subsets
+
+Large projects can exceed what the detection models can usefully attend to in a single review, even when each agent reads the files from disk itself — review quality degrades long before the context-window hard limit, and a single agent juggling 50 files reasons more shallowly than splitting the work across reviewers. When the target is large, the review is split into multiple subsets that are reviewed in parallel as independent pipelines, then merged at synthesis (Step 6).
+
+**Resolve the file list and measure the target.** First resolve the user's argument the same way Step 2 will (explicit paths, `git diff main...HEAD`, or all files under a directory via `git ls-files`). Then compute:
+- Total source lines: `wc -l <files>` (sum the `total` row).
+- Total file count.
+- Approximate total byte size: `wc -c <files>` summed, or `du -bc <files> | tail -1`.
+
+**Threshold for splitting (moderate):**
+- ≤ ~6,000 source lines **AND** ≤ ~40 files **AND** ≤ ~300 KB → **single subset called `all`**, proceed to Step 2 unchanged.
+- Otherwise → **plan a split** before launching reviewers.
+
+**Plan the split.** The goal is 2–5 subsets where each subset (a) fits comfortably under the threshold above and (b) is internally cohesive and externally as independent as possible from the other subsets. Apply these heuristics in order of preference:
+
+1. **By top-level subdirectory** (`src/`, `scripts/`, `tests/`, language-specific dirs, etc.) — usually the cleanest natural boundary.
+2. **By language / runtime** (e.g. Python build scripts vs. browser JS/HTML/CSS) — often correlates with module boundaries.
+3. **By named feature module** when a feature has its own subdir and few cross-imports.
+4. **By coarse import/require analysis** — quickly grep for cross-file references; group strongly-connected files together.
+
+Sanity-check the split: each subset should be reviewable without constantly cross-referencing other subsets. If two candidate subsets are deeply interdependent (one imports many symbols from the other, shared types, etc.), merge them. When a cross-subset reference is unavoidable, you may include the referenced file in BOTH subsets if it is small (under a few hundred lines) and the dependency is non-trivial; otherwise note the dependency in a one-line `> Out-of-subset dependency: <file>` header inside the dependent subset's prompt so reviewers know what's intentionally out of scope.
+
+**Oversize fallback.** If a single file or directory is itself larger than the threshold and cannot be cleanly split along module boundaries, review it as its own subset anyway. Append a one-line `> Note: this subset exceeds the recommended review size; reviewer attention may be degraded.` header to that subset's prompt so the user sees the caveat in the synthesis output. Do NOT mechanically chunk a file mid-way.
+
+**Output of this step:** a list of subsets, each with:
+- A short kebab-case name (e.g. `web-ui`, `build-scripts`, `audio-pipeline`).
+- The file list.
+- A one-sentence rationale for the boundary.
+
+Print the planned splits to the user as a brief preview before launching reviewers (subset name → file count, short rationale) so they can interrupt if the boundaries look wrong.
+
+**Threading subsets through Steps 2–5.** When more than one subset is planned, run Steps 2–5 **once per subset**, with these naming conventions:
+- The Step 2 `<label>` becomes `<base-label>__<subset-name>` (e.g. `swedish_flashcards__web-ui`). All existing `XX_PROMPT__<label>__…` and `XX_PROMPT__<label>_…_validate.md` paths in Steps 2–5 keep their exact shape; only the `<label>` value carries the subset.
+- The reviewer/validator subdirectories (`.code_review/opus`, `.code_review/sonnet`, `.code_review/agy`) are shared across subsets — each subset's CLI invocations use a distinct prompt-file path, so parallel runs from the same subdirectory don't collide as long as we rely on captured stdout (we do; no CLI writes files we depend on later).
+
+**Concurrency cap.** Launching every (subset × reviewer) at once can trip rate limits and overload the machine. **Cap at ~6 concurrent CLI invocations when agy is in the roster (3 reviewers), ~4 when it isn't (2 reviewers).** Batch the work: e.g. with 3 subsets × 3 reviewers = 9 runs, launch 6 first and queue the remaining 3 to start as earlier ones finish. Use `run_in_background: true` with `Monitor` to wait, or chain sequentially after a first batch returns. The same cap applies to the Step 5 validation pass.
+
+If only a single subset is planned (project is below threshold), the rest of the skill behaves exactly as it did before splitting was introduced.
+
+### Step 2: Resolve the target and write the detection prompt
+
+> **Per subset.** When Step 1b planned multiple subsets, perform this step once per subset using that subset's file list as the resolved `{TARGET}`. Express `{TARGET}` as an explicit file list (e.g. "the files `path/to/foo.py` and `path/to/bar.py` (paths are relative to the repo root)") so the agent reviews only the subset's files. Use `<label>` = `<base-label>__<subset-name>` in the prompt-file paths. Write all subsets' prompts before moving on to Step 3.
+
+Parse the user's argument to `/review` (after the Step 1 skip-agy scan has already stripped `--no-agy`, if present):
+- If it names files/directories or a git ref (e.g. `--diff main...HEAD`), use that.
+- Otherwise default to `git diff main...HEAD` if there's a non-empty diff, else "the code in the current directory".
+
+Resolve `{TARGET}` to a concrete description the agent can act on, e.g.:
+- "the files `path/to/foo.py` and `path/to/bar.py` (paths are relative to the repo root)"
+- "the changes in `git diff main...HEAD` (run the diff yourself to see them, then read the changed files in full)"
+- "all source files under `./analysis/` (use `git ls-files analysis/` to enumerate, then read each)"
+
+Write one detection prompt per reviewer in the active roster — `.code_review/XX_PROMPT__<label>__opus.md`, `.code_review/XX_PROMPT__<label>__sonnet.md`, and, if agy is in the roster, `.code_review/XX_PROMPT__<label>__agy.md` — using the template below with `<agent>` substituted to the agent's actual subdirectory name (`opus`, `sonnet`, or `agy`) in each file. The prompts are identical EXCEPT the agy prompt additionally gets the **agy narration-suppression block** (defined below the template) appended at its very end. (A single shared file would leave the literal `<agent>` placeholder in the prompt, which is confusing to the model even if path resolution via `../..` still works.)
+
+````
+Do a thorough code review of {TARGET}.
+
+**Read the files from disk yourself.** You are running from a subdirectory two levels below the repo root; the repo root is `../..` (your cwd is `.code_review/<agent>/` under the repo root). Use `../..` to construct all file paths. Start by listing what's in scope (e.g. `git -C ../.. ls-files` or the explicit paths above, prefixed with `../../`), then read each file in full before forming opinions.
+
+For each candidate issue:
+
+1. Pinpoint the exact file and line(s).
+2. Re-open the file and confirm the cited lines actually say what you claim.
+3. Confirm the failure mode is reachable: trace at least one caller / test / config that exercises this code, and confirm the bad input can occur in practice. If you cannot, do not report the finding. Speculative "this would crash if X were None" concerns when every caller statically prevents X from being None are the dominant false-positive class — drop them. **Do not invent hypothetical inputs to argue reachability** — phrases like "if the test used X" or "if a caller passed Y" mean you have not found a real trigger. Cite a concrete input an existing caller / test / config actually produces, or drop the finding. A hypothetical that would-trigger-the-bug-if-it-existed is not evidence of reachability; it is a confession that you couldn't find one.
+
+**Severity bar — report only:**
+- `critical` — wrong output, data loss, security issue, or crash on a realistic input.
+- `high` — likely bug under normal use, OR significant maintainability hazard.
+- `medium` — verifiable quality issue (dead code with no caller; duplicated logic that has actually drifted; documentation that contradicts the implementation in a misleading way).
+
+Do NOT report `low` / style / nits.
+
+**Specifically DO NOT flag:**
+- Missing type hints, formatting.
+- Defensive checks for inputs that cannot occur given the call sites.
+- "Consider extracting a helper" / suggested abstractions where existing code is clear and used in one place.
+- Hypothetical security / untrusted-input concerns when the code is a one-shot script or runs in a trusted environment.
+- Pre-existing issues outside the target.
+- Anything a linter would catch.
+
+**Output format — STRICT.** Before the JSON, you may include a brief `<scratch>…</scratch>` block listing the files you inspected and any candidates you ruled out — use this to free up exploration, not as part of the answer. The final answer must be a single JSON object inside one ```json fenced code block, emitted as the LAST ```json block in your response. **If multiple ```json blocks appear in your response (e.g. you echoed the example schema), only the LAST block is parsed.** Anything outside the parsed block (including the scratch) is discarded.
+
+```json
+{
+  "summary": {"critical": 0, "high": 2, "medium": 1},
+  "findings": [
+    {
+      "id": "F1",
+      "file": "path/to/file.py",
+      "lines": "42-45",
+      "severity": "high",
+      "title": "Short one-line title (≤ 100 chars)",
+      "claim": "Self-contained 1-2 sentence statement of what is wrong, grounded in the code. Another reader who has not seen your other findings must be able to judge it from this field alone. Cite line content where useful.",
+      "evidence": "Concrete reachability: which caller/test/config triggers it, and the input that produces the bad outcome. Cite file:line.",
+      "suggested_fix": "Brief concrete fix, or empty string if not obvious"
+    }
+  ]
+}
+```
+
+Field rules:
+- `id`: `F1`, `F2`, … in listed order.
+- `lines`: `42`, `42-45`, or `42,50,73`.
+- `severity`: exactly one of `critical`, `high`, `medium`.
+- `claim` and `evidence` will be shown verbatim to peer validators — keep them self-contained and grounded.
+- If you find no issues, return `{"summary": {"critical": 0, "high": 0, "medium": 0}, "findings": []}`.
+````
+
+If the user passed extra instructions beyond a target, append them after the template (do not modify the output schema). **Do not** append a project file tree or file contents — each agent reads the disk itself.
+
+**agy narration-suppression block (append to the agy prompt ONLY — both detection here and validation in Step 5).** agy's print mode streams step-by-step tool narration to stdout ("I will view file X", "I will search for Y", …) and can exhaust its `--print-timeout` budget on narration before it ever emits the final answer (observed: a detection run that printed dozens of "I will view …" lines then died on `Error: timed out waiting for response` with zero ```json blocks). agy has no CLI flag to suppress this, so instruct it in-prompt. Append this verbatim as the last lines of the agy prompt file:
+
+```
+**Suppress narration — IMPORTANT.** Do NOT print step-by-step progress narration, plans, or reasoning traces (e.g. "I will view file X", "I will search for Y", "Next I will check Z"). Read the files you need SILENTLY using your tools, then emit ONLY the final answer. Any such narration wastes your limited print-timeout budget and risks the run timing out before the answer is produced. Your entire stdout should be (optionally) the brief `<scratch>` block followed by the single final ```json block — nothing else.
+```
+
+(The reference to `<scratch>` matches the detection template; for the Step 5 validation prompt, which has no `<scratch>` block, drop that clause so the last sentence reads "Your entire stdout should be the single final ```json block — nothing else.")
+
+### Step 3: Launch the active roster's detection agents in parallel
+
+All runs use `run_in_background: true`. Each agent runs in its own subdirectory (`.code_review/opus`, `.code_review/sonnet`, and, if in the roster, `.code_review/agy`) two levels below the repo root, so it reads the repo from `../..`. **When multiple subsets exist, launch each subset's agents the same way, but obey the Step 1b concurrency cap — batch the remainder and start queued runs as earlier ones finish.**
+
+**Opus — pinned model, fast non-interactive:**
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.code_review/opus" && cat ../XX_PROMPT__<label>__opus.md | claude -p --model opus --output-format text
+```
+
+**Sonnet — pinned model, fast non-interactive:**
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.code_review/sonnet" && cat ../XX_PROMPT__<label>__sonnet.md | claude -p --model sonnet --output-format text
+```
+
+**agy (only when in this run's roster) — permissions auto-approved, 10-minute print timeout (default is 5m, which can be short for review-sized prompts):**
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.code_review/agy" && OUTPUT=$(cat ../XX_PROMPT__<label>__agy.md | agy -p --print-timeout 10m 2>&1); STATUS=$?; echo "$OUTPUT"; if [ -z "$(echo "$OUTPUT" | tr -d '[:space:]')" ] || [ "$STATUS" -ne 0 ]; then echo "AGY_FAILED"; fi
+```
+
+If agy prints `AGY_FAILED`, drop it from this run's roster and proceed with opus + sonnet only — no stand-in needed, since that pair is already a complete two-reviewer roster on its own. If opus or sonnet itself fails (non-zero exit, empty output) — unusual, since both run through the same `claude` CLI executing this skill — proceed with whichever survived (plus agy, if in the roster); do not fabricate output for the missing slot.
+
+### Step 4: Consolidate findings
+
+> **Per subset.** When Step 1b planned multiple subsets, perform consolidation independently per subset (each subset has its own set of agent JSON outputs). Use subset-local finding ids like `<subset-name>:X1`, `<subset-name>:X2`, … so the subset is obvious downstream. Cross-subset deduplication is unnecessary because subsets contain disjoint files; if a finding happens to span subsets (e.g. an out-of-subset dependency you exposed via the `> Out-of-subset dependency:` header), assign it to whichever subset's reviewers raised it and leave the other subset alone.
+
+After every agent in the active roster returns, parse its JSON. **If the response contains multiple ```json fenced blocks (e.g. the model echoed the example schema), use the LAST block as the answer** — the templates instruct the model to emit its answer last, and any earlier block is an echo. If an agent returned prose, salvage what you can and flag the run as less reliable.
+
+- `AGY_FAILED` → proceed with opus + sonnet findings only.
+- If opus or sonnet failed with no counterpart to fall back on → proceed with the survivor(s).
+
+Deduplicate across agents (same file, overlapping lines, same root cause → one merged finding). Be conservative — only merge when clearly the same issue. When merging, take the higher severity.
+
+For each merged finding, assign a stable cross-val id `X1`, `X2`, … and record `file`, `lines`, `severity`, `title`, `claim`, `evidence`, `suggested_fix` (most self-contained variant when multiple agents flagged it). **`suggested_fix` must end up non-empty for every finding** — if every agent that flagged it left `suggested_fix` empty, write a concrete one-line fix yourself from the `claim`/`evidence` before moving on. Step 6 always prints a planned fix per finding, so there must be one to print.
+
+The set of unique findings — regardless of who flagged each one — is the input to Step 5. **Every reviewer in the active roster validates every finding** (including findings it originally flagged); the prompt removes explicit authorship signals (no reviewer name, no ordering hint, no "you said" framing). Note that the verbatim `claim` text retains its original stylistic fingerprint, so this is a soft (not absolute) protection against self-recognition bias.
+
+### Step 5: Peer validation pass
+
+> **Per subset.** When Step 1b planned multiple subsets, run a separate validation pass per subset, scoring only that subset's consolidated findings. Validator prompts use `<label>` = `<base-label>__<subset-name>`. Across all subsets the same concurrency cap from Step 1b applies; batch validators if running many subsets at once. Findings from different subsets are never mixed in a single validator prompt — that would force a validator to chase paths outside the subset it was scoped to.
+
+Every reviewer in the active roster (opus, sonnet, and agy if included) runs against **every** consolidated finding — including findings it originally flagged. The prompt is deliberately neutral and hides any framing about who proposed the issue. **All validators read from disk — no file contents are inlined**, since every CLI in this skill has disk access.
+
+Write `.code_review/XX_PROMPT__<label>_<agent>_validate.md`:
+
+````
+For each item below: read the cited source code and answer — do you agree with the finding? Provide a reason grounded in the actual code.
+
+Your cwd is `.code_review/<agent>/`. The source lives at `../..`. Read each cited file from disk before answering, prefixing paths with `../../`. Read freely within the target project directory and its subdirectories. Consult files outside the project only reluctantly, when a finding genuinely cannot be settled from inside the project.
+
+Output: a single JSON array in one ```json fenced code block, in the same order as the items below. No preamble. If multiple ```json blocks appear in your response (e.g. you echoed the example), only the LAST block is parsed. Each entry: `{"issue_id": "...", "verdict": "agree" | "disagree" | "unsure", "reason": "<cite specific code>"}`. Use `unsure` only when the cited code does not let you reach a confident answer.
+
+```json
+[
+  {"issue_id": "X1", "verdict": "agree",    "reason": "foo.py:42 calls bar() before bar is defined; bar is only set inside the `if cfg:` branch on line 47. Falsy cfg → NameError."},
+  {"issue_id": "X2", "verdict": "disagree", "reason": "Line 98 has `if x is None: return`, so x is provably non-None at line 100."},
+  {"issue_id": "X3", "verdict": "unsure",   "reason": "The cited code does not show enough of the surrounding control flow to decide."}
+]
+```
+
+Items:
+
+<for each consolidated finding, render in shuffled order, using ONLY the fields below — no reviewer names, no ordering hints, no framing about where the finding came from>
+### X<N>
+- file: <file>
+- lines: <lines>
+- finding: <claim>
+- reachability: <evidence>
+````
+
+Per-agent prompt rules:
+- **Shuffle the order of items independently for each validating agent.** This defeats position bias.
+- Every reviewer in the active roster gets the same full list of consolidated findings (including ones it originally flagged at detection).
+- **No reviewer attribution and no meta-framing.** Do not name any original finder; do not say "you wrote this" or "you flagged this"; do not reveal that this prompt follows an earlier *detection* pass or that another agent produced these claims. The agree/disagree question itself IS the task — `do you agree with the finding?` is fine and intentional; what's forbidden is exposing the multi-agent / peer-review workflow context.
+- Include `file`, `lines`, `finding` (the `claim` text), and `reachability` (the `evidence` text) per item — the detection schema promises validators will see both. Severity and any other Step-4 metadata are still omitted to avoid anchoring the verdict.
+- Do NOT inline file contents — every validator reads from disk.
+- **agy validator prompt ONLY (when agy is in the roster):** append the **agy narration-suppression block** (defined in Step 2, using the no-`<scratch>` wording) as the last lines of `XX_PROMPT__<label>_agy_validate.md`, for the same timeout reason as detection. The opus and sonnet validator prompts do not get it.
+
+**Launch the active roster's validators in parallel.** Each Claude validator uses the same pinned model as its own detection run — opus stays opus, sonnet stays sonnet. Pinning matters here: the point of splitting Claude into two slots is to compare Opus's and Sonnet's independent judgment on every finding, not just add a second inference pass at whatever the CLI's default happens to be.
+
+**Opus validator:**
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.code_review/opus" && cat ../XX_PROMPT__<label>_opus_validate.md | claude -p --model opus --output-format text
+```
+
+**Sonnet validator:**
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.code_review/sonnet" && cat ../XX_PROMPT__<label>_sonnet_validate.md | claude -p --model sonnet --output-format text
+```
+
+**agy validator (only when in this run's roster):**
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.code_review/agy" && OUTPUT=$(cat ../XX_PROMPT__<label>_agy_validate.md | agy -p --print-timeout 10m 2>&1); STATUS=$?; echo "$OUTPUT"; if [ -z "$(echo "$OUTPUT" | tr -d '[:space:]')" ] || [ "$STATUS" -ne 0 ]; then echo "AGY_FAILED"; fi
+```
+
+If the agy validator returns `AGY_FAILED`, drop it from validation for this run and proceed with the opus + sonnet verdicts using the two-slot tier scheme (Step 6) — this can happen even when agy succeeded at detection, since validation is a separate CLI call; treat detection and validation rosters as decided independently.
+
+If opus or sonnet's validator run fails, proceed with the survivor(s); do NOT manufacture a verdict for the missing slot.
+
+Parse each validator's JSON into per-issue verdicts. You now have, for each finding, one verdict per validator that actually ran (2 or 3).
+
+### Step 6: Synthesis
+
+> **Multiple subsets.** When Step 1b planned multiple subsets, the synthesis report combines all subsets into a single output. Re-number findings into a global `X1`, `X2`, … sequence and append `(subset: <subset-name>)` after each X-id label so the reader can see where each finding came from. Order severity tiers globally (all Critical findings first across all subsets, then High across all subsets, etc.). If any subset had its `> Note: this subset exceeds the recommended review size` header, surface that caveat once near the top of the report. If a subset returned zero findings at any tier, you do not need a per-subset placeholder — the tier-level `None.` rule still applies globally.
+
+For each finding, compute a confidence label **purely from validator verdicts**. Who originally flagged the issue at detection is not used at synthesis — every active validator scored every finding.
+
+Each validator returns one of `agree`, `disagree`, `unsure` per finding (those are the only valid verdicts — "unverified" is not a verdict).
+
+**Pick the tier scheme once per run, based on how many validator slots actually returned a verdict** (not how many were originally planned — a mid-run `AGY_FAILED` at validation still counts as "didn't run"):
+
+**Three validators ran (opus, sonnet, agy):** apply top-down, first match wins:
+1. **Rejected** — 2 or more `disagree`, no `agree`.
+2. **Unanimous** — all three returned `agree`.
+3. **Controversial** — at least one `agree` AND at least one `disagree` (a genuine split among voters). Show every dissenting reason inline.
+4. **Agreed** — 2 or more `agree`, no `disagree`.
+5. **Inconclusive** — everything else (unsure-heavy, or too few opinions to decide).
+
+**Two validators ran (opus, sonnet only — agy skipped, unavailable, or dropped mid-run):** apply top-down, first match wins:
+1. **Rejected** — both slots ran and both returned `disagree`.
+2. **Agreed** — both slots ran and both returned `agree`.
+3. **Disputed** — both slots ran, one `agree` and one `disagree`. Show both reasons inline.
+4. **Inconclusive** — everything else: any `unsure` involved, OR only one validator slot ran at all. A single surviving verdict is never enough on its own to reach Agreed/Rejected/Disputed — it needs corroboration from a second validator. Show the lone verdict and reason so the reader can weigh it themselves.
+
+**Do NOT re-judge severity at synthesis.** The reviewers/validators saw the code; you're working from JSON. Your job is narrow: deduplicate, label confidence, present. Use the merged severity from Step 4. If you think a verdict is weak, surface that as a user-facing note next to the finding — do not silently downgrade or drop it.
+
+**Present** grouped by severity tier. For each tier, list findings or write `None.` explicitly. Every bullet starts with the X-id in bold. The label lists each active validator's verdict in a fixed order (Opus, Sonnet, agy — dropping agy from the list entirely when it isn't in this run's roster) so the reader can see at a glance how each model voted — but do NOT mention who originally flagged the issue.
+
+**Every finding gets a `Fix:` line — no exceptions.** Print it as a second line under the bullet, using the finding's (possibly synthesizer-authored, per Step 4) `suggested_fix`. This lets the reader decide apply/skip from the report alone, without re-opening each agent's raw JSON. For a `Rejected` finding, replace the fix text with a one-line note that no fix is planned since validators treat it as a false positive — do not invent a code fix for something the review concluded isn't real.
+
+```
+## Critical (must fix immediately)
+- **X1** [Unanimous: Opus agree, Sonnet agree, agy agree] Description… (file:line)
+  Fix: <concrete one-line fix>
+
+## High (likely bugs / significant hazards)
+- **X2** [Agreed: Opus agree, Sonnet agree] Description… (file:line) — agy not in this run's roster.
+  Fix: <concrete one-line fix>
+- **X3** [Controversial: Opus agree, Sonnet disagree — "<reason>", agy agree] Description… (file:line)
+  Fix: <concrete one-line fix>
+- **X4** [Disputed: Opus agree, Sonnet disagree — "<reason>"] Description… (file:line)
+  Fix: <concrete one-line fix>
+
+## Medium (quality issues)
+- **X5** [Rejected: Opus disagree — "<reason>", Sonnet disagree — "<reason>", agy disagree — "<reason>"] Description… (file:line) — included for transparency; no validator agrees, treat as a likely false positive.
+  Fix: None planned — treated as a false positive.
+- **X6** [Inconclusive: Opus agree, agy unavailable] Description… (file:line) — agy's validator failed mid-run; only one validator vote available.
+  Fix: <concrete one-line fix>
+```
+
+For Disputed / Controversial / Inconclusive items, always include each non-`agree` validator's short reason in quotes.
+
+**Offer to fix.** Ask which findings to apply, by X-id (e.g. "apply X1 and X3").
+
+### Step 7: Mark the review complete
+
+Once the user has triaged the findings — either by responding to all or most of them (apply / dismiss / "skip the rest") or explicitly signalling they're done — write an empty marker file so future runs (and the user) can tell that this review was closed out:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" && touch .code_review/XX__CODE_REVIEW_COMPLETED
+```
+
+`XX` is the same run id chosen in Step 1, so the marker sits alongside that run's prompts under `.code_review/`. Do NOT write this marker preemptively after just presenting the synthesis — it means the user has actually engaged with the findings, not merely seen them.
+
+## Notes
+
+- Large projects are split into independent subsets at Step 1b (~6k lines / ~40 files / ~300 KB threshold), with Steps 2–5 running per subset in parallel under a concurrency cap, and Step 6 merging all subsets into a single global report.
+- The two Claude slots are **pinned** (`--model opus`, `--model sonnet`) in both detection (Step 3) and validation (Step 5) — the whole point of the split is to compare Opus's and Sonnet's independent judgment, not to add a second run at whatever the CLI's default model happens to be.
+- agy is optional and purely additive. It's included only when the `agy` CLI is found on PATH AND the user hasn't asked to skip it (`--no-agy`, "skip agy", "without agy"). If it fails at detection or validation, it's simply dropped from the roster for that step — there's no stand-in, since opus + sonnet is already a complete two-reviewer roster on its own.
+- **Every reviewer in the active roster validates every finding** (including ones it originally flagged at detection). The prompt removes explicit origin signals — no reviewer name, no ordering hint, no "you said" framing. Self-recognition via stylistic fingerprints in the verbatim `claim` text is a known residual risk (frontier evaluators recognize their own outputs above chance — Panickssery et al. 2024), so treat this as a soft, not absolute, protection.
+- Claim order is shuffled independently per validator to defeat position bias.
+- Synthesis labels are derived **purely from validator verdicts**, not from who originally flagged the finding. Detection only determines what gets into the candidate list; validation determines confidence.
+- Validators are told to read freely inside the target project directory; consulting files outside the project is allowed only reluctantly when a claim genuinely cannot be settled from in-project code.
+- The confidence-tier scheme (Step 6) is chosen per run based on how many validator slots actually returned a verdict — 3 slots use Unanimous/Agreed/Controversial/Rejected/Inconclusive; 2 slots use Agreed/Disputed/Rejected/Inconclusive. Detection and validation rosters are decided independently, so it's possible for agy to contribute detection findings but drop out of validation (or vice versa).
+- If opus or sonnet fails with no counterpart to fall back on, proceed with the survivor(s) — never invent a verdict for the missing slot. A single surviving validator verdict on its own always lands in the Inconclusive tier (see Step 6) since it lacks corroboration.
+- If a review is requested multiple times, write each prompt as if it's the first review — do not mention prior reviews.
+

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ ENV/
 
 # tokens
 slack_creds.py
+
+# Per-developer Claude notes (machine-specific paths, cluster names)
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# gnomad_methods
+
+Shared Hail utility library for gnomAD pipelines. **This is a library, not a pipeline** — it exposes APIs that other repos (`gnomad_qc`, `gnomad-constraint`, and others) import, so public-API changes ripple outward. Prefer additive changes over breaking renames.
+
+## gnomAD & Hail institutional knowledge
+
+`knowledge/` is a shared reference of gnomAD + Hail institutional knowledge maintained by the methods group: silent-fail bug classes, design tradeoffs, release conventions, and facts that are hidden in the source.
+
+**Consult [`knowledge/README.md`](knowledge/README.md) before writing gnomAD- or Hail-touching code.** It is a routing index — read it, then load only the sub-document you need (missingness, Hail idioms, lazy evaluation, partitioning/shuffles, VDS, gnomAD-specific, biology, analysis patterns, Dataproc, release conventions, testing) rather than the whole tree.
+
+It is also where new institutional knowledge belongs. The contribution rules live in that README; the two that matter most are **never add a fact you have not verified** (against the Hail source, the official docs, or a job you actually ran) and **propose entries to the user before writing them**.
+
+## Verbosity: write less prose than you think you should
+
+Applies to docstrings, comments, and the text of a PR description alike. The default failure mode of an AI assistant here is too much prose, not too little.
+
+- **Comments explain *why*, never *what*.** If a line needs a comment to say what it does, rename something instead. A comment restating the code is worse than no comment: it goes stale and it dilutes the comments that matter.
+- **Don't comment or docstring code you didn't touch.** A diff that adds explanation to surrounding lines is harder to review and buries the actual change.
+- **Docstrings: one summary line, then only what a caller can't infer from the signature.** `:param ht: Input Table.` earns nothing. Spend the words on units, defaults that matter, filters already applied, and invariants the caller must satisfy.
+- **No section headers, bullet summaries, or restatements of the request** in an explanation. Say the thing once.
+- **When there's nothing to say, say nothing.**
+
+The test: delete a sentence. If nothing is lost, it should not have been there.
+
+## CLAUDE.md vs CLAUDE.local.md
+
+`CLAUDE.md` is committed and holds facts true for anyone working in this repo. `CLAUDE.local.md` is gitignored and holds anything tied to one person's machine — absolute paths, conda env names, cluster names, GCP projects.
+
+Decide by portability: if a new contributor on a different laptop would need it, it belongs here. When in doubt, prefer this file with a placeholder (`<repo-root>`, `<cluster>`) over the local file with a concrete value. See [`knowledge/working-with-ai.md`](knowledge/working-with-ai.md) for the longer version, including how to bootstrap both files.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 This repo contains a number of [Hail](https://hail.is/) utility functions and scripts for the [gnomAD project](http://gnomad.broadinstitute.org) and the [Translational Genomics Group](https://the-tgg.org). As we continue to expand the size of our datasets, we are constantly seeking to find ways to reduce the complexity of our workflows and to make these functions more generic. As a result, the interface for many of these functions will change over time as we generalize their implementation for more flexible use within our scripts. We are also continously adapting our code to regular changes in the Hail interface. These repos thus represent only a snapshot of the gnomAD code base and are shared without guarantees or warranties.
 
 We therefore encourage users to browse through the [API reference](https://broadinstitute.github.io/gnomad_methods/api_reference/) to identify modules and functions that will be useful in their own pipelines, and to edit and reconfigure relevant code to suit their particular analysis and QC needs.
+
+## gnomAD & Hail institutional knowledge
+
+[`knowledge/`](knowledge/README.md) is a reference of gnomAD + Hail institutional knowledge maintained by the methods group: silent-fail bug classes, design tradeoffs, and facts that are hidden in the source. Start at the README — it routes you to the relevant sub-document.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,8 @@
 # Generated files
 api_reference
 
+# Copied from ../knowledge by build.sh
+knowledge
+
 # sphinx-build output
 html

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -6,5 +6,10 @@ cd "${DOCS_DIR}"
 rm -rf api_reference
 ./generate_api_reference.py
 
+# The knowledge tree lives at the repo root (readable on GitHub, not coupled
+# to this build); stage a copy here so Sphinx can render it into the site.
+rm -rf knowledge
+cp -R ../knowledge knowledge
+
 rm -rf html
 python3 -m sphinx -W -b html . html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,10 @@ extensions = [
 # README.md contains developer documentation for building docs
 exclude_patterns = ["README.md"]
 
+# Generate anchors for headings in Markdown so the knowledge tree's
+# cross-document links (file.md#some-heading) resolve.
+myst_heading_anchors = 3
+
 master_doc = "index"
 
 html_theme = "sphinx_rtd_theme"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,5 +14,6 @@ Contents
    Getting Started <getting_started>
    Examples <examples/index>
    API Reference <api_reference/index>
+   gnomAD & Hail Knowledge <knowledge/README>
    Resource Sources <resource_sources>
    Change Log <https://github.com/broadinstitute/gnomad_methods/releases>

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -1,0 +1,234 @@
+# gnomAD & Hail reference — institutional knowledge
+
+Reference doc for anyone — AI or human — working with gnomAD data + Hail.
+Contents range across:
+
+- Classes of bug that **produce plausible-looking wrong output rather
+  than crashes** (the original motivation — silent-fail traps).
+- **Design considerations** for gnomAD-touching analyses — when to
+  prefer one pattern over another, tradeoffs that aren't obvious from
+  the code.
+- **Useful-but-hidden facts** about the datasets, HT schemas, and
+  cross-repo conventions — the kind of thing that's known to the
+  methods group by folklore but not easy to find from source.
+
+Prefer the listed patterns and considerations when writing new analysis
+code, and use the symptoms + design notes as a checklist when
+scoping or debugging.
+
+---
+
+## Which sub-doc do I need?
+
+Load only the one you need — that's the point of the split.
+
+| sub-doc | consult it when |
+|---|---|
+| [Missingness](missingness.md) | you touch a nullable field, a `hl.case` / `hl.if_else`, a `group_by` on a derived key, or a max/min over floats that could be NaN |
+| [Hail idioms](hail-idioms.md) | you rebind `ht`, build a big literal or many-branch expression, join with `ht[key]`, sort with `order_by`, use scans, or reach for a Python UDF |
+| [Lazy evaluation and materialization](lazy-eval-and-materialization.md) | you add a logging `.count()`, or you're choosing between `cache` / `persist` / `checkpoint` |
+| [Partitioning, shuffles, and OOM](partitioning-shuffles-oom.md) | a job dies in a shuffle, you're about to `repartition`, or you want to know what shuffles in the first place |
+| [Hidden and undocumented APIs](hidden-apis.md) | you meet an underscore-prefixed Hail parameter in gnomad_qc, or want the `hl.experimental` helpers we use |
+| [gnomAD-specific](gnomad-specific.md) | you filter variants, index into `freq`, or cross HTs with different variant sets |
+| [VDS](vds.md) | you subset or densify a VDS, or you're choosing between Table / MatrixTable / VDS |
+| [Biology](biology.md) | reference builds, multiallelics, sex chromosomes, trios, AC/AF null semantics, or what QUAL and LOFTEE do and don't tell you |
+| [Release conventions and data policy](dataset-conventions.md) | you wonder why the data is shaped the way it is — annotation versions, subsets, constraint cutoffs across releases, labels, requester-pays |
+| [Codebase and analysis patterns](analysis-patterns.md) | you pick a starting table, a VEP transcript, a bucket scheme, or a per-stratum aggregation |
+| [Dataproc / operational](dataproc-operational.md) | you run, size, package, or post-mortem a job on Dataproc or QoB, or you're wondering why storage costs what it does |
+| [Testing](testing.md) | after any refactor of the join graph or aggregation semantics, and before you pay for a cluster run |
+| [Working with an AI assistant](working-with-ai.md) | you're setting up `CLAUDE.md` / `CLAUDE.local.md`, or wondering what's burning tokens and cluster time |
+
+
+Entries are tagged **`[Hail]`** (universal Hail behavior) and/or
+**`[gnomAD data]`** (dataset- or schema-specific). Entries tagged
+**`[internal only]`** describe data or artifacts available only to the
+internal production team — unreleasable samples, the pre-release VDS,
+internal QC tables. Everything untagged that way applies to anyone
+working with released gnomAD data.
+
+---
+
+## For AI or human reading this file
+
+**What this file is:** a shared reference maintained by the gnomAD
+methods group. It captures data-model quirks, Hail idioms, codebase
+conventions, and design-choice tradeoffs — the kind of institutional
+knowledge that usually only gets learned by running into the problem
+(or being told by someone who already did).
+
+**When to consult it:** any time you're touching gnomAD annotation
+tables, writing Hail aggregations, filtering by QC status, making
+assumptions about coverage between HTs, or picking between two
+reasonable-sounding analysis approaches. See the [When to consult this
+](#when-to-consult-this) section at the bottom for the concrete trigger
+list.
+
+---
+
+### How to contribute
+
+**Rules — these come first** (and apply to AI assistants especially):
+
+1. **Never guess. No claims without proof.** Verify every fact against
+   the official Hail docs, the Hail source, or a tiny job you actually
+   ran. Never reference a function that doesn't exist. If you can't
+   verify it, don't add it.
+2. **Propose, don't edit.** Surface candidate entries to the user and
+   get a yes before writing. This doc bloats easily; only high-value or
+   recurring issues belong.
+3. **Be concise.** Tight entries, no padding. Prefer one line over a
+   paragraph.
+4. **Don't duplicate the official Hail docs.** Link them; capture only
+   the non-obvious or anecdotal part.
+5. **Tag every entry** (format below).
+6. **Build the docs before opening the PR.** These pages are published
+   to the documentation site, so CI renders them with
+   `sphinx -W` — warnings are errors, and a malformed entry fails the
+   build rather than merely looking odd on GitHub:
+
+   ```sh
+   pip install -r docs/requirements.docs.txt
+   ./docs/build.sh
+   ```
+
+   Three things GitHub renders happily and Sphinx rejects:
+   - **Adjacent `---` rules** with nothing between them.
+   - **Skipping a heading level** — entries are `##` under the page's
+     single `#` title. Don't reach for `###`.
+   - **Non-Python placeholders in a ` ```python ` block** — `…` outside
+     a string literal can't be lexed. Use `...`, or drop the fence's
+     language tag.
+
+**What clears the bar.** If during a session you learn something that
+would help future readers — a bug you hit, a design choice you had to
+reason through, a fact that took a while to piece together from code —
+propose an entry. It should be:
+
+1. **Non-obvious**: not readily discoverable from Hail / gnomAD docs or
+   from a `grep` in the code. You either ran into it, or someone told
+   you, or you had to reason your way to it.
+2. **Generalizable**: applies beyond one specific analysis. If it's
+   one-file-specific, it belongs in that file's docstring instead.
+3. **Actionable**: a future reader can use it. Either "use this pattern
+   instead of that one" or "know this fact before you make this
+   choice" — not just background context.
+
+**Item categories worth capturing:**
+- **Silent-fail bugs** — the wrong pattern produces a plausible answer.
+  Fixing these silently improves any analysis that would have hit them.
+- **Design-choice tradeoffs** — e.g. "canonical vs MANE Select
+  transcript picking, and when each is right"; "per-population EM vs
+  full-cohort EM"; "when to drop OE-candidate × candidate pairs vs keep
+  them." Documenting these lets a future analysis start with the right
+  default.
+- **Hidden-in-code facts** — things about HT schemas, path
+  conventions, filter definitions, or upstream pipeline behavior that
+  aren't apparent without reading the source. Reduces "why does this
+  do that" debugging.
+- **Cross-cutting conventions** — things like "adj is per-genotype and
+  separate from variant-level filters"; "the v4 VDS is stored split";
+  "test-mode output paths can differ between steps of the same
+  pipeline, so a test run isn't necessarily self-consistent."
+
+**Contribution format:** every item follows this shape:
+- **Heading** (`##`) — one-line "the thing" summary, in whichever
+  sub-document fits (see the routing table above). If nothing fits, a
+  new sub-document is fine — add it to the routing table and to this
+  README's `toctree` so the docs build can find it.
+- **One-paragraph explanation** of the mechanism / rationale.
+- **Code example** where relevant (fenced code block, small).
+- **Symptom** for silent-fail items ("aggregation totals < input
+  rowcount", etc.), OR **Tradeoff** for design items (what does each
+  option cost / gain), OR **Where to find more** for hidden-fact items
+  (file paths, upstream repo, etc.).
+- **Recommendation / rule of thumb**.
+- **Scope tag** — one of **`[Hail]`** (universal Hail behavior),
+  **`[gnomAD data]`** (dataset/schema-specific), or both. Add
+  **`[internal only]`** for anything that applies solely to the internal
+  production team (unreleasable samples, internal bucket paths).
+- **Hail version** — whenever the behavior is version-dependent, state
+  the version it was verified on (`Verified on Hail 0.2.134`). Behavior
+  noted for one version can change.
+
+Add new items in whichever section fits best. If nothing fits, add a
+new section — but tell the user first so we can decide whether that
+section belongs.
+
+Do **not** add:
+- One-off analysis details (put in the analysis's docstring)
+- Anything already well-covered in Hail docs
+- Anything about specific code paths (belongs in code comments)
+- Full explainers of biology / statistics / methods — this file is a
+  quick-reference, not a textbook
+
+**When to re-look at this doc:** on every Hail version bump, re-verify
+the entries carrying a `Verified on Hail X` line — those are the ones
+whose behavior can silently change under you. Also re-read it when a
+gnomAD release changes schema (v4.1 → v5).
+
+---
+
+## When to consult this
+
+Before writing new gnomAD-touching analysis code, especially:
+
+- Anything that **filters variants** — see [gnomAD-specific](gnomad-specific.md#gnomad-specific)
+  (filters, only_filters.ht, releasability).
+- Anything with **`hl.case`, `hl.if_else`, set/dict ops on nullable
+  fields** — see [Missingness](missingness.md#missingness).
+- Anything that **group_by / agg_group_by on derived keys** — same.
+- Anything that takes a **max / min over float data that can be NaN** —
+  same section; `hl.max` and `hl.agg.max` disagree on NaN.
+- Anything that builds a **many-branch expression or a per-stratum
+  breakdown in one row op** (a `hl.case` with many `.when`s, or a dict
+  comprehension of heavy sub-exprs) — the `ClassTooLargeException` item
+  in [Hail idioms](hail-idioms.md#hail-idioms); prefer the loop-restrict-per-stratum
+  pattern in [Codebase / analysis patterns](analysis-patterns.md#codebase-and-analysis-patterns).
+- Anything that calls an **`hl.experimental` numeric kernel / iterative
+  solver** (EM, statistical routines) — cast dtypes and assert value
+  invariants first; see the un-validated-kernel item in
+  [Hail idioms](hail-idioms.md#hail-idioms).
+- Anything that adds a **logging `.count()` / `.show()`** to a pipeline
+  — see [Lazy evaluation and materialization](lazy-eval-and-materialization.md#lazy-evaluation-and-materialization);
+  it's free after a checkpoint and a full re-run before one.
+- Anything that **indexes into `freq` arrays** — the freq[0] item.
+- Anything that touches **trios, family data, or non-release samples**
+  — releasability + trio gotchas.
+- Anything that **picks a single VEP transcript** — the MANE / canonical
+  item.
+- Anything that **reads HTs whose filter provenance is unclear** — the
+  bake-time-vs-read-time item.
+- Anything that **subsets a VDS** (samples or sites) or densifies one —
+  see [VDS](vds.md#vds); filtering one of the two MatrixTables alone corrupts
+  the densified output silently.
+- Anything involving **sex chromosomes, PAR, or multiallelics** — see
+  [Biology](biology.md#biology).
+- Anything that **densifies the v4 VDS and classifies genotypes**
+  (het / hom-var counts, freq, phasing) — the high-AB correction +
+  operation-order item under [gnomAD-specific](gnomad-specific.md#gnomad-specific).
+- Anything you **run or debug on Dataproc** — log capture and
+  post-mortems in [Dataproc / operational](dataproc-operational.md#dataproc--operational),
+  especially when a job dies with no Python traceback.
+
+And after any bug that looks like "the total is smaller than I
+expected but there's no error message" — that's almost always a
+`hl.case`/`hl.if_else`/`group_by` null drop.
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+missingness.md
+hail-idioms.md
+lazy-eval-and-materialization.md
+partitioning-shuffles-oom.md
+hidden-apis.md
+gnomad-specific.md
+vds.md
+biology.md
+analysis-patterns.md
+dataproc-operational.md
+dataset-conventions.md
+testing.md
+working-with-ai.md
+```

--- a/knowledge/analysis-patterns.md
+++ b/knowledge/analysis-patterns.md
@@ -1,0 +1,237 @@
+# Codebase and analysis patterns
+
+## Row-set anchor determines what "could possibly appear"
+
+**`[Hail]` + `[gnomAD data]`**
+
+`hl.Table.filter()` removes rows; it can never add them. Similarly, an
+"annotate" step's `.annotate(**...)` adds *columns* but not *rows* — the
+row set is fully determined by the input HT's row set. Choice of the
+starting HT (the "anchor") determines the outer bound on what downstream
+code can see.
+
+**Two concrete instances** where this trap fires in the variant-
+cooccurrence pipeline:
+
+1. **`assemble_sites_ht`** starts with `ht = vep_ht.select("vep")` —
+   anchoring on `vep_ht`. If a variant is in the filter HT but missing
+   from vep_ht, it's gone before any `.filter()` runs. Swapping the
+   filter for something more permissive doesn't help.
+
+2. **`annotate_phased_ht_with_sites`** takes a `phased_ht` and adds
+   `v1_ann`/`v2_ann` per-endpoint via sites-HT lookup. The output's
+   row set is `phased_ht`'s row set. If you swap in a more permissive
+   sites HT but leave `phased_ht` pointing at a release-scoped table,
+   trio-only pairs (absent from the release phased HT) still get no
+   annotation row — they get null `v_ann` on the downstream left-join
+   from consumers. The fix isn't in the sites HT, it's in what you pass
+   as `phased_ht`. Anchor on the trio-comparison HT if you want trio-
+   only pairs annotated.
+
+**Symptom of getting this wrong:** you build a "permissive" annotation
+path and downstream aggregations produce bit-identical output to the
+release-scoped baseline. The permissive lookups happened, but the row
+set never grew.
+
+**Rule of thumb:** anchor on the widest-coverage table for the
+semantics you want. Join everything else with nullability tolerance
+downstream. When you have both a "release" and a "trio-inclusive"
+consumer, you likely need two annotated HTs — one anchored on the
+release pair space, one on the trio comparison. Document the anchor
+choice in the function docstring so callers can predict what's missing.
+
+---
+
+## Multi-source variants collapse to one "priority" tag
+
+**`[gnomAD data]`**
+
+Analyses that assign a single "priority" tag per variant (source-set →
+priority-source) pick from a priority list. That priority list is a
+design decision — not obvious from input tags.
+
+Example: `SOURCE_PRIORITY = ["clinvar_plp", "hc_lof", "splice_path",
+"clinvar_vus", "in_trans_oe_candidate", ..., "clinvar_blb"]`. A variant
+tagged both `clinvar_blb` and `in_trans_oe_candidate` gets priority
+= `in_trans_oe_candidate` (because `clinvar_blb` is at the *bottom* of
+the list — a deliberate choice for that analysis).
+
+**Symptom:** apparent tag counts don't sum to source-set counts.
+**Fix:** document the priority order visibly in code and downstream
+analysis narratives.
+
+---
+
+## VEP transcript picking: canonical vs MANE Select vs first vs explode-all
+
+**`[gnomAD data]`**
+
+A variant has many `transcript_consequences`. Different analyses pick
+different representative transcripts:
+
+- **Explode all** — one row per (variant, transcript). Right when you
+  need per-transcript info.
+- **Canonical** — `tc.canonical == 1`. Ensembl's designated canonical
+  transcript per gene.
+- **MANE Select** — `tc.mane_select` defined and non-empty. NCBI/EBI
+  joint standard; generally preferred over canonical when available.
+- **First** — `tcs[0]`. Order depends on VEP config; can be non-coding
+  or a pseudogene transcript when the variant is intergenic.
+
+The gotcha: picking `tcs[0]` when the first transcript is non-coding
+gives a `gene_symbol = null` for a variant that clearly has a real
+gene. Silently blanks out downstream per-gene tables. In one session
+this caused MUC16/FBN3 to disappear from gene-symbol columns.
+
+**Recommended:** filter to protein-coding Ensembl transcripts first,
+then prefer canonical → MANE Select → first → `or_missing()`. Document
+the pick order at the call site.
+
+**The same trap applies to per-transcript pathogenicity scores.** REVEL
+and similar predictors emit a score **per transcript**, not per variant.
+Collapsing them with `max` is common and quietly picks whichever
+transcript scored highest — which is frequently not the canonical or MANE
+transcript, and not the one your consequence annotation came from
+(*reported · project meeting*). If your consequence and your score are
+chosen by different rules, they describe different transcripts. Pick the
+transcript first, then take that transcript's score.
+
+---
+
+## `missing_*` / "other" default buckets: check what they actually catch
+
+**`[Hail]` + `[gnomAD data]`**
+
+A `hl.case().default("missing_af")` (or `"unknown"`, `"other"`, etc.) is
+a *catch-all* for pairs that didn't match any preceding `.when()`. It
+does **not** mean "the AF value was null" — it means "the AF didn't fit
+any of the buckets you defined."
+
+Concrete failure mode from a session:
+
+```python
+AF_BUCKETS = [
+    ("Singleton", ...),
+    ("(0, 1e-4)", 0.0, 1e-4),
+    ("[1e-4, 1e-3)", 1e-4, 1e-3),
+    ("[1e-3, 1e-2)", 1e-3, 1e-2),
+    ("[1e-2, 5e-2)", 1e-2, 5e-2),  # ← ceiling at 5e-2
+]
+# Any variant with AF ≥ 5e-2 falls through to the default:
+case.default("missing_af")
+```
+
+If the analysis populates the pair list from a dataset that includes
+higher-AF variants (e.g., OE-candidate expansion up to AF 0.5), those
+common variants land in `missing_af` — same bucket as genuinely null-AF
+variants. The label is misleading. We saw a session where 438k of 682k
+trio pairs (64%) landed in `missing_af` and were interpreted as "AC0
+coverage gap" — actually they were common-AF variants overflowing Guo
+2024's rare-focused bucket range.
+
+**Rule of thumb:**
+- Name catch-all default buckets by what they *catch* ("out_of_range",
+  "af_gte_5e-2"), not by what you *hope* they catch ("missing_af").
+- If a plausible input range extends past your bucket ceiling, add
+  an explicit bucket for it rather than relying on the default.
+- Before interpreting a large "missing" bucket as a coverage gap, sanity-
+  check by looking at the actual input distribution. Ideally emit
+  separate default and null buckets:
+  ```python
+  case = case.when(hl.is_missing(af_expr), "null_af")
+  # ... range buckets ...
+  return case.default("out_of_range")
+  ```
+
+**Symptom:** a large fraction of your pairs end up in the default
+bucket, and interpreting the fraction as a coverage / annotation-scope
+issue leads you down a rabbit hole that's actually about bucket-range
+design.
+
+---
+
+## Import paths from a resource module; don't type bucket paths in analysis code
+
+**`[gnomAD data]`**
+
+Dataset paths belong in a versioned resource module, not in the script
+that uses them:
+
+```python
+from gnomad_qc.v3.resources import gnomad_v3_genotypes_vds   # good
+vds_path = "gs://.../v3.1/raw/gnomad_v3.1.vds"               # bad
+```
+
+Two reasons, and the second is the one that bites. First, everyone
+resolves the same version of the same artifact. Second, a hardcoded path
+is invisible to the *next* release: when a dataset is re-cut, moved, or
+superseded, the resource module gets updated and every consumer follows,
+while pasted paths keep silently reading last year's data — a job that
+still runs, on the wrong input.
+
+This applies to this doc too: entries here name artifacts by what they
+are and how to reach them through a resource function, not by bucket
+path.
+
+**Related, on cost rather than correctness:** before a large or
+expensive run, it's worth asking someone who has run something similar
+what cluster configuration they used. Compute for a genome-scale job is
+easy to over- or under-provision by an order of magnitude, and both
+directions cost real money.
+
+---
+
+## Aggregation-time vs bake-time filters — both need documenting
+
+**`[gnomAD data]`**
+
+If your on-disk HT has 1M rows but a downstream analysis shows 700k
+rows, you need to know *where* the filter was applied — inside a
+Dataproc job that wrote the HT, or inside the loader at read time.
+
+Common example: mega-gene exclusion via `--exclude-gene-ids` gets baked
+into some HTs at build time, but not others. Downstream loaders may
+re-apply the exclusion at read time. `ht.count()` on the raw on-disk
+HT gives one number; `_load_trio_ht(args).count()` gives another.
+Neither is wrong.
+
+**Rule of thumb:** in the docstring of any function that returns an
+HT, list the filters applied. When passing HT paths as CLI overrides,
+expect that the caller may not know what filters are baked in.
+
+---
+
+## Per-stratum aggregates: loop-restrict-per-stratum, don't one-pass-inline-all
+
+**`[Hail]`**
+
+For per-population (or any per-stratum) counts / EM over a large keyed
+dataset, prefer **restrict the cohort to each stratum, aggregate that
+stratum on its own, then assemble the strata** over computing every
+stratum in a single pass. Two payoffs:
+
+1. **Codegen-safe** — sidesteps the `ClassTooLargeException` cliff (one
+   heavy expression per stratum inlined into one row op; see
+   [Hail idioms](hail-idioms.md#hail-idioms)).
+2. **Cheaper shuffle** — each pass moves only that stratum's (smaller)
+   data. Restricting a per-variant sample-set encoding to one group and
+   re-indexing to that group's dense sample space shrinks the stored sets
+   ~by the group's cohort fraction, so the co-partition / join shuffle is
+   a fraction of the full-cohort size.
+
+Derive the `"all"` stratum as the **element-wise sum over strata** (v2's
+fold-sum), valid when the strata partition the cohort (every sample has a
+group label); don't run a separate full-cohort pass for it.
+
+**Tradeoff:** K passes instead of 1. But each pass is smaller *and it
+actually completes at K≥3*, where the one-pass form both blows codegen and
+shuffles the full-cohort sets. For a handful of strata this is a clear win;
+for hundreds of tiny strata, reconsider (per-pass fixed overhead adds up).
+
+**Where this lives:** the variant-cooccurrence per-population counts
+(`compute_counts_by_pop`: `restrict_encoded_to_pops` per group → flat
+count → assemble; `"all"` = sum over groups).
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/biology.md
+++ b/knowledge/biology.md
@@ -1,0 +1,246 @@
+# Biology
+
+Fewer of these came up in a specific recent session; contribute more as
+you hit them.
+
+## Multiallelic sites: split vs unsplit changes everything
+
+**`[Hail]` + `[gnomAD data]`**
+
+A single VCF row like `chr1:100 A→G,T` splits into two biallelic rows
+`chr1:100 A→G` and `chr1:100 A→T`. Whether your HT is split determines:
+- Whether `(locus, alleles)` is a unique key (split: yes; unsplit: no —
+  same locus appears multiple times with a length-≥3 alleles array)
+- Whether AC / AF are per-alt or aggregated
+- Whether VEP consequences are per-alt or shared
+
+Reading an unsplit HT and treating it as split (or vice versa) produces
+plausible-looking wrong output. Check `hl.experimental.split_multi_hts`
+or `hl.split_multi` provenance before joining. The v4 VDS is read split
+by convention; v2 was mixed.
+
+**Canary: an AF spike at exactly 0.5.** A pile-up of allele frequencies
+landing on 50% is a classic signature of multiallelic mishandling — a QC
+or splitting step that forces AF to 0.5 at multiallelic sites rather than
+apportioning it (*reported · project meeting*). If a frequency histogram
+has a spike at 0.5 that biology doesn't explain, check how multiallelics
+were split before interpreting anything downstream.
+
+---
+
+## Reference genome coordinates: GRCh37 vs GRCh38
+
+**`[Hail]` + `[gnomAD data]`**
+
+gnomAD v2 is GRCh37; v3/v4 are GRCh38. Loci from different builds are
+not comparable. Cross-referencing v2 and v4 requires liftOver (which
+loses ~1–2% of variants and may flip alleles). Related: chromosome
+naming (`1` vs `chr1`) and MT vs chrM. Hail's `hl.get_reference('GRCh38')`
+uses `chrN` prefix.
+
+**Hail defaults to GRCh37** (`[Hail]` · verified on 0.2.134). `hl.init()`
+without `default_reference=` gives you GRCh37, so `hl.locus`,
+`hl.parse_locus_interval`, and `hl.tlocus()` all build GRCh37 objects
+unless told otherwise. Because GRCh38 in Hail uses `chr`-prefixed
+contigs, the mismatch usually surfaces as a loud error (`invalid
+interval expression: 'chr1:1000-2000'`, or a reference mismatch on a
+join) — but it surfaces *at execute time*, which on Dataproc means
+you've paid for the cluster to get there.
+
+```python
+hl.init(default_reference="GRCh38", tmp_dir="gs://…")                 # do this
+hl.parse_locus_interval("chr1:1000-2000", reference_genome="GRCh38")  # or be explicit
+```
+
+---
+
+## Reference false duplications make some medically relevant genes unreliable
+
+**`[gnomAD data]` · Verified against the paper and the shipped browser flag**
+
+Both GRCh37 and GRCh38 contain **false duplications** — regions
+erroneously present twice in the reference. Reads that belong to one
+real locus get split across the copies, so coverage and genotypes at the
+real gene are wrong, and the effect is **reference-specific**: a gene
+broken in GRCh38 can be fine in GRCh37 and vice versa. Wagner et al.
+([*Nat Biotechnol* 2022](https://www.nature.com/articles/s41587-021-01158-1))
+characterized 273 of the ~395 medically relevant genes that standard
+benchmarks exclude for repetitiveness, and found that masking these false
+duplications improved variant recall **from 8% to 100%** in affected
+genes.
+
+On GRCh38 the ones that matter for gnomAD are **CBS, KCNE1, and CRYAA**.
+The browser flags exactly these three on GRCh38:
+
+> Variant calls in this gene may be missing or unreliable due to false
+> duplications in the GRCh38 reference.
+
+**What this means for you:** absence or an odd frequency in one of these
+genes is a reference artifact until proven otherwise. Because the defect
+is build-specific, cross-checking the other build (v2, on GRCh37) is a
+genuine diagnostic rather than a fallback. Long-read and assembly-based
+callsets — the All of Us CMRG callset is the one gnomAD plans to
+integrate — are the real fix.
+
+---
+
+## Sex chromosomes: X/Y ploidy, PAR regions
+
+**`[gnomAD data]`**
+
+- Males are hemizygous outside PAR on chrX (haploid) — AC/AN counting
+  and AF calculation need special handling.
+- Pseudoautosomal regions (PAR1, PAR2) are diploid in both sexes on
+  chrX/chrY; the gnomAD freq HT typically treats PAR separately.
+- `locus.in_autosome()` excludes chrX/Y/M (and chr sex-linked regions).
+  Trio-analysis or PBT code that filters to autosomes drops these.
+
+If you're doing anything sex-chromosome-inclusive, check that AC/AN
+denominators respect ploidy and PAR boundaries.
+
+**chrY ploidy can't be called from variants alone.** There is too little
+variant data on Y to infer ploidy from calls, so it is derived from
+reference-block coverage instead, normalized against an autosome
+(gnomad_methods exposes the choice as
+`impute_sex_ploidy(..., use_only_variants=...)`; the default path uses
+reference blocks). X tolerates a variant-based approach in a way Y does
+not (*reported · project meeting*) — worth knowing before you assume the
+two chromosomes were inferred the same way.
+
+---
+
+## Trio / family / relatedness gotchas
+
+**`[gnomAD data]` · `[internal only]`**
+
+- **PBT ∩ release is a small subset.** Many trio members in gnomAD v4
+  are non-releasable, so the intersection between PBT trios and release
+  samples is much smaller than either alone (~2,318 of 730,947 release
+  samples in v4). Any subtraction (release-minus-PBT) has this small-
+  overlap consequence.
+- **Trio-only variants exist.** Variants carried only by non-releasable
+  trio members won't appear in release freq (AC=0). See the
+  releasability item under gnomAD-specific.
+- **Consanguinity / high inbreeding.** Some cohorts have elevated
+  inbreeding coefficients. Filter thresholds tuned to outbred cohorts
+  may not port cleanly.
+- **De novo vs transmitted vs family-recurring.** Trio phasing (PBT /
+  transmission-phase) works only for variants transmitted from a parent.
+  De novos and mosaic sites don't get phased-by-transmission tags.
+- **Relatedness inference depends on the cohort you run it on.**
+  `pc_relate` run across a whole diverse callset behaved very differently
+  from the same method run on a subset — at full scale it inferred
+  individuals across diverse genetic ancestry groups to be related to one
+  another, because the PC space it corrects against is not the same space
+  (*reported · project meeting*). Relatedness results are not portable
+  between a subset and the full callset; re-run rather than reuse, and be
+  suspicious of a relatedness matrix that makes a whole ancestry group
+  look like a family.
+
+---
+
+## AC=0 vs AF=0 vs AF=null are three distinct cases
+
+**`[gnomAD data]`**
+
+- **AC=0** (defined, zero) — variant was called at the locus, but no
+  alt-allele carriers in the current cohort. AF = 0/AN is defined and
+  zero.
+- **AF=0** (defined, zero) — usually implies AC=0. Sometimes reflects
+  rounding at very low AF (unlikely with float64).
+- **AF=null** (missing) — usually because AN=0 (nobody callable at that
+  locus in this cohort) or because the variant is absent from the HT
+  entirely. `AF = AC / AN` is undefined at AN=0.
+
+Downstream code often conflates these. Filters like `AF > 0` drop AC=0
+AND missing-AF variants together; `hl.is_defined(AF)` distinguishes the
+two-null case from the zero case.
+
+**And AF moves when AN moves.** `AF = AC / AN`, so anything that guts AN
+at a site — a coverage dropout, a quality problem affecting the
+denominator more than the numerator — inflates AF without a single extra
+carrier. A site whose AN has collapsed relative to its neighbours can
+show a dramatically higher AF that is an artifact of callability, not
+frequency (*reported · project meeting*).
+
+**Rule of thumb:** read AN next to AF, always. Treat low-AN sites as
+unstable rather than rare-and-interesting, and consider an AN floor
+(e.g. a percentage of the cohort maximum) before ranking anything by AF.
+
+---
+
+## QUAL is frequency-coupled, not a site-quality score
+
+**`[gnomAD data]` · reported · project meeting**
+
+QUAL reads like "how good is this site," and it isn't. It is closer to
+the probability that **at least one sample in the callset carries at
+least one alt allele** — so it scales with how common the variant is, not
+with how trustworthy the call is. A segmental duplication throwing
+systematic error across thousands of samples can carry an extremely high
+QUAL precisely *because* the error is everywhere.
+
+**Use the QC filters and the allele-specific metrics instead** — the
+`filters` set encodes the actual pass/fail decision, and the AS_* metrics
+are the per-allele evidence. A high QUAL is not a reason to trust a site
+that the filters flagged.
+
+---
+
+## LOFTEE evaluates one variant at a time
+
+**`[gnomAD data]` · reported · project meeting**
+
+LOFTEE's pLoF calls and flags are computed **per variant, in isolation**.
+It has no view of a second variant that might change the interpretation:
+a nearby frameshift restoring the reading frame, two pLoFs in phase on
+the same haplotype versus on opposite haplotypes, or a rescuing variant
+downstream. Doing that jointly is hard computationally and is outside
+what the tool attempts.
+
+**What this means for you:** if your analysis is co-occurrence-shaped —
+compound heterozygosity, phasing, haplotype-level consequence — the
+per-variant LoF annotation is an input, not an answer. Two `HC` pLoFs in
+the same gene is not the same finding as two pLoFs *in trans*, and
+LOFTEE cannot tell you which you have.
+
+(One flag that is worth understanding for the same reason: pLoF variants
+in the last exon are flagged as predicted to escape nonsense-mediated
+decay — an escape prediction, again made one variant at a time.)
+
+---
+
+## PCR amplifies shorter fragments — so PCR+ samples look *less* expanded
+
+**`[gnomAD data]` · reported · project meeting**
+
+At repeat loci, the naive expectation is that PCR+ samples will show
+longer repeat expansions than PCR-free ones. The observed direction is
+the opposite: PCR preferentially amplifies **smaller** fragments, so
+PCR+ samples appear *less* expanded.
+
+Relevant any time you compare repeat genotypes across samples prepared
+differently — the library prep is a confounder with a counterintuitive
+sign, and "the PCR+ cohort has shorter repeats" is a technical artifact
+before it is a biological finding.
+
+---
+
+## Synonymous O/E ≈ 1 is the constraint sanity check
+
+**`[gnomAD data]` · reported · project meeting**
+
+In a constraint analysis of essential genes the expected picture is:
+missense depleted, pLoF close to absent, and **synonymous
+observed/expected sitting near 1**. Selection doesn't act on synonymous
+variation the way it acts on the other two, so that ratio is your
+control.
+
+If synonymous O/E drifts away from 1, suspect the pipeline before the
+biology — coverage handling, the mutational model, or which bases were
+included are the usual causes. It's the cheapest available check that a
+constraint calculation is behaving.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/dataproc-operational.md
+++ b/knowledge/dataproc-operational.md
@@ -1,0 +1,349 @@
+# Dataproc / operational
+
+## Always `hl.copy_log()` to GCS in a `finally` — the local log dies with the cluster
+
+**`[Hail]`/ops**
+
+Hail writes its driver log to a local path on the Dataproc master
+(`hl.init(log=…)`, default under `/tmp`). When the cluster is deleted —
+or the job crashes, or your local `hailctl dataproc submit` loses its
+network connection — that log is gone, which is exactly when you want
+it. gnomad_qc's convention (`get_logging_path` + `hl.copy_log`) copies it
+to GCS; put the copy in a `finally` so a *crashed* run's log is
+preserved too:
+
+```python
+try:
+    main(args)
+finally:
+    hl.copy_log(f"{tmp_dir}/logs/{script}.{label}.log")
+```
+
+`hailctl dataproc submit` streaming is **not** a durable record — a
+dropped local connection stops the stream but the job keeps running on
+the cluster, so the streamed stdout is not what you post-mortem from.
+The `finally`-copied log is. This caught a run that hung for ~3h45m and
+then died on an executor loss: the streamed client had long since
+disconnected, and the GCS log was the only trace.
+
+**Where to find more:** `get_logging_path` / `qc_temp_prefix` in
+`gnomad_qc/v4/resources/basics.py`.
+
+---
+
+## Diagnosing a Dataproc job that "just died" (no Python traceback)
+
+**`[Hail]`/ops**
+
+A job that ERRORs with no Python traceback in the streamed output
+usually failed JVM-side. Pull the driver log from GCS:
+
+```bash
+gcloud dataproc jobs describe <id> --format='value(driverOutputResourceUri)'
+gsutil cat '<uri>*'   # quote the * so the local shell doesn't expand it
+```
+
+Find the *first* `Caused by`. Two common ones:
+
+- **`ChunkFetchFailureException: … Executor is not registered (execId=N)`**
+  — an executor died (OOM, or spot / preemptible-VM preemption) and a
+  later task couldn't fetch its shuffle blocks. Not a code bug. Mitigate
+  with non-preemptible workers, more executor memory, or by shrinking the
+  shuffle.
+- **A single task running for hours while the stage sits at `(N-1)/N`
+  complete** — data skew: one partition inherited a pathological share of
+  work (e.g. one key with a set ≈ n_samples in size). It often ends in
+  the executor-loss above. Fix by sharding / repartitioning the skewed
+  key, not by adding memory.
+
+**Symptom:** `gcloud … describe` shows `ERROR`, but the streamed stdout
+ended cleanly hours earlier and the progress bar was frozen at
+`(N + 1) / N`.
+
+**Gotcha while polling job state:** a `describe` loop that does
+`2>/dev/null` turns a persistent auth / network failure into an
+indistinguishable "empty state," so it can spin for hours (or days)
+reporting nothing while the job already finished. Don't swallow stderr;
+treat an empty state as *unknown*, not "still running."
+
+---
+
+## Standalone Dataproc scripts need `hl.init(tmp_dir="gs://...")`
+
+**`[Hail]`/ops**
+
+`hailctl dataproc submit` does **not** wire a GCS scratch path into
+`hl.init` for you the way gnomad_qc's shared entrypoints do (via
+`qc_temp_prefix`). If your script calls `hl.init()` bare, Hail defaults
+its scratch directory to local HDFS `/tmp` on the *driver* node — tens
+of GB of local disk, not shared with executors. Any checkpoint,
+`hl.utils.new_temp_file()`, or large shuffle spill that outgrows that
+fails with:
+
+- `org.apache.hadoop.ipc.RemoteException: could only be replicated to 0
+  nodes instead of minReplication`
+- `java.io.EOFException: Premature end of file`
+
+Both look like spot-VM preemption or an executor loss. They aren't —
+they're the driver running out of local scratch. On a small cluster
+this can fire at surprisingly modest sizes (a few-GB checkpoint on a
+`n1-standard-4` driver).
+
+**Fix:**
+```python
+hl.init(
+    tmp_dir="gs://<your-scratch-bucket>",
+    default_reference="GRCh38",
+)
+```
+
+**Rule of thumb:** every standalone script that runs on Dataproc should
+pass `tmp_dir=gs://...` to `hl.init`. gnomad_qc's shared entrypoints do
+this via `qc_temp_prefix`; scripts that don't inherit from that
+scaffolding need it explicitly.
+
+**Symptom:** a checkpoint or shuffle write on a moderately-sized HT
+fails with an HDFS `minReplication` / `Premature end of file` error;
+the failed stage in the DAG is the checkpoint or shuffle-write itself
+(not the compute upstream); job history shows no executor loss.
+
+---
+
+## Installing packages on a Dataproc cluster: driver-time pip vs `--packages` at start
+
+**`[Hail]`/ops**
+
+`hailctl dataproc submit`'s image ships Hail, numpy, pandas, scipy,
+sklearn — but no ML / DL / bio libraries beyond that. A script that
+imports `xgboost` / `lightgbm` / `shap` / `torch` / a specific
+`pyarrow` version at module top-level dies with `ModuleNotFoundError`
+on load, even if it worked locally in your conda env.
+
+**Fix — pip-install at driver import time**, before any transitive
+import that needs the package:
+
+```python
+import subprocess, sys
+try:
+    import xgboost  # noqa: F401
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "xgboost"])
+```
+
+Works for driver-only workloads (fit-a-model-on-collected-pandas,
+driver-side scoring, etc.). For executor-side use — e.g. broadcasting
+a model into a `mapPartitions` scorer — the package has to be on the
+**workers**, and only cluster creation can put it there:
+
+```bash
+hailctl dataproc start CLUSTER \
+  --packages xgboost,shap \        # --pkgs is the same flag; installed on all nodes
+  --properties spark:spark.driver.maxResultSize=0 \   # arbitrary Spark config
+  --metadata VEP_CONFIG_URI=…      # consumed by the init actions
+```
+
+`hailctl dataproc submit` has **no** `--packages` equivalent, so a
+driver-time pip-install never reaches the workers. Decide which side
+needs the package *before* you start the cluster; otherwise it's a
+cluster rebuild.
+
+**Symptom:** job dies with `ModuleNotFoundError` on `import <package>`
+at load time, before any Hail work starts. `hailctl dataproc submit`'s
+streamed output ends at the traceback with no Spark stage having run.
+If the driver imports fine and executors fail later, the package went
+on the wrong side.
+
+---
+
+## Anything that pulls a large HT / MT to the driver silently stalls — filter Hail-side first
+
+**`[Hail]`**
+
+`hl.Table.to_pandas()`, `.collect()` (row / expression / global),
+`hl.agg.collect(...)` inside an `.aggregate(...)` — all of these
+materialize their result *into driver memory*. On a large table
+(tens of millions of rows, or a per-row array collected across many
+rows), the Spark stage backing the collect sits at N-1/N for hours,
+sometimes returns, sometimes cascades into executor-loss. There's
+no OOM message; the driver just becomes unresponsive.
+
+**Fix — narrow it Hail-side first.** The specific technique depends
+on what you actually need on the driver:
+
+```python
+# 1. You need a small subset of rows → semi_join (NOT hl.set().contains,
+#    which broadcasts the whole key set into every task; see the
+#    hl.literal / large-collection entry above).
+key_ht = hl.import_table(keys_tsv, ...).key_by("locus", "alleles").select()
+df = ht.semi_join(key_ht).to_pandas()
+
+# 2. You need per-partition summaries, not per-row values → aggregate to
+#    a small struct before pulling.
+stats = ht.aggregate(hl.struct(
+    n=hl.agg.count(),
+    mean_af=hl.agg.mean(ht.af),
+))  # <- one struct, safe to collect
+
+# 3. You need per-gene numbers → group_by + aggregate before to_pandas.
+per_gene = ht.group_by(ht.gene_id).aggregate(n=hl.agg.count()).to_pandas()
+
+# 4. You need a Python list of a small keyed field → export to GCS,
+#    read back locally (uses Spark to materialize, doesn't blow driver RAM).
+ht.select(ht.gene_id).export("gs://…/genes.tsv.bgz")
+```
+
+Rule of thumb: **anything you're about to `.to_pandas()` /
+`.collect()` / `.aggregate(hl.agg.collect(...))` needs to be small
+enough to fit in driver RAM** — a large HT / MT never is. If the
+shape isn't obviously ≪ 10⁶ rows, use one of the Hail-side patterns
+above.
+
+**Symptom:** a Spark stage sitting at `(N-1)/N` for hours after a
+`to_pandas()` / `collect()` line; no traceback, no OOM message; you
+eventually kill the job. If the executor-loss cascade fires, the
+driver *does* die — but hours later, with a
+`ChunkFetchFailureException` that reads like a preemptible-VM issue
+rather than the real "driver was collecting a huge HT" cause.
+
+---
+
+## Size the driver deliberately — and keep scoring on the workers
+
+**`[gnomAD data]` · anecdotal; hailctl defaults verified**
+
+`hailctl dataproc start` defaults: master `n1-highmem-8`, workers
+`n1-standard-8` with **40 GB boot disks**, and
+`--master-memory-fraction 0.9` (that fraction of master memory goes to
+the JVM, the remainder to Python).
+
+- **A bigger driver is usually cheap.** You pay for one node, not N.
+  `-m n1-highmem-16` on a job that keeps stalling driver-side often
+  costs less than the wall-clock lost to retries.
+- **Driver-side Python needs that fraction lowered.** If the driver
+  runs pandas / sklearn, the default 0.9 has already handed the memory
+  to the JVM.
+- **The 40 GB worker boot disk is the shuffle-spill ceiling**
+  (`--worker-boot-disk-size`, `--num-worker-local-ssds`); see the
+  `ht[key_expr]`-is-a-join entry.
+
+**Don't collect in order to score.** The established gnomAD pattern for
+model scoring hands the table to Spark ML and takes it back — it never
+pulls the feature matrix to the driver:
+
+```python
+df = ht.key_by().select(*features).to_spark()   # gnomad_methods variant_qc/random_forest.py
+# ... pyspark.ml pipeline: fit / transform, distributed across workers ...
+rf_ht = hl.Table.from_spark(rf_df)
+```
+
+**Gotcha, documented in that same file:** write the Spark DataFrame to
+parquet and re-read it before `hl.Table.from_spark` — without the
+intermediate write the resulting HT "sometimes has missing and/or
+duplicate rows."
+
+---
+
+## Use `gcloud storage`, not `gsutil`
+
+**ops · verified against Google's docs, July 2026**
+
+Google's current guidance: *"gsutil is not the recommended CLI for Cloud
+Storage. Use `gcloud storage` commands in the Google Cloud CLI
+instead."* gsutil is legacy and minimally maintained, and **after March
+2027 it will no longer ship with the Google Cloud CLI**. `gcloud
+storage` also "requires less manual optimization in order to achieve the
+fastest upload and download rates" — which matters when you're moving
+multi-TB HTs, where gsutil needed `-m` plus tuning to keep up.
+
+Translation is mostly mechanical:
+
+| gsutil | gcloud storage |
+|---|---|
+| `gsutil -m cp -r src dst` | `gcloud storage cp --recursive src dst` |
+| `gsutil ls 'gs://…/*'` | `gcloud storage ls 'gs://…/*'` |
+| `gsutil du -sh gs://…` | `gcloud storage du --summarize --readable-sizes gs://…` |
+| `gsutil -m rsync -r a b` | `gcloud storage rsync --recursive a b` |
+
+Two habits worth keeping either way: **quote globs** (`'gs://…/*'`) so
+the local shell doesn't expand them, and prefer `rsync` over re-copying
+when syncing a directory of checkpoints.
+
+---
+
+## Query on Batch (QoB) vs Dataproc
+
+**`[Hail]`/ops**
+
+Query on Batch is the same Hail you already write (`import hail as hl`)
+with a different executor: instead of a Spark cluster you provision with
+`hailctl dataproc start`, queries run on a shared, Hail-maintained Batch
+service. Switching is one argument:
+
+```python
+hl.init(
+    backend="batch",
+    worker_cores=1, worker_memory="standard",
+    driver_cores=1, driver_memory="standard",
+)
+```
+
+| | Dataproc | QoB |
+|---|---|---|
+| user-provisioned cluster | yes | no |
+| latency, short queries | low | low–medium (depends on cluster size) |
+| all operations supported | yes | not all BlockMatrix ops |
+| per-job logs visibility | no | yes |
+| per-job cost visibility | no | yes |
+
+The cost and log visibility is the practical difference: on Dataproc you
+find out what a job cost by looking at the cluster bill afterwards; QoB
+attributes it per job. Against that, a shared service means you don't
+control the machine shape the way `--master-machine-type` lets you (see
+the driver-sizing entry above).
+
+**`[internal only]`** — the operating guidance for this group is to
+prefer QoB where it works, and to raise cases where it doesn't with the
+Hail team rather than quietly falling back to Dataproc.
+
+**Not everything in this section transfers.** The Dataproc entries above
+(boot disks, `--packages`, `hl.copy_log`, driver sizing) are
+cluster-provisioning concerns that QoB takes over. The *Hail-level*
+entries — shuffles, partitioning, laziness, missingness — apply
+identically on both backends.
+
+---
+
+## Cloud storage settings quietly dominate the bill
+
+**ops · current as of July 2025**
+
+Four settings that cost money without appearing anywhere in your code:
+
+- **Multi-regional buckets.** Data replicated across data centers costs
+  substantially more to store and to move. Use regional buckets unless
+  someone has deliberately decided otherwise — and check inherited or
+  requester-pays buckets, which are where the surprises live.
+- **Compute/data region mismatch.** A job running in one region reading
+  a bucket in another pays inter-region transfer on every byte. Hail's
+  Batch default region was effectively "any region" **before 0.2.135**,
+  which made this easy to hit by accident; 0.2.135 sets a default.
+- **Soft delete is ON by default on new buckets** — you keep paying for
+  every object for 7 days *after* deleting it. Turn it off on scratch
+  buckets, or the "cleanup" you just ran doesn't show up on the bill for
+  a week.
+- **Temp directories accumulate.** A remote temp dir wants a lifecycle
+  policy of ~7 days or less, should be used *only* by Hail, and should
+  be one-per-project so read/write costs bill to the right place.
+
+`hailctl batch init` creates a temp bucket with these settings already
+right (lifecycle on, soft-delete off, correctly labeled), and
+`hailctl config profile` switches billing project, region, and temp dir
+together — worth having one profile per project rather than editing
+config by hand.
+
+Deleting an old temp directory is `gcloud storage rm -R <path>`. Check
+what you're pointing at first; it is not recoverable.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/dataset-conventions.md
+++ b/knowledge/dataset-conventions.md
@@ -1,0 +1,176 @@
+# Release conventions and data policy
+
+Why the released data looks the way it does. These are project decisions
+rather than Hail or biology facts — the kind of thing that's obvious to
+whoever was in the room and invisible to everyone else.
+
+Entries marked **reported · project meeting** come from the project's own
+meeting record rather than from something re-derived here. They're
+accurate as statements of what was decided; check the current release
+notes before treating any of them as the present state of the data.
+
+## Annotation versions are pinned per release, and deliberately not bumped
+
+**`[gnomAD data]` · reported · project meeting**
+
+A release's VEP and GENCODE versions are fixed for the life of that
+release. v4 and v5 sit on **VEP 105 / GENCODE 39** — partly because
+downstream products are coupled to it, notably pext, which depends on
+GTEx being on the same GENCODE build.
+
+Staying put has a known cost: a problem in `RNU4ATAC` (a coordinate shift
+relative to ClinVar, fixed upstream in VEP 114) persists in the pinned
+version. The remedy was to patch that one gene rather than move the whole
+release, and that patch has shipped — the browser now annotates
+`RNU4ATAC` with **VEP 115 / GENCODE v49** while everything else stays on
+the pinned version, and flags the gene page to say so. So "which
+annotation version is this?" can have a per-gene answer.
+
+Moving isn't cheap either. VEP 115 more than doubles the transcript count
+(protein-coding and lncRNA alike) and takes roughly 3.5 hours where 105
+takes 45 minutes — and every transcript-level annotation downstream
+shifts with it.
+
+**What this means for you:** don't assume gnomAD's consequences match
+whatever VEP you run locally. When your annotation disagrees with the
+browser's, compare versions before you debug anything else. If you need a
+newer annotation for a specific gene, that's a targeted re-run, not a
+reason to expect the release to move.
+
+---
+
+## LOEUF cutoffs do not port across gnomAD versions
+
+**`[gnomAD data]` · reported · project meeting**
+
+The constraint distribution shifts as sample size grows — as N rises,
+observed/expected converges toward a normal distribution centered near 1,
+so a fixed threshold means something different in each release. v2's
+widely-used LOEUF < 0.35 corresponds roughly to pLI 0.9; the equivalent
+stringency in v4 is nearer **0.45**.
+
+Reusing a v2 threshold on v4 data therefore silently changes what your
+gene list *is*, with no error and a perfectly plausible-looking result.
+
+The project's own position is stronger than "pick the right cutoff":
+**don't encourage binary cutoffs on continuous metrics at all.** Use the
+metric as a continuous ranking where you can, and if you must threshold,
+state the version the threshold was calibrated on.
+
+**Related:** derived per-gene metrics can move across releases for
+entirely non-biological reasons. Per-gene mutation rates differed by up
+to ~10× between v2 and v4 for some genes, traced to coverage-cutoff
+changes in which bases were included in the model — not to any change in
+mutation. Re-derive, don't carry over.
+
+---
+
+## Which subsets exist, and why others don't
+
+**`[gnomAD data]` · reported · project meeting**
+
+v4 ships **UKB** and **non-UKB**. Two categories of subset people ask
+for do not exist, both deliberately:
+
+- **non-TOPMed** was planned and then dropped. gnomAD holds only a small
+  fraction of TOPMed (on the order of 30k of ~160k samples at the time),
+  it was expensive to construct without the metadata, and user demand
+  was low. It could return in a point release if demand appears.
+- **Disease-specific subsets** (the v2-era non-neuro being the one still
+  asked about) ended after v2, on two grounds: no single disease is
+  over-enriched in the callset, and the label was inaccurate about what
+  the subset actually contained.
+
+**What this means for you:** if your analysis needs "gnomAD minus cohort
+X," check whether the subset exists before designing around it. It
+usually doesn't, and the frequencies you want may have to come from a
+subset that does exist plus an explicit caveat.
+
+---
+
+## Age data is binned because the extremes are protected
+
+**`[gnomAD data]` · reported · project meeting**
+
+Released age information is bucketed: **under 20**, five-year bins from
+20 to 80, and **over 80**. Ages below 18 and above 80 are protected
+information, so finer resolution at the tails isn't available at any
+access level. It isn't a display choice you can work around by
+requesting the underlying data.
+
+---
+
+## "Remaining individuals," not "other" or "unassigned"
+
+**`[gnomAD data]` · reported · project meeting**
+
+The label for samples not assigned to a genetic ancestry group is
+**"remaining individuals."** It was chosen over "other" and over
+"unassigned" on genetic-counselor feedback that `un-` and `non-`
+constructions should be avoided when describing people.
+
+Worth knowing when you're writing anything user-facing off gnomAD data,
+and when you're matching labels programmatically — the string is
+`remaining` in the data.
+
+---
+
+## Superseded releases stay online, unsupported
+
+**`[gnomAD data]` · reported · project meeting**
+
+Old versions aren't taken down — v2 remains available, partly because
+its GRCh37 coordinates still have real users. But the browser defaults
+to the newest release, superseded datasets carry a "legacy dataset"
+banner, and questions about them are not answered.
+
+**What this means for you:** building new work on a superseded release
+means no support if something looks wrong, and the newer release may
+have fixed exactly the thing you're about to report. Check whether your
+question is version-specific before assuming it's a bug.
+
+---
+
+## Joint exome + genome FAF isn't defined for every variant
+
+**`[gnomAD data]` · reported · project meeting**
+
+Where a variant's exome and genome filtering allele frequencies differ
+enough that combining them would be misleading, no combined value is
+produced. Treat a missing joint FAF as "these two callsets disagree
+here," not as "no data" — and go look at the two separately.
+
+---
+
+## The large Hail tables are requester-pays
+
+**`[gnomAD data]` · Verified against Hail 0.2.134 API**
+
+Reading the full Hail Tables/VDS means paying for the egress yourself,
+which needs a billing project configured or the read fails.
+
+```python
+hl.init(gcs_requester_pays_configuration="my-project")
+# or, to scope it to particular buckets:
+hl.init(gcs_requester_pays_configuration=("my-project", ["bucket-a", "bucket-b"]))
+```
+
+On Dataproc, allow the buckets at cluster start:
+
+```bash
+hailctl dataproc start CLUSTER --requester-pays-allow-buckets BUCKET
+# --requester-pays-allow-all also exists; prefer naming buckets
+```
+
+Two things that make this bite harder than it should. Costs are
+**region-dependent** — reads from a distant region are markedly more
+expensive than in-region ones, which is the same trap as the
+compute/data region mismatch in
+[Dataproc / operational](dataproc-operational.md#dataproc--operational).
+And some third-party tools give you **no way to pass a billing project
+at all**, so a requester-pays bucket is simply unreadable from them;
+you'll need to copy what you need out first.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/gnomad-specific.md
+++ b/knowledge/gnomad-specific.md
@@ -1,0 +1,319 @@
+# gnomAD-specific
+
+## `filters.length() == 0` means "PASS AND AC>0", not just "PASS"
+
+**`[gnomAD data]` · Applies to:** v4 (and v2, v3 by analogy — `filters` is a set of
+*reasons for failure*, not a status string).
+
+gnomAD's final_filter HT stores QC status as `Set[String]`. Empty set =
+passes everything. But **`"AC0"` is one of the filter reasons** —
+variants with `adj_freq.AC == 0` in the release cohort get
+`filters = {"AC0"}` alongside sets for AS_VQSR, InbreedingCoeff,
+Monoallelic, etc.
+
+See [`gnomad_qc/v4/variant_qc/final_filter.py`](https://github.com/broadinstitute/gnomad_qc/blob/main/gnomad_qc/v4/variant_qc/final_filter.py):
+```python
+filters = {
+    ...
+    "AC0": adj_freq_expr.AC == 0,
+    ...
+}
+```
+
+**Consequence:** `filters.length() == 0` drops both fail-QC AND
+AC0-in-release variants together. For trio-side analyses (or any
+analysis that legitimately wants variants carried only by non-release
+samples), this silently loses a large fraction of pairs.
+
+**Correct patterns:**
+- **Pure release-side analysis** (variant needs a release AC>0 to be
+  meaningful): `filters.length() == 0` is correct.
+- **Trio / non-release-inclusive analysis** ("PASS *or* AC0-only"):
+  ```python
+  filters.difference(hl.set(["AC0"])).length() == 0
+  ```
+
+**Symptom:** trio-adjacent aggregations with totals materially less than
+input rowcount, or `missing_af` / `missing_source` buckets that grow
+much larger than expected.
+
+---
+
+## `only_filters.ht` (all-variants) exists
+
+**`[gnomAD data]` · `[internal only]`**
+
+Alongside the release-scoped `final_filter.ht` there is an
+**all-variants** sibling — same directory, `…final_filter.all_variants.only_filters.ht`
+— reachable through `gnomad_qc.v4.resources.variant_qc` rather than by
+typing a bucket path.
+
+Schema: `(locus, alleles) → filters: Set[String]`. Covers **every v4
+exome variant**, not just AC>0-in-release. Not obvious this exists
+unless you already knew — the "normal" `final_filter.ht` sibling only
+has the release-scoped subset.
+
+Use this when you need PASS status for variants absent from release-
+scoped tables (sites, freq, vep). Combine with the `.difference({"AC0"})`
+pattern above to build "permissive" annotation paths for trio / non-
+release / rare-tail analyses.
+
+Genomes counterpart at the analogous path.
+
+---
+
+## `only_filters.ht` and release `final_filter.ht` are NOT interchangeable for AC0 semantics
+
+**`[gnomAD data]` · `[internal only]`**
+
+Both HTs have the same `filters: Set[String]` schema. But their **`AC0`
+tag is defined against different cohorts**:
+
+- **Release `final_filter.ht`** (from `gnomad_qc.v4.resources.variant_qc.final_filter(data_type='exomes')`):
+  `AC0` fires when `adj_freq[release_cohort].AC == 0`. So "AC0" means
+  "no release-sample carrier."
+- **`all_variants.only_filters.ht`**: `AC0` appears to be defined against
+  a wider joint-genotyping cohort, so it effectively never fires on real
+  variants. Empirically, applying its filter check to a 682k-pair trio
+  substrate classified 100% of pair endpoints as `filters={}` — no
+  `AC0`-tagged variants at all.
+
+**Rule of thumb:**
+- Use `only_filters.ht` when you want *global* QC status (does this
+  variant pass v4 joint-cohort QC).
+- Use release `final_filter.ht` when you want *release-cohort* QC status
+  (does this variant pass QC **and** have AC>0 in release samples).
+- The two answer different questions. Picking the wrong one is silent —
+  your PASS check will match a different variant population than you
+  intend.
+
+---
+
+## `freq` is an array of strata — index it via `freq_index_dict`, not a hardcoded number
+
+**`[gnomAD data]` · Verified against the released v4.1 exomes public HT**
+
+Not `freq["all"].AF`. `freq` is an array of structs
+(`AC` / `AF` / `AN` / `homozygote_count`), one per sample grouping —
+**329 of them** in v4.1 exomes. The supported way to reach a stratum is
+the `freq_index_dict` global, a dict from grouping label to array index:
+
+```python
+from gnomad.resources.grch38.gnomad import public_release
+ht = public_release("exomes").ht()
+
+ht.freq[ht.freq_index_dict["adj"]]              # whole callset, high-quality genotypes
+ht.freq[ht.freq_index_dict["afr_XX_adj"]].AC    # one gen-anc × sex stratum
+```
+
+Label keys compose as group / sex-group / subset-group /
+gen-anc-group / gen-anc-sex-group / subset-gen-anc-sex-group
+(`adj`, `raw`, `XX_adj`, `non_ukb-raw`, `afr_adj`, `ami_XX_adj`,
+`non_ukb_mid_XX_adj`, …). The same pattern applies to the filtering
+allele frequency array via `faf_index_dict`.
+
+For the record, `freq_index_dict["adj"] == 0` and `["raw"] == 1`, and
+`freq_meta[0] == {"group": "adj"}` — so the familiar `freq[0]` does mean
+"whole callset, adj." **Use the dict anyway**: hardcoding an index that
+happens to be right today silently returns a *different stratum* if the
+ordering ever changes, and reads as a magic number in review.
+
+**Related globals:** `freq_meta` (ordered list of the grouping structs,
+parallel to `freq`), `freq_meta_sample_count`, and `frequency_README` —
+an explanation of this whole scheme carried on the HT itself.
+
+**Where to find more:** gnomAD's
+[v4 HTs help page](https://gnomad.broadinstitute.org/help/v4-hts)
+documents the released HT schemas and this access pattern (source:
+`browser/help/topics/v4-hts.md` in the gnomad-browser repo).
+
+---
+
+## Sample releasability skews annotation coverage
+
+**`[gnomAD data]` · `[internal only]` · Applies to:** v4 (multi-cohort release model; less relevant in v2).
+
+gnomAD joint-calls variants across ALL samples (releasable +
+non-releasable) but the release freq HT only counts releasable samples.
+Consequence:
+- Variants carried only by non-releasable samples → AC=0 in release
+  freq → dropped from sites HT (by the AC>0 filter) → absent from
+  downstream release-scoped annotations.
+- BUT those variants ARE in the "all variants" final_filter HT above,
+  and usually in vep_ht (which is annotate-once at joint-call time).
+
+Whenever your analysis spans releasable and non-releasable samples
+(trios where some members are non-release, external cohorts joined to
+gnomAD, family sub-sets), you'll see this gap. It commonly manifests as
+a large fraction of trio-truth pairs with null AC/AF because at least
+one endpoint is a "trio-only variant" absent from release annotations.
+
+**Rule of thumb:** for any analysis touching non-release samples, use
+the permissive filter path (`only_filters.ht` + AC0-allowed check)
+rather than the release-scoped sites HT.
+
+---
+
+## "Absent from gnomAD" often means "not covered," not "not present"
+
+**`[gnomAD data]` · reported · project meeting**
+
+A variant missing from gnomAD is routinely read as evidence that nobody
+in 800k people carries it. Often it means nobody **sequenced** it there.
+Exome capture kits differ in what they cover, and coverage varies across
+exons as a result, so "not in gnomAD" mixes two very different
+statements:
+
+- the site was callable in the cohort and no alt allele was seen, and
+- the site wasn't well covered, so no call could be made either way.
+
+The distinction matters most exactly where people lean on it hardest —
+arguing a candidate variant is rare or novel because gnomAD lacks it.
+
+**Rule of thumb:** before treating absence as evidence, check the
+coverage at that locus (and `AN`, which is the same statement in
+frequency terms — see [Biology](biology.md#biology)). Absence at a
+well-covered site is informative; absence at a poorly-covered one is not.
+
+---
+
+## Different gnomAD HTs may have different variant sets
+
+**`[gnomAD data]`**
+
+An annotation join graph like `variant_filter_ht → sites_ht →
+annotated_phase_ht` may not have identical row coverage between steps:
+- `variant_filter_ht` may include tags for variants absent from
+  `sites_ht`
+- `sites_ht` may drop AC0 variants that `only_filters.ht` retains
+- `vep_ht` and `freq_ht` are typically joint-call-scoped (broader) but
+  `sites_ht` is release-scoped (narrower)
+
+A downstream function that reads a `v_ann` struct may find:
+- `v_ann.source` defined (from `variant_filter_ht`)
+- `v_ann.ac` null (variant absent from release `sites_ht`)
+- `v_ann.vep` defined or null depending on `vep_ht` scope
+
+**Always check field-level nullability, not just struct-level.**
+`hl.is_defined(v_ann)` does NOT guarantee `hl.is_defined(v_ann.ac)`.
+
+---
+
+## Identifying UKB samples in v4: `s.startswith("UKB")` vs `project_meta.ukb_sample`
+
+**`[gnomAD data]` · `[internal only]` · Applies to:** v4 exomes. Any analysis that subsets or removes the UKB
+cohort.
+
+The authoritative UKB flag is `meta().project_meta.ukb_sample` (defined as
+`project == "UKBB"` in
+`gnomad_qc/v4/sample_qc/create_sample_qc_metadata_ht.py`). The sample-ID prefix
+`s.startswith("UKB")` is a lighter, meta-free proxy used elsewhere in gnomad_qc
+(e.g. `identify_trios.py`). Across all 955,213 v4 exomes meta samples the two
+agree on every sample except **2** UKBB-project *control* samples that carry
+control IDs rather than a UKB prefix: `CHMI_CHMI3_Nex1` (CHM1 mole) and
+`Coriell_NA12878_NA12878` (NA12878), both non-release. Critically, **zero**
+non-UKB samples carry the "UKB" prefix, so the prefix never leaks a non-UKB
+sample into a UKB subset — it only leaves those 2 controls on the non-UKB side.
+
+**Tradeoff:** the prefix is dependency-free and safe for bulk cohort splits (no
+non-UKB leakage). Use `project_meta.ukb_sample` when you must remove/retain
+*all* UKBB-project data exactly — e.g. UKB data-removal / governance — so those
+2 controls go with the rest of UKB.
+
+**Where to find more:** `create_sample_qc_metadata_ht.py`
+(`ukb_sample = project == "UKBB"`); prefix use in `identify_trios.py`.
+
+---
+
+## Large globals structs ride along in every downstream IR — `select_globals()` early
+
+**`[Hail]` + `[gnomAD data]`**
+
+A table's globals are carried into every expression built from it, so a
+large globals struct bloats every downstream IR whether or not you touch
+it — and past a certain size it can trip Hail's optimizer outright, at
+execute time, before any rows are processed. **If you only need the
+rows, drop the globals right after reading:**
+
+```python
+ht = some_table.ht().select_globals()
+```
+
+The gnomAD instance: the v4 sample-QC `meta()` HT carries a
+deeply-nested `global_annotation_descriptions` struct. Carrying it
+through a nontrivial `select → annotate → filter → checkpoint` chain
+raises `FatalError: AssertionError: type mismatch … bad ir from forward
+lets`, with the dump showing the giant `project_meta` struct.
+
+```python
+ht = meta(data_type="exomes").ht().select_globals()
+```
+
+**Symptom:** "bad ir from forward lets" / a type-mismatch assertion on
+an otherwise simple pipeline, raised at execute time before any rows are
+processed. Any richly-annotated HT can do this; the meta HT is just the
+one we hit.
+
+---
+
+## v4 genotype classification: match the high-AB het→hom-alt correction, and get the operation order right
+
+**`[gnomAD data]` · Applies to:** v4 (exomes + genomes). Any analysis that densifies the
+release VDS and classifies per-sample genotypes (het / hom-var /
+hom-ref) for counting, freq, or phasing — if you want to reproduce the
+released `freq`.
+
+GATK <4.1.4.1 mis-called some true hom-alts as high-allele-balance
+het-refs. gnomAD v4's released `freq` is `ab_adjusted_freq`:
+`correct_for_high_ab_hets` reclassifies such calls het→hom-var. If you
+classify genotypes yourself and skip this, your het / hom-var counts
+won't match release — silently; the totals still look sane. Reclassify a
+call het-ref→hom-var when:
+
+```python
+GT.is_het_ref() & adj & (AD[1]/DP > 0.9) & ~is_het_non_ref \
+    & ~fixed_homalt_model & (af > 0.01)
+```
+(`fixed_homalt_model` from `meta().project_meta`; `af` = release
+`freq[0].AF`; cutoffs are the `ab_cutoff=0.9` param on `densify_and_prep_vds_for_freq`, AF threshold `af_threshold=0.01` on `correct_for_high_ab_hets`.)
+
+Two traps:
+
+1. **The correction applies to RAW too, not just adj.** The released
+   `freq[1]` (raw) is the raw-group aggregate of the *adj-gated*
+   `high_ab_het`, so a corrected call lands in both raw and adj hom-var.
+   Reclassify in raw as well — but keep it **gated on adj-pass** (a
+   non-adj high-AB het is not in the correction set, so it stays het in
+   raw). The gnomad_qc docstring says "raw is not adjusted," but the code
+   + released data do adjust it — verify against released `freq[1].AC` if
+   unsure.
+
+2. **Capture `is_het_non_ref()` BEFORE the split.**
+   `sparse_split_multi` downcodes a het-non-ref (e.g. `1/2`) to `0/1` at
+   each biallelic row — indistinguishable from a true het-ref afterward.
+   Test `is_het_non_ref()` post-split and it's always False, so the
+   correction wrongly fires on split multiallelic calls. Capture it from
+   the local `LGT` pre-split and carry it through as a passthrough entry.
+
+**Order of operations** (matches `generate_freq.densify_and_prep_vds_for_freq`):
+```
+capture _het_non_ref (LGT, pre-split) → sparse_split_multi → to_dense_mt
+→ adjusted_sex_ploidy_expr(GT) → adj = get_adj_expr(GT, …) → high-AB correction
+```
+Each dependency is load-bearing:
+- **sex-ploidy before adj** — adj and the correction must see the
+  haploid-adjusted GT; an XY chrX het dropped to missing by ploidy
+  adjustment then can't be "corrected" into a hom-var.
+- **correction after adj** — it's adj-gated.
+- **`_het_non_ref` before the split** — see trap 2.
+
+Reorder any of these and the classification silently diverges from
+release.
+
+**Where to find more:** `correct_for_high_ab_hets` +
+`densify_and_prep_vds_for_freq` in
+`gnomad_qc/v4/annotations/generate_freq.py`.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/hail-idioms.md
+++ b/knowledge/hail-idioms.md
@@ -1,0 +1,412 @@
+# Hail idioms
+
+## `.filter()` / `.select()` / `.annotate()` produce a new source object — don't mix with pre-op references
+
+**`[Hail]`**
+
+Hail tracks the source object of every expression. After
+`sub = ht.filter(cond)` (or `.select` / `.annotate` / any re-binder),
+expressions built off `ht` and expressions built off `sub` are considered
+to come from *different sources*; mixing them raises
+`Cannot combine expressions from different source objects`. The error
+names the operation, not the two sources, so in a long
+`.select(a=…, b=…, c=…, …)` where one of ten fields still points at
+`ht` it takes a minute to find the stale reference.
+
+```python
+sub = ht.filter(cond)
+sub.select(x=sub.foo)     # GOOD — every reference goes through the new binding
+sub.select(x=ht.foo)      # BAD — ht.foo is from the pre-filter source
+```
+
+**Rule of thumb:** whenever you assign the result of `.filter` /
+`.select` / `.annotate` to a new variable, refer to fields *only*
+through that new variable. Two-liner filter-then-project is the common
+site because it's tempting to reach back into the outer name.
+
+**Same-name reassignment (`ht = ht.annotate(...)`) has the same failure
+mode.** If you bind an expression to `ht` at the top of a function, then
+later do `ht = ht.annotate(...)`, the earlier expression is now bound to
+a stale source object. The bug is easy to miss because it looks like
+"just modifying `ht` in place":
+
+```python
+# BAD -- in_training_genes is bound to ht #1, but ht is rebound below.
+in_training_genes = ht.is_phaplo_gene | ht.is_ddg2p_nonlof_gene
+if af_threshold_changed:
+    ht = ht.annotate(is_common=recomputed)      # ht is now object #2
+# ...200 lines later...
+ht = ht.annotate(
+    label=hl.if_else(in_training_genes & ht.is_blb_clnsig, 0, ...),
+    # ^ crashes: in_training_genes from #1, ht.is_blb_clnsig from #2
+)
+```
+
+Two fixes:
+
+1. **Re-bind the expression right before you use it.** Cheap if it's
+   built from a couple of fields:
+
+   ```python
+   ht = ht.annotate(is_common=recomputed)
+   in_training_genes = ht.is_phaplo_gene | ht.is_ddg2p_nonlof_gene  # rebind
+   ht = ht.annotate(label=hl.if_else(in_training_genes & ht.is_blb_clnsig, 0, ...))
+   ```
+
+2. **Wrap the expression as an inline closure that takes the current
+   `ht` and resolves at call time.** Useful when the expression is
+   reused at several points across multiple `ht.annotate(...)` calls,
+   so rebinding at every use-site is noisy:
+
+   ```python
+   def _tg(h):
+       return h.is_phaplo_gene | h.is_ddg2p_nonlof_gene
+
+   ht = ht.annotate(is_common=recomputed)              # ht rebound
+   ht = ht.annotate(label=... _tg(ht) & ht.is_blb_clnsig ...)   # OK
+   ht = ht.annotate(is_reference=... _tg(ht) ...)              # OK, still resolves fresh
+   ```
+
+   The closure defers the field lookup until call time, so it always
+   picks up the current binding of `ht` at the use site.
+
+**Symptom:** `Cannot combine expressions from different source objects`
+inside a function that has one or more `ht = ht.annotate(...)` /
+`ht = ht.filter(...)` lines between where the offending expression was
+bound and where it's used.
+
+---
+
+## `hl.literal(large_collection)` blows up JVM codegen and Spark RPC
+
+**`[Hail]`**
+
+Hail compiles literals into the query bytecode: a `hl.literal({...})`
+with hundreds of thousands of elements produces a code object that
+takes JVM codegen minutes of CPU, or OOMs before any Hail work starts.
+The Dataproc analogue: a large literal used inside a *per-row*
+expression is replicated into every task's serialized closure,
+overflowing `spark.rpc.message.maxSize` (default ~128 MB, raised to
+~835 MB in some gnomad_qc configs) on pipelines with tens of thousands
+of partitions.
+
+**Two failure modes, same root cause:**
+- Local: `hl.literal(<~730k-element set>)` in a unit test hung the JVM
+  for minutes before returning — no error, no progress bar, just CPU.
+  Bigger sets OOM the driver.
+- Dataproc: an `hl.literal(<PBT-index-set>)` embedded in a per-pair
+  count expression got replicated into every count task and killed the
+  job at task-scheduling time with a serialized-task-too-big error.
+
+**Fix pattern:** keep the large collection in the *data plane* (a
+Table you join or semi-join against), not the *code plane*.
+
+```python
+# BAD: literal in a row-scoped expression → replicated to every task
+mt = mt.annotate_rows(
+    is_pbt=hl.literal(pbt_index_set).contains(mt.sample_idx)
+)
+
+# GOOD: put it in a Table, join once, checkpoint if the set is big
+pbt_ht = hl.Table.parallelize(
+    [{"sample_idx": s} for s in pbt_index_set],
+    hl.tstruct(sample_idx=hl.tint32),
+    key="sample_idx",
+)
+mt = mt.annotate_rows(is_pbt=hl.is_defined(pbt_ht[mt.sample_idx]))
+```
+
+If you *must* use `hl.literal` for a large set (small keep-set, one-off
+transform), materialize it once inside a checkpointed transform and
+hand the checkpointed HT to downstream steps — never inside a
+`map`/`filter` lambda that runs per row.
+
+**Symptom:** local Hail hangs before printing anything Hail-related
+(JVM CPU spikes for minutes with no `Stage 0` line); Dataproc job dies
+with `RpcSizeExceededException` or serialized-task-too-big errors,
+often at task-scheduling time before any row work begins.
+
+---
+
+## `ClassTooLargeException` from inlining many sub-expressions into one row expression
+
+**`[Hail]`**
+
+Hail compiles a row expression into JVM bytecode. Building one expression
+that inlines *K copies* of a heavy sub-expression — a Python loop that
+stuffs a per-stratum breakdown (or a big `hl.case` / dict) into a single
+`.annotate` / `.select` — compiles to one method/class that overflows the
+JVM **64 KB class-size limit**. It's a scaling cliff, not a gradual
+slowdown: the same code works at K≤2 and dies at K≥3 with
+`is.hail.relocated.org.objectweb.asm.ClassTooLargeException: Class too
+large: __C…native_writer`.
+
+Concrete case: a per-population count built
+```python
+hl.dict([
+    (pop, hl.struct(raw=_count_from_sets(...), adj=_count_from_sets(...)))
+    for pop in pops
+])
+```
+inside one `vp.select(gt_counts_by_pop=…)`. `_count_from_sets` is ~dozens
+of set intersections; 2 pops compiled fine, 3 pops (`afr,nfe,eas`) blew
+the class limit before any row work ran.
+
+**Fix:** don't inline all K into one expression. Compute each in a
+**separate pass / table**, checkpoint, then join-assemble the pieces:
+```python
+# BAD: K heavy sub-exprs inlined into one row expression → ClassTooLarge at K≥3
+ht = ht.annotate(by_stratum=hl.dict([(s, heavy_expr(s)) for s in strata]))
+
+# GOOD: one (checkpointed) table per stratum, then join into the dict
+per = {s: compute(restrict_to(ht, s)).checkpoint(tmp(s)) for s in strata}
+ht = ht.annotate(
+    by_stratum=hl.dict([(s, per[s][ht.key].counts) for s in strata])
+)
+```
+The K separate joins are separate IRs (fine); the assembled dict of K
+struct-lookups is a small expression. See the per-stratum pattern under
+[Codebase / analysis patterns](analysis-patterns.md#codebase-and-analysis-patterns).
+
+**Symptom:** `ClassTooLargeException` naming a generated `__C…` class
+(often `…native_writer`), raised at compile/execute time before rows are
+processed; the same code path works with fewer strata / `hl.case`
+branches and fails as you add more. Not memory, not data — pure codegen
+size.
+
+---
+
+## `hl.experimental` numeric kernels don't validate inputs — check dtype and value invariants yourself
+
+**`[Hail]`**
+
+Experimental / numeric Hail functions (EM solvers, statistical kernels)
+are thin wrappers over a numeric routine with far fewer guardrails than
+core Hail: they assume a specific input dtype, assume the input already
+satisfies the routine's invariants, and don't cap iterations. Three
+failure *classes*, none documented, all silent or misleading:
+
+- **Strict, undocumented dtype requirements.** The kernel wants one
+  specific numeric type and errors — or worse, misbehaves — on the
+  wrong one. gnomAD aggregations default to `int64` / `float64`
+  (`hl.agg.sum` / `count` promote), so you frequently need an explicit
+  cast the signature doesn't advertise.
+- **No input validation + uncapped iteration.** Iterative solvers
+  assume well-formed input and have no max-iteration bound. Feed one
+  input that violates an invariant it relies on (negative counts,
+  totals exceeding the cohort) and it *oscillates instead of
+  converging* — spinning forever on a single partition with no error
+  and no progress, indistinguishable from a hung executor.
+- **Degenerate input → NaN / Inf, not an error.** Division-based
+  statistics silently return NaN on a zero denominator and propagate it
+  into whatever consumes the result.
+
+`hl.experimental.haplotype_freq_em` exhibits all three at once: it
+requires `array<int32>` (cast `gt_counts.map(hl.int32)`); its iterations
+are uncapped, so a set-encoding bug that yields negative cells or
+`sum(gt_counts) > n_samples` makes it loop forever; and its
+`p_chet = (h1·h2) / ((h0·h3) + (h1·h2))` is NaN when there are zero
+double-het pairs, so guard with `hl.if_else(hl.is_nan(p),
+hl.missing(...), p)`.
+
+**Symptom:** a step using an experimental kernel either errors on a type
+mismatch, or stalls for hours at `(N-1)/N` on one partition with no
+traceback (looks exactly like the data-skew case under
+[Dataproc](dataproc-operational.md#dataproc--operational)), or emits NaNs that quietly poison a
+downstream aggregation.
+
+**Rule of thumb:** treat any `hl.experimental` / numeric kernel as
+un-validated. Before calling: cast inputs to the exact dtype it wants;
+assert the value invariants it depends on (non-negativity,
+`sum <= n_samples` — canary #1); and bound partition count so one
+malformed row caps worst-case wall time instead of hanging the job.
+Guard NaN on the output of any ratio.
+
+---
+
+## Aggregating across samples? Localize entries, then hoist each field into its own array
+
+**`[Hail]` + `[gnomAD data]` · Verified in current `gnomad_methods` code**
+
+To aggregate across samples per variant without paying the MatrixTable
+machinery, the frequency code turns the MT into a Table whose rows carry
+an array of every sample's entry:
+
+```python
+ht = mt.localize_entries("entries", "cols")
+```
+
+That much is a well-known trick. The part that isn't: **do not aggregate
+by reaching into that array of structs.** Project each field you need
+into its **own flat array** first, once, and aggregate over those:
+
+```python
+# gnomad_methods gnomad/utils/annotations.py :: agg_by_strata
+ht = ht.select(
+    *select_fields,
+    **{ann: ht.entries.map(lambda e: e[ann]) for ann in select_expr.keys()},
+)
+```
+
+The comment on that line in the source is explicit that this exists for
+memory:
+
+> Pull out each annotation that will be used in the array aggregation
+> below as its own ArrayExpression. This is important to prevent memory
+> issues when performing the below array aggregations.
+
+**Why it matters:** an array-of-structs keeps the whole entry struct
+live for every sample while you aggregate, and each field access inside
+the aggregation walks that struct again. Hoisting gives you arrays of
+exactly the values being aggregated — one narrow array per field instead
+of one wide array of everything. On a release-scale callset that is the
+difference between a job that fits and one that blows up. Gating the
+`select_entries` down to only the fields the aggregation needs, *before*
+localizing, is the same idea applied a step earlier.
+
+**Rule of thumb:** the shape of the expression, not just the volume of
+data, decides whether an aggregation fits in memory. If you're iterating
+a per-row array of structs, project first.
+
+---
+
+## `ht[key_expr]` is a Spark join (shuffle), not an indexed point lookup
+
+**`[Hail]`**
+
+Hail's Spark backend compiles `other[ht.key]` /
+`ht.annotate(x=other[ht.key].x)` into a **Spark join** — broadcast if the
+right side is small, otherwise sort-merge with a shuffle to disk — not an
+indexed random-access lookup. So "just annotating one field" from a
+multi-GB table triggers a full shuffle. On Dataproc this is where
+boot-disk sizing bites: secondary / preemptible workers with small
+(~40 GB) boot disks and several executors per node sharing that disk
+overflow when a shuffle spills > ~2 GB, killing the stage.
+
+**Plan around it:**
+- A right-side table > ~10 MB won't broadcast; it sort-merge joins
+  (shuffle). Keep frequently-joined annotation tables small, or
+  `checkpoint` + co-partition them.
+- **Disk, not just memory, is a scaling limit on Dataproc** — size worker
+  boot disks (or use SSDs) for the shuffle, or shrink / shard the join.
+- Chaining many `[key]` lookups chains many joins/shuffles; assemble via
+  one keyed join where you can.
+
+**Symptom:** an `annotate` that "should be cheap" spends its wall time in
+a shuffle stage; the stage dies disk-full / `FetchFailed` on secondary
+workers.
+
+---
+
+## `.order_by()` destroys the key — use `add_index` to rekey cheaply
+
+**`[Hail]`**
+
+`ht.order_by(expr)` returns an unkeyed table. Any subsequent
+`ht[key_expr]` join will fail (`Table is not keyed`), and even
+`.key_by(...)` after the sort requires a *full pass* to rekey. This is
+easy to trip over when computing ranks: sort by score, annotate
+`hl.scan.count()` to get 0-based ranks, then try to join the rank back
+onto the original table.
+
+**Cheap-rekey pattern**: assign a stable integer index *before* the
+sort, then key by that integer after the sort. Integer keys are
+zero-overhead to rejoin because you already have the key in-hand from
+either side:
+
+```python
+# BAD -- re-keying after order_by triggers a full-table shuffle
+ranked = ht.order_by(ht.score).annotate(rank=hl.scan.count())
+ranked = ranked.key_by(*ht.key)   # slow: has to re-shard by the original key
+ht = ht.annotate(rank=ranked[ht.key].rank)
+
+# GOOD -- add an integer index before sorting, use it to rejoin
+ht = ht.add_index("_row_idx")
+ranked = (
+    ht.order_by(ht.score)
+      .annotate(rank=hl.scan.count())
+      .key_by("_row_idx")
+)
+ht = ht.annotate(rank=ranked[ht._row_idx].rank)
+ht = ht.drop("_row_idx")
+```
+
+**When to reach for this**: computing per-row ranks, quantile bins, or
+any other order-dependent annotation you need to fold back onto the
+original table. Also useful when you have many independent "sort by
+column X, compute stat, join back" passes: run each on a `select`ed
+narrow table (`ht.select("_row_idx", _val=X)`) plus the shared index,
+checkpoint the tiny result, then join each back in one wide pass.
+Avoids checkpointing the full wide table once per rank iteration.
+
+**Symptom:** unexpected `Table is not keyed` after an `order_by`; or a
+per-column rank loop that scales super-linearly with the number of
+columns because each iteration is checkpointing the full wide table.
+
+---
+
+## `hl.scan.*` is the aggregator over everything *before* the current row
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+`hl.scan.<agg>` mirrors `hl.agg.<agg>` but produces a per-row running
+value over all **preceding** rows in the table's current order,
+**excluding** the current row:
+
+```python
+ht = hl.utils.range_table(5)
+ht = ht.annotate(cum=hl.scan.sum(ht.idx), rank=hl.scan.count())
+# cum   -> [0, 0, 1, 3, 6]     (row i sees rows 0..i-1)
+# rank  -> [0, 1, 2, 3, 4]     (0-based row index)
+# hl.agg.sum(ht.idx) for contrast -> 10 (one value for the whole table)
+```
+
+The exclusivity is the part people get wrong: `hl.scan.sum` on row 0 is
+the aggregator's *empty* value, not that row's own value. For an
+inclusive running total, add the current row back: `hl.scan.sum(x) + x`.
+
+Scans follow the table's current row order, so an `order_by` before the
+scan is what makes a rank meaningful — and `order_by` drops the key (see
+the `.order_by()` entry above). `hl.scan.count()` is the cheap way to
+get a 0-based row index for ranking.
+
+`hl.scan` is thinly documented; the aggregators it accepts are the same
+set as `hl.agg`.
+
+---
+
+## There are no Python UDFs — a Python function in `.map()` runs once, at plan-build time
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+Hail compiles expressions to JVM bytecode; it cannot call back into your
+Python per row. A Python callable passed to `.map()` / `.filter()` is
+invoked **once**, while the query plan is built, with an *expression* as
+its argument — its job is to return an expression:
+
+```python
+calls = []
+def py(x):
+    calls.append(1)     # runs once for the whole array, not per element
+    return x + 1
+hl.eval(hl.array([1, 2, 3]).map(py))   # [2, 3, 4]; len(calls) == 1
+```
+
+That works only because `x + 1` is expressible in Hail. Anything with
+real Python semantics inside — a regex library call, a lookup against a
+Python object, an `if` on the *value* — either fails at plan-build time
+or silently captures a constant.
+
+**What to reach for instead:**
+- Express it in Hail (`hl.if_else`, `hl.case`, `hl.rbind`, the string /
+  math function library).
+- `hl.experimental.define_function(f, *param_types)` — packages an
+  expression-returning function as a reusable Hail-native function.
+- Genuinely non-expressible per-row Python → restructure so the Python
+  runs on the driver over a *small* aggregate, or export and process
+  outside Hail. That's the "don't pull a large table to the driver"
+  problem; size it before you reach for it.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/hidden-apis.md
+++ b/knowledge/hidden-apis.md
@@ -1,0 +1,24 @@
+# Hidden and undocumented APIs we rely on
+
+Private (underscore) parameters are unsupported and can change between
+Hail versions — but several are load-bearing in gnomad_qc, so you'll
+meet them in code review. Re-check these on a Hail upgrade.
+
+| API | what it does |
+|---|---|
+| `read_table` / `read_matrix_table(_n_partitions=n)` | set partitioning at read, no shuffle |
+| `read_*(_intervals=…, _filter_intervals=True)` | read only the given intervals |
+| `checkpoint(_read_if_exists=not overwrite)` | skip already-written steps on a re-run |
+| `expr.aggregate(..., _localize=False)` | keep the result as an expression instead of pulling it to the driver |
+| `ht._force_count()` | force a real full pass (vs the metadata-only `count()`) |
+| `ht._filter_partitions(range(n))` | read just the first `n` partitions of a real table — cheap iteration on real data |
+
+Supported-but-easy-to-miss `hl.experimental` helpers the pipelines lean
+on: `sparse_split_multi`, `densify`, `filtering_allele_frequency`,
+`pc_project`, `import_gtf`, `get_gene_intervals`, `read_expression` /
+`write_expression`, `define_function`. Note the input-validation caveat
+in the experimental-kernel entry above before using the numeric ones.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/lazy-eval-and-materialization.md
+++ b/knowledge/lazy-eval-and-materialization.md
@@ -1,0 +1,122 @@
+# Lazy evaluation and materialization
+
+## Hail is lazy — an action re-runs everything upstream of it
+
+**`[Hail]`**
+
+Hail builds an unevaluated query plan; nothing executes until an
+*action* forces it. The common actions: `count()`, `collect()`,
+`take()`, `show()`, `aggregate()`, `to_pandas()`, `export()`,
+`write()`, `checkpoint()`. (`describe()` is not one — it prints the
+schema off the plan.)
+
+The consequence that costs real money: an action on an
+**un-checkpointed** table re-executes its entire lineage, and a second
+action re-executes it *again*. A "harmless" logging line in the middle
+of a pipeline —
+
+```python
+ht = expensive_join(...)
+logger.info("%d rows", ht.count())   # <-- runs the whole join
+ht = ht.filter(...)
+ht.write(out)                        # <-- runs the whole join a SECOND time
+```
+
+— doubles the stage. Nothing about it looks expensive at the call site.
+
+**AI assistants are especially prone to this**: they insert `count()` /
+`show()` calls for progress logging and sanity-checking, which is
+harmless on a toy table and doubles wall-clock on a real one. When
+reviewing generated code, grep for `.count()` and `.show()` and check
+that each one sits *after* a checkpoint.
+
+**Rule of thumb:** checkpoint first, then count. If you want a count
+without keeping the table, that's still a full pass — decide it's worth
+it deliberately.
+
+---
+
+## `ht.count()` after `checkpoint` is free — use it, don't avoid it
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+`ht.count()` on an unmaterialized table forces a full pass through the
+query plan, so it's expensive on large HTs and the usual guidance is
+"never count for logging on a big table." That guidance flips
+completely once you've checkpointed:
+
+```python
+ht = build_expensive_ht(...).checkpoint("gs://scratch/x.ht")
+n = ht.count()                   # <-- reads metadata from the checkpoint,
+                                 #     doesn't re-run the upstream query
+logger.info("checkpoint has %d rows", n)
+```
+
+A checkpointed HT is a materialized on-disk table in Hail's native
+format (not Parquet) with a per-partition index; `count()` answers from
+that metadata rather than scanning, and its wall time stays flat as the
+table grows. You get a free logging / sanity-check point. (`_force_count()`
+is the private counterpart that *does* force the full pass — useful when
+you actually want to materialize or time one.)
+
+**Rule of thumb:** place `logger.info("%d rows", ht.count())` calls
+*after* checkpoints, not before them. Also useful for the "did my
+filter drop what I expected" check — `ht_after.count()` after a
+checkpoint is essentially free; `ht_before.count()` before the
+checkpoint costs a full extra pass.
+
+**Symptom of the anti-pattern:** a pipeline where a "quick" logging
+`.count()` doubles the wall-clock of a stage, because it's on an
+un-checkpointed intermediate and forces a re-execution of everything
+upstream.
+
+---
+
+## cache vs persist vs checkpoint
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+| | what it is | survives executor loss | survives the session |
+|---|---|---|---|
+| `ht.cache()` | alias for `persist("MEMORY_ONLY")` | no | no |
+| `ht.persist()` | Spark block storage, default `MEMORY_AND_DISK` | no | no |
+| `ht.checkpoint(path)` | `write()` + read back — a real on-disk table | yes | yes |
+
+- **Small intermediate reused a few times in one session** → `cache()`.
+  Also load-bearing before a shuffle (next entry).
+- **Large intermediate, anything feeding a big shuffle, or anything
+  you'd hate to recompute** → `checkpoint("gs://…")`. Durable across
+  executor loss, and makes `count()` free.
+- **`persist()`** only when you specifically want `MEMORY_AND_DISK`
+  without paying a write.
+
+`checkpoint()` takes `_read_if_exists=True` — private, but an
+established gnomad_qc idiom (`_read_if_exists=not overwrite`) that lets
+a re-run of a partially-completed pipeline skip already-written steps.
+
+---
+
+## `.cache()` before a shuffle is load-bearing, not just a perf optimization
+
+**`[Hail]`**
+
+Materializing the input to a `group_by` / big join with `.cache()` (or
+`.checkpoint()`) isn't only about speed — it empirically avoids
+intermittent shuffle failures (fetch-failures, timeouts) on large
+datasets, because the shuffle reads a stable materialized source instead
+of recomputing the upstream lineage under retry. Deleting a `.cache()`
+that looks redundant (the intermediate is used once) reintroduces flaky
+shuffle errors that only surface at scale.
+
+**Symptom:** a `group_by` that intermittently dies with `FetchFailed` /
+shuffle-fetch timeouts and sometimes succeeds with no code change — often
+worse under executor churn.
+
+**Rule of thumb:** keep `.cache()` before shuffle-heavy ops even when the
+intermediate is used once; treat it as load-bearing, not decorative. For
+very large intermediates prefer `.checkpoint("gs://…")` (spills to GCS,
+survives executor loss) over in-memory `.cache()`.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/missingness.md
+++ b/knowledge/missingness.md
@@ -1,0 +1,223 @@
+# Missingness
+
+Null and NaN are separate concepts in Hail and are handled
+*inconsistently* between functions. Most of the silent-fail bugs in this
+doc reduce to one of them propagating somewhere you didn't expect.
+
+## `hl.case()` without `missing_false=True` silently drops rows
+
+**`[Hail]`**
+
+```python
+case = hl.case()                            # BAD
+case = hl.case(missing_false=True)          # GOOD
+```
+
+Without `missing_false=True`, a `.when(cond, val)` where `cond` evaluates
+to null makes the entire case return null. When that null becomes a
+`group_by` key (or feeds into another null-propagating op), Hail silently
+drops the row.
+
+Concrete failure: an expression like
+```python
+hl.case()
+  .when(hl.is_missing(cv), "none")
+  .when(cv.is_plp, "plp")
+  ...
+  .default("none")
+```
+returns null when `cv` is defined but `cv.is_plp` is null (edge case:
+partial struct). Whole case → null → dropped from group_by. Symptom:
+~184k trio-truth pairs missing from a stratification table with no error.
+
+**Fix:** `hl.case(missing_false=True)` — treats null conditions as False,
+falling through to the default. Same fix applies to
+`.when(source.contains(tag), tag)` patterns where `source` might be null.
+
+**Symptom checklist:**
+- Aggregation total < input rowcount, no error
+- One or more "large" cells in a stratification are missing entirely
+- Off-diagonal cells populated at zero when they should have entries
+
+---
+
+## `hl.if_else(null_cond, a, b)` returns null, not `b`
+
+**`[Hail]`**
+
+Unlike SQL COALESCE or Python's ternary, Hail's `hl.if_else` propagates
+null when the condition is null:
+```python
+is_v1_rarer = ht.v1_ann.ac <= ht.v2_ann.ac  # null if either .ac is null
+rarer_ac = hl.if_else(is_v1_rarer, ht.v1_ann.ac, ht.v2_ann.ac)  # → null!
+```
+
+If a downstream analysis expects `rarer_ac` to hold *one of* v1 or v2
+(like a min), you get all-nulls when either input is null. Mysteriously
+empty buckets in stratifications.
+
+**Fixes:**
+- `hl.coalesce(v1.ac, v2.ac)` — if you just want first-defined.
+- `hl.if_else(cond, ..., ..., missing_false=True)` — treat null
+  condition as False.
+- Coalesce inputs before the comparison: `hl.or_else(ht.v1_ann.ac, ...)`.
+
+---
+
+## `group_by` with null-string keys drops rows from labeled outputs
+
+**`[Hail]`**
+
+`hl.agg.group_by(k, ...)` where `k` is a null string: Hail preserves the
+null-keyed items in the raw result dict (as `key=None`), but consumers
+that build a matrix or filter by known labels (`if k not in labels:
+continue`) silently drop them. Compounds with the `hl.case`/`hl.if_else`
+issues above.
+
+**Debug pattern:** print the raw `result.items()` keys before matrix
+conversion; look for `None` and empty-string keys.
+
+---
+
+## `hl.explode` on a null array/set drops the row
+
+**`[Hail]`**
+
+`ht.explode("gene_id")` when `gene_id` is null (from a left-join miss)
+silently drops that row. Not preserved with a null; not errored on; just
+vanishes.
+
+If you want to keep the row: `.filter(hl.is_defined(ht.gene_id))`
+upstream to make the drop explicit, or coalesce to `hl.empty_array(...)`
+— but note that exploding empty gives zero rows too. Use nullability
+handling deliberately.
+
+---
+
+## `hl.set` / `hl.dict` operations on null return null, not empty
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+- `null_set.contains(x)` → null
+- `null_set.difference(other)` → null
+- `null_set.length()` → null
+- `null_dict.get(k, default)` → null, **not** the default (see the
+  `dict.get` entry below)
+
+These null returns propagate. In a `filter()`, null → row dropped. In an
+`agg_group_by` key, null → row dropped.
+
+**Defensive pattern for potentially-null Set / Array fields:**
+```python
+source = hl.or_else(ht.v1_ann.source, hl.empty_set(hl.tstr))
+gene_id = hl.or_else(ht.v1_ann.gene_id, hl.empty_array(hl.tstr))
+```
+
+---
+
+## `dict.get(k, default)` covers an absent key, not a present-but-missing value
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+```python
+hl.dict({"a": 1}).get("b", 5)                       # 5    -- key absent
+hl.dict({"a": 1}).get(hl.missing(hl.tstr), 5)       # 5    -- key itself missing
+hl.dict({"a": hl.missing(hl.tint32)}).get("a", 5)   # None -- value is missing
+hl.missing(hl.tdict(hl.tstr, hl.tint32)).get("a", 5)  # None -- the dict is missing
+```
+
+The default fires on *lookup failure*, not on *null value*. A dict built
+from a join whose right side had null fields hands those nulls straight
+through your default, and a dict field that is itself null ignores the
+default entirely. Use `hl.or_else(d.get(k), default)` when you want
+"default on null" semantics too.
+
+---
+
+## `hl.parse_json` with a mismatched schema returns nulls, not an error
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+When you hand `hl.parse_json` a type that doesn't match the JSON, it
+does not complain — it produces the closest thing it can:
+
+```python
+j = '{"gene":"BRCA1","impact":"HIGH","score":3}'
+
+hl.parse_json(j, hl.tstruct(gene=hl.tstr, impact=hl.tstr, score=hl.tint32))
+# Struct(gene='BRCA1', impact='HIGH', score=3)          <- correct
+
+hl.parse_json(j, hl.tstruct(gene=hl.tstr, consequence=hl.tstr))
+# Struct(gene='BRCA1', consequence=None)                <- field name wrong -> null
+
+hl.parse_json(j, hl.tstruct(gene=hl.tstr, score=hl.tstr))
+# Struct(gene='BRCA1', score='3')                       <- type wrong -> coerced
+
+hl.parse_json(j, hl.tarray(hl.tstr))
+# None                                                  <- wholly wrong -> all null
+```
+
+A misspelled or renamed field yields a **column of nulls** that looks
+exactly like "this annotation is legitimately missing for these
+variants," and a wrong scalar type is silently coerced. This is the
+mechanism behind hand-written schemas for large nested JSON (VEP output
+being the usual suspect) quietly losing fields after an upstream version
+bump.
+
+**Seen in production, and note there are two distinct causes.** gnomAD
+v3 and v4 both shipped VEP structs with several fully-missing fields
+(`ancestral`, `context`, `swissprot`, `trembl`, `uniparc`, the
+`*.minimised` ones), and the two explanations are different problems that
+present identically (*reported · project meeting*):
+
+1. **The field was never produced.** `ancestral` and `context` come from
+   the LOFTEE plugin; without that plugin supplying them there is nothing
+   to parse.
+2. **The declared structure didn't match the JSON**, so parsing returned
+   nulls for the fields that didn't line up — the mechanism above.
+
+Both look like "this annotation is missing for every variant." The fix
+in that case was to drop the dead fields from the release, but you can
+only make that call once you know which of the two you're looking at.
+
+**Rule of thumb:** after parsing JSON with an explicit type, assert
+definedness on a field you *know* is populated —
+`ht.aggregate(hl.agg.count_where(hl.is_defined(ht.parsed.some_field)))`
+— rather than trusting that the parse "worked." Canary #3 in
+[Testing](testing.md#canary-tests) covers this shape.
+
+---
+
+## `hl.max` drops missing but propagates NaN — and the aggregator disagrees
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+| expression | result |
+|---|---|
+| `hl.max([1, NA, 3])` | `3` — missing dropped (`filter_missing=True` is the default) |
+| `hl.max([1, NA, 3], filter_missing=False)` | missing |
+| `hl.max([NA, NA])`, `hl.max(hl.empty_array(...))` | missing |
+| `hl.max([1.0, nan, 3.0])` | **`nan`** — NaN is *not* dropped |
+| `hl.nanmax([1.0, nan, 3.0])` | `3.0` |
+| `hl.agg.max(x)` over a NaN row | **`3.0`** — ignores NaN |
+| `hl.agg.mean(x)` over a NaN row | **`nan`** — does not |
+
+Two traps stacked. First, missing and NaN are handled *oppositely* by
+`hl.max`: missing is silently skipped, NaN poisons the result. Second,
+`hl.agg.max` ignores NaN as well ("for back-compatibility reasons, in
+contrast with `hl.max`" —
+[agg.max docs](https://hail.is/docs/0.2/aggregators.html#hail.expr.aggregators.max)),
+so the scalar and the aggregator form of "the max" disagree on the same
+column. A sanity-check `hl.agg.max` sitting next to a per-row `hl.max`
+reports a plausible number while every per-row value is NaN. Identical
+story for `min` / `nanmin`.
+
+**Rule of thumb:** on float data that can carry NaN — any ratio with a
+possibly-zero denominator, e.g. the EM outputs in the
+[experimental-kernel entry](hail-idioms.md#hail-idioms) — reach for `hl.nanmax` /
+`hl.nanmin` explicitly. Pass `filter_missing=False` when a missing input
+should invalidate the result rather than be quietly skipped.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/partitioning-shuffles-oom.md
+++ b/knowledge/partitioning-shuffles-oom.md
@@ -1,0 +1,163 @@
+# Partitioning, shuffles, and OOM
+
+## What an OOM actually looks like
+
+**`[Hail]` · from a captured local-backend log, Hail 0.2.137**
+
+Heap exhaustion in Hail is usually reported *inside the lowering or
+encoding machinery*, not at the line of your code that caused it. A real
+one, from a local-backend job that collected too much:
+
+```
+LoweringPipeline: ERROR: error while applying lowering 'EvalRelationalLets'
+java.lang.OutOfMemoryError: Java heap space
+    at java.util.Arrays.copyOf(Arrays.java:3745)
+    at java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
+    at is.hail.io.StreamBlockOutputBuffer.writeBlock(OutputBuffers.scala:286)
+    at is.hail.io.BlockingOutputBuffer.writeDouble(OutputBuffers.scala:229)
+    at __C16collect_distributed_array_table_collect.__m87ENCODE_SFloat64$_TO_o_float64(...)
+    at __C16collect_distributed_array_table_collect.__m84ENCODE_SBaseStructPointer_TO_r_struct_of_...
+    at is.hail.backend.BackendUtils.$anonfun$runCDA$2(BackendUtils.scala:95)
+    at is.hail.backend.local.LocalBackend$$anon$1.$anonfun$mapCollectPartitions$3(LocalBackend.scala:87)
+```
+
+**How to read it.** The generated class name is the diagnosis. Here
+`collect_distributed_array_table_collect` and the `ENCODE_*` frames say
+this died **encoding results to send back**, i.e. the answer being
+collected was too big — not the computation. The long
+`ENCODE_SBaseStructPointer_TO_r_struct_of_o_binaryANDo_binaryAND…` frame
+spells out the struct being encoded, which usually tells you *which*
+table it was.
+
+**Read the generated frame first:**
+- `…_table_collect` / `ENCODE_*` → too much coming back to the driver;
+  see the driver-memory entry in
+  [Dataproc / operational](dataproc-operational.md#dataproc--operational).
+- `…native_writer` + `ClassTooLargeException` → codegen size, not
+  memory; see [Hail idioms](hail-idioms.md#hail-idioms).
+- Frames inside `RegionPool` / `Region` allocation → genuine per-partition
+  data volume; shrink partitions or the row.
+
+**On a cluster it looks different.** An executor that runs out of heap is
+usually killed before it can print this — you see the executor loss
+instead (`ExecutorLostFailure`, container killed), and the OOM itself is
+only in that executor's log, not the driver log. That's why "no
+`OutOfMemoryError` anywhere in the driver log" does **not** mean memory
+was fine; see the fleet-vs-code entry below.
+
+## What actually shuffles — and the `group_by` that doesn't
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+Operations that reorder or summarize across rows shuffle. A
+non-exhaustive list:
+
+- **Changing row order / key** — `key_by` / `key_rows_by`, liftover,
+  `import_vcf` on an unordered VCF.
+- **Joins** — foreign-key joins especially
+  (`ht.annotate(x=ht2[ht.not_a_key])`); see the `ht[key_expr]` entry in
+  [Hail idioms](hail-idioms.md#hail-idioms).
+- **`repartition()`** — avoidable with `shuffle=False`.
+- **Anything summarizing across rows** — `group_by` / `group_rows_by`,
+  `annotate_cols` with an aggregation, `pca`, `pc_relate`.
+
+The pair that looks identical and isn't:
+
+```python
+ht.aggregate(hl.agg.group_by(ht.gene, hl.agg.sum(ht.AC)))  # no shuffle -> dict
+ht.group_by(ht.gene).aggregate(sum_ac=hl.agg.sum(ht.AC))   # shuffles   -> Table
+```
+
+The second re-keys the table by `gene` (its IR carries a `TableKeyBy`),
+which is a shuffle. The first aggregates in a single pass and hands back
+a plain `dict`.
+
+**The catch the "avoid shuffles" advice usually omits:** that dict is
+built in **driver memory**. It's the right tool for a few hundred
+groups and the wrong one for a few million — at which point you want
+the shuffle. See the driver-memory entry in
+[Dataproc / operational](dataproc-operational.md#dataproc--operational).
+
+---
+
+## repartition vs naive_coalesce vs setting partitions at read time
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+| call | what it does | cost |
+|---|---|---|
+| `ht.repartition(n)` | full shuffle, equal-sized partitions (`shuffle=True` is the default) | a shuffle, at the next action |
+| `ht.repartition(n, shuffle=False)` | merges existing partitions; `n` cannot exceed the current count | no shuffle |
+| `ht.naive_coalesce(n)` | merges *adjacent* partitions, no rebalancing — can leave you badly skewed | no shuffle |
+| `hl.read_table(path, _n_partitions=n)` | sets partitioning as the table is read | no shuffle |
+
+**All of these are lazy** — the call returns instantly and the shuffle
+happens at the next action, which is why a repartition usually gets
+blamed on whatever line executed after it. (`n_partitions()` is itself
+not free on a repartitioned plan.)
+
+**Rule of thumb (anecdotal, from repeated production runs): avoid
+repartitioning unless the dataset is small.** A repartition on a large
+table buys balanced partitions at the price of a full shuffle — usually
+the most fragile stage in the job. Prefer, in order: set the partition
+count **at read time** (`_n_partitions`) or **at write time**; use
+`naive_coalesce` when you only need *fewer* partitions after heavy
+filtering; reach for `repartition` last.
+
+---
+
+## Shuffle failures at scale are usually fleet-shaped, not code-shaped — shard the job
+
+**`[gnomAD data]` · anecdotal, v4 exomes scale**
+
+A `group_by` over the full genome that dies at scale is more often
+losing shuffle blocks to preemption than hitting a real memory or skew
+problem. Signature, from the driver log: `FetchFailed` /
+`ExecutorLostFailure`, with large counts of `Container from a bad node`,
+ending in a stage-retry abort — and no `OutOfMemoryError` anywhere.
+
+What worked on the v4 variant-pair-list step, after the genome-wide pass
+failed repeatedly: **shard the job by chromosome** and run each shard on
+its own smaller cluster with fewer preemptible workers. Tuning executor
+memory did not help, because memory was never the problem.
+
+**Distinguish before you tune** (see
+[Dataproc / operational](dataproc-operational.md#dataproc--operational) for how to pull the
+log):
+- `FetchFailed` + `ExecutorLostFailure` + no OOM → lost shuffle blocks;
+  shard the work, or use non-preemptible workers.
+- One task at `(N-1)/N` for hours → data skew; shard the skewed key.
+- Disk-full during shuffle spill → worker boot-disk sizing; see the
+  `ht[key_expr]`-is-a-join entry in [Hail idioms](hail-idioms.md#hail-idioms).
+
+**If you can't avoid a big shuffle, isolate it.** Long-standing advice
+that predates the run above and still holds: run the shuffling step on
+non-preemptible workers only (they cost more, so keep the core count
+down — less is more), and do large shuffles **one at a time**, writing
+an intermediate between them, rather than chaining several into one
+job. Cheap machines can come back for the non-shuffling stages.
+
+---
+
+## How many partitions?
+
+**anecdotal · gathered from production runs, ~2023**
+
+There's no formula, but the failure modes are known:
+
+- **Too many is not free.** A dataset written with ~50k partitions was
+  slow to *read*; ~10k was materially better. Per-partition overhead is
+  real.
+- **Set it at read time to suit the pipeline** rather than
+  repartitioning mid-job (see the entry above).
+- **A join that grows each row wants more partitions than its inputs
+  had.** Joining several large tables multiplies bytes per row while the
+  partition count stays fixed, so partitions that were well-sized going
+  in are oversized coming out. A release-scale join of six or seven
+  tables was one place this bit.
+- Aim for roughly constant *work per partition*, not a constant
+  partition count.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/testing.md
+++ b/knowledge/testing.md
@@ -1,0 +1,76 @@
+# Canary tests
+
+Cheap sanity checks that catch whole classes of the bugs above. Run
+after any refactor that touches the annotation join graph or the
+aggregation semantics.
+
+```python
+# 1. Per-sample count arrays: non-negative, and the sum can't exceed
+#    the cohort size (catches set-encoding / complement-storage bugs,
+#    which otherwise surface only as a downstream EM that never
+#    converges)
+assert ht.aggregate(hl.agg.all(hl.sum(ht.gt_counts_adj) <= n_samples))
+
+# 2. Aggregation totals match input (catches null-key group_by drops)
+n_input = ht.count()
+result = ht.aggregate(hl.agg.group_by(key, hl.agg.count()))
+n_output = sum(result.values())  # includes None-key bucket
+assert n_input == n_output
+
+# 3. No unexplained nulls in critical annotations
+n_null = ht.aggregate(hl.agg.count_where(hl.is_missing(ht.filters)))
+# n_null should match your understanding of the coverage boundary
+
+# 4. Coverage-boundary check for permissive vs release-scoped HTs
+release_n = ht.aggregate(hl.agg.count_where(ht.filters.length() == 0))
+permissive_n = ht.aggregate(hl.agg.count_where(
+    ht.filters.difference(hl.set(["AC0"])).length() == 0
+))
+# permissive_n >= release_n; the gap is your AC0-in-release count
+```
+
+---
+
+## Quick tests
+
+Canary tests above check a *production* output. This is the cheaper
+loop that comes first: a pure transform can be tested on a table you
+type out by hand, locally, in seconds — no cluster, no GCS.
+
+```python
+ht = hl.Table.parallelize(
+    [
+        {"locus": ..., "af": 0.5,  "source": {"clinvar_plp"}},
+        {"locus": ..., "af": None, "source": None},          # <- the null row
+        {"locus": ..., "af": 0.0,  "source": set()},          # <- the empty-collection row
+    ],
+    hl.tstruct(locus=hl.tlocus("GRCh38"), af=hl.tfloat64, source=hl.tset(hl.tstr)),
+)
+assert my_transform(ht).aggregate(...) == expected
+```
+
+**Always include a null row, an empty-collection row, and a
+boundary-value row.** Those are precisely the inputs the
+[Missingness](missingness.md#missingness) section is about, and they're the ones a
+hand-written happy-path fixture omits.
+
+**This is a good task to hand to an AI assistant** — generating small
+fixtures and their expected values is exactly the kind of mechanical
+work it does well, and unlike a Dataproc run you can check the answer
+immediately. Ask for the null / empty / boundary cases explicitly;
+they're the ones that get skipped.
+
+**When you do need real data, take a slice of it.**
+`ht._filter_partitions(range(2))` reads only the first two partitions of
+a real table — enough to exercise a transform against genuine schema and
+genuine nulls without paying for the whole table. Private API; see
+[hidden APIs](hidden-apis.md#hidden-and-undocumented-apis-we-rely-on).
+
+**Keep pipeline code testable this way:** utils functions as pure
+transforms (tables in → tables out) with file I/O confined to the CLI
+entrypoints. A transform that reads its own inputs can only be tested
+against real data on a cluster.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/vds.md
+++ b/knowledge/vds.md
@@ -1,0 +1,161 @@
+# VDS
+
+## Table vs MatrixTable vs VDS — what each one is for
+
+**`[Hail]`**
+
+- **Table** — rows and (optionally) a key. No sample dimension. Any
+  per-sample data has to be exploded into rows or nested into an array
+  field.
+- **MatrixTable** — a rows × columns grid with an **entry** per
+  (row, column). Dense: storage scales with `n_variants × n_samples`,
+  including every hom-ref call.
+- **VDS** — the sparse representation: two MatrixTables, a
+  `reference_data` MT of **hom-ref blocks** (one entry covers a run of
+  loci) and a `variant_data` MT holding only non-ref calls. Storage
+  scales with the number of *calls*, not the grid.
+
+The v4 exomes release is a VDS for exactly this reason — a dense MT of
+that grid is not a thing you can hold. `hl.vds.to_dense_mt` expands it
+back to the grid, so **always narrow first** (filter to your variant set
+or intervals, and to your samples) and densify last. See the
+[Hail VDS docs](https://hail.is/docs/0.2/vds/index.html) for the API.
+
+**Rule of thumb:** if your analysis is per-variant, get to a Table as
+early as you can. Stay in VDS/MT form only for the part that genuinely
+needs per-sample entries.
+
+---
+
+## Column filters must be applied to BOTH reference_data and variant_data
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+A VDS's two MatrixTables must carry the **same columns in the same
+order**. `to_dense_mt` pairs them **positionally**
+(`hl.scan._densify(hl.len(var_cols), ref_entries)`), never by sample ID.
+Filter columns on one and not the other and the densify **succeeds
+silently, with every sample's reference data shifted onto a different
+sample**.
+
+Demonstrated with a per-sample tracer (sample *i* carries `DP = 10i` in
+its reference blocks), dropping sample `0` from `variant_data` only:
+
+| sample | expected DP | got |
+|---|---|---|
+| 2 | 20 | **10** |
+| 3 | 30 | **20** |
+
+No error, no warning — hom-ref depth, GQ, and every other
+reference-block field lands on the wrong sample.
+
+**Rule:** never filter one side alone. Either use
+`hl.vds.filter_samples(vds, ht, keep=…)` (it filters both), or apply the
+*same* predicate to both and rebuild:
+
+```python
+vmt = vds.variant_data.filter_cols(pred)
+rmt = vds.reference_data.filter_cols(pred)
+vds = hl.vds.VariantDataset(rmt, vmt)
+```
+
+**`validate()` is not a reliable backstop.** `vds.validate()` does check
+that the column keys match — but on a VDS in the newer `LEN`
+reference-block representation it crashes first with
+`AttributeError: … no field … 'END'` (`variant_dataset.py:344` still
+aggregates on `rd.END`), so on those datasets the check can't run at
+all. Verify it yourself: `rd.count_cols() == vd.count_cols()`.
+
+**Related:** `hl.vds.filter_samples(..., remove_dead_alleles=True)`
+raises `AttributeError: … 'LA'` on a **split** VDS — recomputing local
+alleles needs the `LA` field, which splitting removes.
+
+---
+
+## A VDS without `ref_block_max_length` gets slow interval filters — and Hail only warns
+
+**`[Hail]` · Verified on Hail 0.2.134**
+
+`hl.vds.filter_intervals` can only skip reference blocks that can't
+reach the target interval if it knows the longest block in the dataset.
+That bound lives in a global on `reference_data`
+(`ref_block_max_length`), written by newer Hail. Read a VDS that predates
+it and you get a **warning, not an error**:
+
+> You are reading a VDS written with an older version of Hail. Hail now
+> supports much faster interval filters on VDS, but you'll need to run
+> either `hl.vds.truncate_reference_blocks(vds, ...)` and write a copy
+> or patch the existing VDS in place with
+> `hl.vds.store_ref_block_max_length(vds_path)`.
+
+Nothing breaks; interval filtering just can't prune, so it reads far
+more reference data than it needs. Hail emits enough warnings on a
+normal job that this one is easy to scroll past — the symptom people
+notice is "interval-filtered reads of this VDS are much slower than
+they should be."
+
+**Fix:** patch the dataset once with
+`hl.vds.store_ref_block_max_length(vds_path)`. Check first with
+`"ref_block_max_length" in vds.reference_data.globals` — cheaper than
+re-reading the warning log.
+
+---
+
+## Split a VDS by columns, not `hl.vds.filter_samples`, if you'll rejoin/densify
+
+**`[gnomAD data]` · `[internal only]` · Applies to:** v4 (the release VDS is split into UKB / non-UKB
+cohorts for size; any analysis that subsets VDS samples with intent to
+recombine).
+
+`hl.vds.filter_samples()` doesn't only subset columns — after removing samples
+it drops `variant_data` rows with no defined entry in the retained set (i.e.
+sites with no alt-allele carrier in the subset), regardless of
+`remove_dead_alleles`, in every Hail version through ≥0.2.128. That's fine for a
+standalone subset. But if you split a VDS into cohorts intending to rejoin or
+densify across the full variant set, the dropped sites mean the subset's
+reference blocks (hom-ref calls) at those loci can't be placed on densify →
+silently reduced AN for any variant private to the *other* subset. This bit the
+v4.0 release freq; corrected in v4.1 (`fix_freq_an.py`, gnomad_production#1366).
+
+Use gnomad_qc's `split_vds` pattern — filter columns on **both** datasets
+(which keeps every variant site, unlike `filter_samples`) and reconstruct
+the VDS:
+
+```python
+# BAD: drops sites with no alt carrier in the subset → AN loss on rejoin
+ukb = hl.vds.filter_samples(vds, ukb_ht, keep=True)
+
+# GOOD: gnomad_qc/v4/annotations/generate_freq.py::split_vds
+vmt = vds.variant_data.filter_cols(pred)      # keeps ALL variant rows/sites
+rmt = vds.reference_data.filter_cols(pred)    # same predicate — see entry above
+rmt = rmt.filter_rows(hl.agg.count() > 0)     # prune now-empty ref blocks (safe)
+ukb = hl.vds.VariantDataset(rmt, vmt)
+```
+
+**Symptom:** AN lower than expected for variants private to one cohort after
+rejoining split VDSs; freq that won't reconcile with the unsplit callset; no
+error.
+
+**Canary:** the subset's `variant_data` row count should equal the input's (all
+sites retained). If it shrank, filter_samples-style site dropping happened.
+
+**Two things that made this hard to spot** when it happened, both worth
+knowing before you trust a subset's variant list:
+
+- `remove_dead_alleles=False` was expected to preserve every locus. It
+  doesn't govern that at all — the row dropping happens regardless, and
+  the subset behaves more like a project-VCF of its own samples than a
+  view onto the callset.
+- Comparing subsets by variant count is muddier than it looks with
+  **multiallelics**. After densify-and-split, a site can carry call-stats
+  information in a subset that has no carrier of that allele, because
+  depth data alone is enough to define the site. So "same variants on
+  both sides" is not a clean check, and the two subsets plus their union
+  need not agree on row count.
+
+**Where to find more:** `split_vds` in `gnomad_qc/v4/annotations/generate_freq.py`;
+`fix_freq_an.py`; gnomad_production#1366.
+
+---
+
+[← back to the index](README.md)

--- a/knowledge/working-with-ai.md
+++ b/knowledge/working-with-ai.md
@@ -1,0 +1,132 @@
+# Working with an AI assistant on this codebase
+
+Not gnomAD or Hail knowledge — this is about the tooling around it: how
+to keep an assistant's output useful, what wastes tokens, and what
+belongs in a project config file versus your own.
+
+The rest of this tree tells an assistant *what is true about the data*.
+This page is about *how to work with one*.
+
+## Keeping output terse
+
+The default failure mode is too much prose: restating the request,
+narrating each step, docstrings that paraphrase the signature, comments
+that restate the line above.
+
+Stating a preference in a config file works, but only where the
+assistant is already reading. **Put the rule next to the thing it
+governs** — a verbosity rule inside the code-style section of a project's
+`CLAUDE.md` lands better than the same sentence in a general preferences
+list, because it's in context exactly when style is being decided. A
+vague global "be concise" competes with everything else in the file and
+gets diluted.
+
+What's worth stating explicitly, because assistants get these wrong by
+default:
+
+- Comments explain **why**, never **what**.
+- Don't add docstrings or comments to code you didn't touch.
+- Don't restate the request before answering it.
+- Delete a sentence; if nothing is lost, it shouldn't have been there.
+
+If a rule is being ignored even when it's in context, that's the point
+to reach for a **hook** — the only mechanism that enforces rather than
+requests. Rules are advisory; hooks run.
+
+## Using compute and tokens well
+
+Two separate costs are easy to conflate: **your token spend** with the
+assistant, and **the cluster time** it causes you to spend. The second
+is usually the larger number.
+
+**Cluster cost.** Everything in [Lazy evaluation and
+materialization](lazy-eval-and-materialization.md#lazy-evaluation-and-materialization)
+is a token-cost issue too — a stray `.count()` for logging costs a full
+re-run of the upstream query. When reviewing generated pipeline code,
+that entry's grep (`.count()`, `.show()`) is the highest-value check you
+can do before submitting a job.
+
+**Token cost.** What actually burns tokens, in rough order:
+
+- **Re-reading whole files** to answer a question about one function.
+  Ask for a targeted `grep`/search first; read the file only when the
+  answer needs surrounding context.
+- **Shell inspection loops** — `cat`-ing several files in sequence,
+  re-running `ls` to re-orient. One combined command that prints exactly
+  what's needed beats five round trips.
+- **Permission round-trips.** Every prompt for a read-only command costs
+  a turn. Allowlisting genuinely read-only commands in a project's
+  `.claude/settings.json` removes that overhead — see the config
+  section below.
+- **Long outputs you don't read.** Piping to `head`, `tail`, or a
+  filtered `grep` is cheaper than dumping a 5,000-line log into context.
+
+Worth knowing: a suggested command you *reject* still costs the tokens
+that proposed it. Rejecting a bad plan is not free, so it's cheaper to
+be specific up front than to iterate through proposals.
+
+> **To fill in.** This section is deliberately partial. Add what you
+> find: model choice per task type, when a fresh session beats
+> continuing a long one, whether long-context sessions are worth their
+> cost on this codebase, and any measured before/after numbers.
+
+## `CLAUDE.md` vs `CLAUDE.local.md`
+
+Most repos here carry two config files, and the split is by
+**portability**, not by secrecy.
+
+| | `CLAUDE.md` | `CLAUDE.local.md` |
+|---|---|---|
+| tracked | **committed** — everyone gets it | **gitignored** — yours alone |
+| holds | facts true for anyone in this repo | facts true only on your machine |
+| examples | project structure, pipeline architecture, code conventions, cross-repo coupling, recurring gotchas, invocation patterns with placeholders | absolute paths, conda env names, your cluster names, GCP project IDs, scratch buckets, output-postfix conventions, personal workflow preferences |
+
+**The test:** would this sentence be true for a new team member on a
+different laptop? If yes it's `CLAUDE.md`; if it names your machine, it's
+`CLAUDE.local.md`. When in doubt, prefer `CLAUDE.md` **with a
+placeholder** (`<repo-root>`, `<cluster>`) over `CLAUDE.local.md` with a
+concrete value — the former helps everyone.
+
+**Confirm `CLAUDE.local.md` is actually ignored.** Being untracked is not
+the same as being ignored: an untracked-but-unignored file is one
+`git add -A` away from being committed, along with your paths and cluster
+names. Check with `git check-ignore -v CLAUDE.local.md`; if it prints
+nothing, add it to `.gitignore`.
+
+### What makes these files work
+
+- **Keep them tight.** These are reference cards, not changelogs. A
+  bullet in the right existing section beats a new heading per finding.
+  If a section sprawls, consolidate rather than append.
+- **Record what you can't re-derive.** Non-obvious API behavior, a
+  version gotcha, why a workaround exists, where a resource lives.
+  Skip anything a 30-second `grep` would answer.
+- **Put rules where they apply.** See the verbosity discussion above —
+  placement affects whether a rule is followed.
+- **Update them as you learn**, in the same session you learned it.
+  The knowledge that never gets written down is the knowledge you
+  acquired while busy.
+
+### Bootstrapping your own
+
+To create or refresh these files, hand your assistant this section and a
+request along these lines:
+
+> Read `knowledge/working-with-ai.md`, then look through this repo —
+> structure, entry points, test setup, CI, and how jobs actually get
+> run. Draft a `CLAUDE.md` covering what any contributor would need, and
+> a `CLAUDE.local.md` for anything specific to my machine. Sort every
+> fact by the portability test in that doc. Show me both before writing
+> them, and don't include anything you haven't verified against the
+> repo.
+
+The last two clauses matter. Ask to see it first — these files are read
+by every future session, so a wrong fact in one is expensive. And an
+assistant asked to write a config file will otherwise cheerfully invent
+plausible-looking conventions that this repo doesn't follow.
+
+To refresh an existing pair, point at them instead: *"reconcile
+`CLAUDE.md` against the current repo — flag anything stale or no longer
+true, and propose cuts for anything I could re-derive with a grep."*
+Staleness is the main failure mode of these files, and pruning is the
+part nobody does.


### PR DESCRIPTION
## Summary

- Adds `knowledge/`, a shared reference of gnomAD + Hail institutional knowledge maintained by the methods group: bug classes that produce plausible-looking wrong output rather than crashing, design tradeoffs that aren't visible in the code, and facts about the released data that are otherwise buried in the source or in meeting minutes.
- Publishes it to the documentation site alongside the API reference, so it's reachable by people outside the team.
- Adds the repo-level assistant configuration that points at it, plus the team's shared Claude Code skills.

## Changes

- **`knowledge/` (14 files, ~2,900 lines).** A routing README plus topic sub-documents — missingness, Hail idioms, lazy evaluation/materialization, partitioning/shuffles/OOM, hidden APIs, gnomAD-specific, VDS, biology, analysis patterns, Dataproc/operational, release conventions, testing, and working with an AI assistant. The README is an index: a reader loads only the sub-document they need rather than the whole reference.
- **Entry conventions.** Every entry is tagged `[Hail]` and/or `[gnomAD data]`, marked `[internal only]` where it describes artifacts outside the public release, and stamped with the Hail version where behavior is version-dependent. Contribution rules are in the README.
- **Docs wiring.** `docs/build.sh` stages a copy of `knowledge/` into the Sphinx source dir the way `api_reference` is generated; `docs/.gitignore` ignores the copy; `docs/index.rst` gains a toctree entry; `docs/conf.py` sets `myst_heading_anchors = 3` so cross-document `file.md#heading` links resolve. The canonical copy stays at the repo root — readable on GitHub, not coupled to the build.
- **`CLAUDE.md`** (new, deliberately minimal): a pointer to `knowledge/README.md` and its contribution rules, a verbosity rule, and the `CLAUDE.md` vs `CLAUDE.local.md` split. Broader repo context is left to the separate PR that adds it.
- **`.gitignore`**: ignores `CLAUDE.local.md`, which was untracked but not ignored.
- **`.claude/settings.json`** (new): allowlists read-only inspection commands (`git status/log/diff/show`, `ls`, `grep`, `find`, `wc`, `head`, `tail`, `pytest`, `./docs/build.sh`).
- **`.claude/skills/`**: the team's shared commit / review / PR-draft / history-cleanup workflows. `review` is bw2's MIT-licensed skill, vendored with its LICENSE.

## Hail / Compute notes

No pipeline code, no Hail operations, no resource paths, and no schema changes — the only Python touched is a single config line in `docs/conf.py`. Nothing here reads or writes GCS, and there is no compute cost.

Claims *about* Hail and gnomAD data in the reference were verified against Hail 0.2.134 source, the released v4.1 exomes HT globals, and small local jobs. Entries that come from the project's meeting record rather than from re-derivation are labeled `reported · project meeting` so a reader can weigh them differently.

## Testing

- Docs build verified locally against the pinned dependencies CI uses (`sphinx 6.2.1`, `myst-parser 2.0.0`) with `sphinx -W`, exactly as `./docs/build.sh` runs it: build succeeds, all 13 knowledge pages render.
- Every cross-page anchor link in the **generated HTML** was checked against the ids that actually exist on the target pages — none broken.
- No unit tests added: this PR contains no library code. `pytest` and lint jobs are unaffected.
- **The `docs` CI job now covers this content.** A malformed entry fails the build rather than merely rendering oddly on GitHub — that's intentional, and the contribution rules tell contributors to run `./docs/build.sh` before opening a PR.

## Code review

- [x] `/review` run — models: Opus, Sonnet (detection and validation; `agy` not installed, so not in the roster)

Three findings, all agreed by both validators. Two are fixed in this branch:

- **Fixed:** `CLAUDE.md` documented an import block in which 12 of 20 names did not exist anywhere in the repo. The file is now cut to the minimum described above, so the list is gone entirely.
- **Fixed:** the draft-PR skill inferred the reviewer roster from detection prompts alone, assuming detection and validation share a roster; the review skill documents them as independent. It now reads both and reports what actually validated.
- **Not fixed (pre-existing on `main`):** `docs/conf.py` calls `requests.head(...)` at config load with no `try/except` and no `timeout=`, so an offline or network-restricted environment aborts or hangs the docs build instead of degrading to the no-intersphinx path. This branch didn't touch those lines, but the new contribution rules make people run `./docs/build.sh` more often, so it's worth a follow-up PR.

## Reviewer notes

- **This PR puts documentation under CI.** The `docs` job builds with `sphinx -W`, so from here on a malformed entry in `knowledge/` fails the build. Worth agreeing that's the tradeoff you want.
- **`.claude/settings.json` changes permission behavior for everyone** on the repo, not just the author. It's read-only commands and a local build, but it's the one change here with a blast radius beyond documentation — easy to trim or drop.
- **Please sanity-check the `[internal only]` tagging.** Parts of the release-conventions and biology entries came from internal meeting records; only facts about *released* data and public-facing policy were kept, with no names, cost figures, or unpublished work. A second pair of eyes on that boundary is the most valuable review this PR can get.
- **Domain review welcome on the data claims** — annotation-version pinning and its GTEx/pext coupling, LOEUF cutoffs not porting across releases, which subsets exist and why, and the CMRG false-duplication genes (CBS, KCNE1, CRYAA).
- `CLAUDE.md` is intentionally minimal here to avoid colliding with the separate PR that adds the fuller version.

## Merge strategy

**Rebase, not squash.** The five commits are deliberately structured — reference content, docs publishing, contributor config, permissions, and tooling each stand alone and are individually revertible. The `.claude/settings.json` commit in particular is the one a reviewer might want to drop on its own, which squashing would make awkward.
