### PR TITLE
Optimizations to sex-ploidy adjustment and reducing groups during aggs

### DIFF
--- a/gnomad/sample_qc/sex.py
+++ b/gnomad/sample_qc/sex.py
@@ -17,6 +17,40 @@ logger.setLevel(logging.INFO)
 SEXES = {"XY": "XY", "XX": "XX"}
 
 
+def _sex_ploidy_case_expr(
+    gt_expr: hl.expr.CallExpression,
+    col_flags: hl.expr.StructExpression,
+    row_flags: hl.expr.StructExpression,
+) -> hl.expr.CallExpression:
+    """
+    Build the sex-ploidy genotype adjustment from precomputed sample and locus flags.
+
+    :param gt_expr: Genotype expression.
+    :param col_flags: Struct with per-sample booleans ``xy`` and ``xx``.
+    :param row_flags: Struct with per-locus booleans ``in_autosome``,
+        ``in_non_par``, ``x_nonpar``, ``y_par`` and ``y_nonpar``.
+    :return: Genotype adjusted for sex ploidy.
+    """
+    return (
+        hl.case(missing_false=True)
+        # Added to reduce the checks by entry.
+        .when(row_flags.in_autosome, gt_expr)
+        .when(
+            (row_flags.y_par | row_flags.y_nonpar) & col_flags.xx, hl.missing(hl.tcall)
+        )
+        .when(~row_flags.in_non_par, gt_expr)
+        .when(
+            (row_flags.x_nonpar | row_flags.y_nonpar) & col_flags.xy & gt_expr.is_het(),
+            hl.missing(hl.tcall),
+        )
+        .when(
+            (row_flags.x_nonpar | row_flags.y_nonpar) & col_flags.xy,
+            hl.call(gt_expr[0], phased=False),
+        )
+        .default(gt_expr)
+    )
+
+
 def adjusted_sex_ploidy_expr(
     locus_expr: hl.expr.LocusExpression,
     gt_expr: hl.expr.CallExpression,
@@ -26,6 +60,15 @@ def adjusted_sex_ploidy_expr(
 ) -> hl.expr.CallExpression:
     """
     Create an entry expression to convert XY to haploid on non-PAR X/Y and XX to missing on Y.
+
+    .. note::
+
+        The per-sample and per-locus flags are indexed back from the source
+        MatrixTable's ``cols()`` and ``rows()`` (see
+        `annotate_and_index_source_mt_for_sex_ploidy`). Hail evaluates those
+        self-joins as a second pass over the source MatrixTable's upstream
+        pipeline, so when the source is expensive to compute (e.g. a densified
+        MatrixTable) use `adjust_sex_ploidy`, which annotates the flags in place.
 
     :param locus_expr: Locus expression.
     :param gt_expr: Genotype expression.
@@ -40,22 +83,7 @@ def adjusted_sex_ploidy_expr(
         locus_expr, karyotype_expr, xy_karyotype_str, xx_karyotype_str
     )
 
-    return (
-        hl.case(missing_false=True)
-        # Added to reduce the checks by entry.
-        .when(row_idx.in_autosome, gt_expr)
-        .when((row_idx.y_par | row_idx.y_nonpar) & col_idx.xx, hl.missing(hl.tcall))
-        .when(~row_idx.in_non_par, gt_expr)
-        .when(
-            (row_idx.x_nonpar | row_idx.y_nonpar) & col_idx.xy & gt_expr.is_het(),
-            hl.missing(hl.tcall),
-        )
-        .when(
-            (row_idx.x_nonpar | row_idx.y_nonpar) & col_idx.xy,
-            hl.call(gt_expr[0], phased=False),
-        )
-        .default(gt_expr)
-    )
+    return _sex_ploidy_case_expr(gt_expr, col_idx, row_idx)
 
 
 def adjust_sex_ploidy(
@@ -63,19 +91,46 @@ def adjust_sex_ploidy(
     sex_expr: hl.expr.StringExpression,
     xy_str: str = "XY",
     xx_str: str = "XX",
+    gt_field: str = "GT",
 ) -> hl.MatrixTable:
     """
     Convert XY to haploid on non-PAR X/Y, sets XX to missing on Y.
+
+    The per-sample (``xy``/``xx``) and per-locus (PAR/non-PAR) flags are
+    annotated directly onto `mt`'s columns and rows and dropped again after the
+    genotype adjustment, so `mt`'s upstream pipeline is evaluated once. This is
+    the same adjustment as `adjusted_sex_ploidy_expr` without that function's
+    ``cols()``/``rows()`` self-joins.
 
     :param mt: Input MatrixTable
     :param sex_expr: Expression pointing to sex in MT (if not xy_str or xx_str, no change)
     :param xy_str: String for XY (default 'XY')
     :param xx_str: String for XX (default 'XX')
+    :param gt_field: Name of the genotype entry field to adjust. Default is "GT".
     :return: MatrixTable with fixed ploidy for sex chromosomes
     """
-    return mt.annotate_entries(
-        GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, sex_expr, xy_str, xx_str)
+    mt = mt.annotate_cols(
+        _sex_ploidy_col=hl.struct(
+            xy=sex_expr.upper() == xy_str, xx=sex_expr.upper() == xx_str
+        )
     )
+    mt = mt.annotate_rows(
+        _sex_ploidy_row=hl.struct(
+            in_non_par=~mt.locus.in_autosome_or_par(),
+            in_autosome=mt.locus.in_autosome(),
+            x_nonpar=mt.locus.in_x_nonpar(),
+            y_par=mt.locus.in_y_par(),
+            y_nonpar=mt.locus.in_y_nonpar(),
+        )
+    )
+    mt = mt.annotate_entries(
+        **{
+            gt_field: _sex_ploidy_case_expr(
+                mt[gt_field], mt._sex_ploidy_col, mt._sex_ploidy_row
+            )
+        }
+    )
+    return mt.drop("_sex_ploidy_col", "_sex_ploidy_row")
 
 
 def gaussian_mixture_model_karyotype_assignment(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2413,7 +2413,9 @@ def find_strata_cells(
     `expand_strata_array_from_leaves` and `agg_by_strata`, with their metadata
     (`{"group": <label>, "cell": "<k>"}`) carried only in the reduced
     `freq_meta`. Groups listed in `force_leaf_groups` are kept as real leaves
-    (their own `freq_meta` index) ahead of the cells.
+    (their own `freq_meta` index) ahead of the cells. A group with no samples
+    has no cell to be built from, so it is also kept as a real leaf (after its
+    label's cells) rather than left without a decomposition.
 
     Samples that belong to no group of a label (an all-False pattern) do not
     form a cell; no group needs them.
@@ -2479,6 +2481,7 @@ def find_strata_cells(
             leaf_indices.append(cell_leaf[p])
             leaf_meta.append({"group": label, "cell": str(k)})
             leaf_sample_count.append(counts_by_label[label][p])
+        zero_sample = []
         for pos, i in enumerate(idxs):
             if i in forced:
                 continue
@@ -2489,6 +2492,9 @@ def find_strata_cells(
                     f"Cells of group {freq_meta[i]} sum to {n_children} samples,"
                     f" expected {freq_meta_sample_count[i]}."
                 )
+            if not children:
+                zero_sample.append(i)
+                continue
             decomposition[i] = children
         if cells:
             cell_of_sample = hl.literal({p: k for k, p in enumerate(cells)}).get(
@@ -2498,6 +2504,14 @@ def find_strata_cells(
                 hl.coalesce(cell_of_sample == k, False) for k in range(len(cells))
             )
         next_leaf += len(cells)
+        # No cell covers a group with no samples, so it would otherwise be
+        # neither a leaf nor decomposable. Keep it as a real leaf with its own
+        # (all-False) membership; aggregating it directly costs nothing.
+        for i in zero_sample:
+            leaf_indices.append(i)
+            leaf_meta.append(dict(freq_meta[i]))
+            leaf_sample_count.append(0)
+            membership_exprs.append(ht.group_membership[i])
 
     logger.info(
         "Reducing freq_meta from %d groups to %d cells (%s) plus %d forced leaves.",
@@ -2706,10 +2720,11 @@ def generate_freq_group_membership_array(
         across their values when `reduce_to_minimal_groups` is True.
         Default is None, which resolves to `{"downsampling"}`.
     :param force_leaf_groups: Optional list of `freq_meta` dicts to keep
-        as leaves under `reduce_to_minimal_groups` (see
-        `find_minimal_strata_groups`). Use this for groups that downstream
-        code accesses directly, so they remain explicitly computed instead
-        of being reconstructed per row from child groups.
+        as leaves under either reduction mode (see
+        `find_minimal_strata_groups` and `find_strata_cells`). Use this for
+        groups that downstream code accesses directly, so they remain
+        explicitly computed instead of being reconstructed per row from
+        child groups or cells.
     :param group_label: Value to use for the `"group"` key on every
         constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
         for callers that don't apply any genotype-level filtering (e.g.,
@@ -2721,7 +2736,7 @@ def generate_freq_group_membership_array(
         reconstructed by summing its cells, so each sample is aggregated once
         per label. The same reduction-tracking globals are written. Mutually
         exclusive with `reduce_to_minimal_groups`; `non_summable_strata` is
-        unused. Default is False.
+        unused, but `force_leaf_groups` is still applied. Default is False.
     :return: Table with the 'group_membership' array annotation.
     """
     if reduce_to_minimal_groups and reduce_to_cells:

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2454,10 +2454,18 @@ def find_strata_cells(
         idx_by_label[label].append(i)
 
     # One pass over the sample Table: per label, count samples per membership
-    # pattern, encoded as a "0"/"1" string so it can key a literal dict.
+    # pattern, encoded as a "0"/"1" string so it can key a literal dict. A
+    # membership bit is missing when a sample lacks a stratification value;
+    # the group aggregations (`hl.agg.filter`) and `freq_meta_sample_count`
+    # (`hl.agg.count_where`) both treat that as not a member, so the pattern
+    # must too (`hl.delimit` would otherwise render it as "null" and shift
+    # every later position).
     def _pattern_expr(label: str) -> hl.expr.StringExpression:
         return hl.delimit(
-            [hl.if_else(ht.group_membership[i], "1", "0") for i in idx_by_label[label]],
+            [
+                hl.if_else(hl.coalesce(ht.group_membership[i], False), "1", "0")
+                for i in idx_by_label[label]
+            ],
             "",
         )
 
@@ -2475,7 +2483,9 @@ def find_strata_cells(
     # stays linear in the number of cells (see below).
     membership_parts: List[hl.expr.ArrayExpression] = []
     if forced:
-        membership_parts.append(hl.array([ht.group_membership[i] for i in forced]))
+        membership_parts.append(
+            hl.array([hl.coalesce(ht.group_membership[i], False) for i in forced])
+        )
 
     next_leaf = n_full
     for label in labels:
@@ -2529,7 +2539,9 @@ def find_strata_cells(
             leaf_sample_count.append(0)
         if zero_sample:
             membership_parts.append(
-                hl.array([ht.group_membership[i] for i in zero_sample])
+                hl.array(
+                    [hl.coalesce(ht.group_membership[i], False) for i in zero_sample]
+                )
             )
 
     logger.info(

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2469,7 +2469,13 @@ def find_strata_cells(
     leaf_meta = [dict(freq_meta[i]) for i in forced]
     leaf_sample_count = [freq_meta_sample_count[i] for i in forced]
     decomposition: Dict[int, List[int]] = {}
-    membership_exprs = [ht.group_membership[i] for i in forced]
+    # Leaf-only membership is assembled from array-valued parts, in leaf order:
+    # forced leaves, then per label its cells followed by its zero-sample
+    # leaves. Each label's cell flags come from a single bound lookup so the IR
+    # stays linear in the number of cells (see below).
+    membership_parts: List[hl.expr.ArrayExpression] = []
+    if forced:
+        membership_parts.append(hl.array([ht.group_membership[i] for i in forced]))
 
     next_leaf = n_full
     for label in labels:
@@ -2497,11 +2503,21 @@ def find_strata_cells(
                 continue
             decomposition[i] = children
         if cells:
+            # Look the sample's cell up once and derive every cell flag from
+            # that bound value. Reusing the lookup expression in one comparison
+            # per cell would re-embed the literal dict and the pattern
+            # expression in each, making the IR quadratic in the cell count.
+            n_cells = len(cells)
             cell_of_sample = hl.literal({p: k for k, p in enumerate(cells)}).get(
                 _pattern_expr(label)
             )
-            membership_exprs.extend(
-                hl.coalesce(cell_of_sample == k, False) for k in range(len(cells))
+            membership_parts.append(
+                hl.bind(
+                    lambda c: hl.range(n_cells).map(
+                        lambda k: hl.coalesce(c == k, False)
+                    ),
+                    cell_of_sample,
+                )
             )
         next_leaf += len(cells)
         # No cell covers a group with no samples, so it would otherwise be
@@ -2511,7 +2527,10 @@ def find_strata_cells(
             leaf_indices.append(i)
             leaf_meta.append(dict(freq_meta[i]))
             leaf_sample_count.append(0)
-            membership_exprs.append(ht.group_membership[i])
+        if zero_sample:
+            membership_parts.append(
+                hl.array([ht.group_membership[i] for i in zero_sample])
+            )
 
     logger.info(
         "Reducing freq_meta from %d groups to %d cells (%s) plus %d forced leaves.",
@@ -2526,7 +2545,11 @@ def find_strata_cells(
         decomposition,
         leaf_meta,
         leaf_sample_count,
-        hl.array(membership_exprs),
+        (
+            hl.flatten(hl.array(membership_parts))
+            if membership_parts
+            else hl.empty_array(hl.tbool)
+        ),
     )
 
 

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2443,10 +2443,16 @@ def find_strata_cells(
             )
         forced.extend(matches)
 
-    # Group positions by label, preserving first-seen label order.
+    # Group the non-forced positions by label, preserving first-seen label
+    # order. Forced groups are aggregated directly, so they neither split a
+    # label's cells nor need any; a label whose groups are all forced gets no
+    # cells at all (a cell nothing decomposes into would be aggregated and
+    # then discarded).
     labels: List[str] = []
     idx_by_label: Dict[str, List[int]] = {}
     for i, m in enumerate(freq_meta):
+        if i in forced:
+            continue
         label = m.get("group")
         if label not in idx_by_label:
             labels.append(label)
@@ -2499,8 +2505,6 @@ def find_strata_cells(
             leaf_sample_count.append(counts_by_label[label][p])
         zero_sample = []
         for pos, i in enumerate(idxs):
-            if i in forced:
-                continue
             children = [cell_leaf[p] for p in cells if p[pos] == "1"]
             n_children = sum(counts_by_label[label][p] for p in cells if p[pos] == "1")
             if n_children != freq_meta_sample_count[i]:
@@ -2590,11 +2594,15 @@ def expand_strata_array_from_leaves(
 
     The expansion is encoded as a compact Hail IR operation
     (`hl_children.map(...)`) with lookup tables for leaf positions and
-    child-index lists. The serialized IR size is therefore O(n_full)
-    regardless of how many groups there are. This avoids Jackson's JSON
-    string-length limit that would otherwise be hit if each group's
-    expression were inlined as a separate Python-side Hail expression
-    literal.
+    child-index lists. The serialized IR size is therefore proportional to
+    the total number of (group, child) pairs in `decomposition` rather than
+    to the number of inlined expressions: O(n_full) under
+    `find_minimal_strata_groups`, where each group has a handful of children,
+    and up to O(n_full x n_cells) under `find_strata_cells`, where a broad
+    group (e.g. the all-samples group) decomposes into every cell of its
+    label. This avoids Jackson's JSON string-length limit that would
+    otherwise be hit if each group's expression were inlined as a separate
+    Python-side Hail expression literal.
 
     :param leaf_array: Hail array expression of length `len(leaf_indices)`
         produced by aggregating only the leaf groups.

--- a/gnomad/utils/annotations.py
+++ b/gnomad/utils/annotations.py
@@ -2381,6 +2381,141 @@ def find_minimal_strata_groups(
     return leaf_indices, decomposition
 
 
+def find_strata_cells(
+    ht: hl.Table,
+    freq_meta: List[Dict[str, str]],
+    freq_meta_sample_count: List[int],
+    force_leaf_groups: Optional[List[Dict[str, str]]] = None,
+) -> Tuple[
+    List[int],
+    Dict[int, List[int]],
+    List[Dict[str, str]],
+    List[int],
+    hl.expr.ArrayExpression,
+]:
+    """
+    Reduce `freq_meta` to its "cells": the distinct per-sample membership patterns.
+
+    This is an alternative to `find_minimal_strata_groups` that does not reason
+    about strata names at all. Within each `"group"` label (typically `adj` and
+    `raw`), two samples fall in the same cell when they belong to exactly the
+    same set of `freq_meta` groups. Cells are disjoint by construction and every
+    group is the exact union of the cells whose pattern includes it, so every
+    group's call stats can be reconstructed by summing its cells with
+    `expand_strata_array_from_leaves`. Because the cells partition the samples,
+    aggregating once per cell visits each sample once per label, however many
+    (overlapping) groups `freq_meta` contains -- including groups that
+    `find_minimal_strata_groups` cannot decompose, such as downsamplings.
+
+    Cells are synthetic leaves: they are not entries of `freq_meta`. They are
+    numbered from `len(freq_meta)` onward so they fit the same
+    `(leaf_indices, decomposition)` encoding consumed by
+    `expand_strata_array_from_leaves` and `agg_by_strata`, with their metadata
+    (`{"group": <label>, "cell": "<k>"}`) carried only in the reduced
+    `freq_meta`. Groups listed in `force_leaf_groups` are kept as real leaves
+    (their own `freq_meta` index) ahead of the cells.
+
+    Samples that belong to no group of a label (an all-False pattern) do not
+    form a cell; no group needs them.
+
+    :param ht: Table with the full-length per-sample `group_membership` array.
+    :param freq_meta: Full `freq_meta` list aligned with `ht.group_membership`.
+    :param freq_meta_sample_count: Per-group sample counts aligned with
+        `freq_meta`; each group's cells are checked to sum to it.
+    :param force_leaf_groups: Optional `freq_meta` dicts to keep as real leaves
+        rather than reconstructing them from cells.
+    :return: Tuple of `(leaf_indices, decomposition, leaf_meta,
+        leaf_sample_count, leaf_membership_expr)`: the leaf encoding as for
+        `find_minimal_strata_groups` (cell leaves are indices >=
+        `len(freq_meta)`), the reduced `freq_meta` and sample counts, and the
+        per-sample leaf-only `group_membership` expression on `ht`.
+    """
+    n_full = len(freq_meta)
+    force_leaf_groups = force_leaf_groups or []
+    forced = []
+    for target in force_leaf_groups:
+        matches = [i for i, m in enumerate(freq_meta) if m == target]
+        if not matches:
+            raise ValueError(
+                f"`force_leaf_groups` entry {target} is not in `freq_meta`."
+            )
+        forced.extend(matches)
+
+    # Group positions by label, preserving first-seen label order.
+    labels: List[str] = []
+    idx_by_label: Dict[str, List[int]] = {}
+    for i, m in enumerate(freq_meta):
+        label = m.get("group")
+        if label not in idx_by_label:
+            labels.append(label)
+            idx_by_label[label] = []
+        idx_by_label[label].append(i)
+
+    # One pass over the sample Table: per label, count samples per membership
+    # pattern, encoded as a "0"/"1" string so it can key a literal dict.
+    def _pattern_expr(label: str) -> hl.expr.StringExpression:
+        return hl.delimit(
+            [hl.if_else(ht.group_membership[i], "1", "0") for i in idx_by_label[label]],
+            "",
+        )
+
+    counts_by_label = ht.aggregate(
+        hl.struct(**{label: hl.agg.counter(_pattern_expr(label)) for label in labels})
+    )
+
+    leaf_indices = list(forced)
+    leaf_meta = [dict(freq_meta[i]) for i in forced]
+    leaf_sample_count = [freq_meta_sample_count[i] for i in forced]
+    decomposition: Dict[int, List[int]] = {}
+    membership_exprs = [ht.group_membership[i] for i in forced]
+
+    next_leaf = n_full
+    for label in labels:
+        idxs = idx_by_label[label]
+        # Skip the all-False pattern; sort the rest so numbering is stable.
+        cells = sorted(p for p in counts_by_label[label] if "1" in p)
+        cell_leaf = {p: next_leaf + k for k, p in enumerate(cells)}
+        for k, p in enumerate(cells):
+            leaf_indices.append(cell_leaf[p])
+            leaf_meta.append({"group": label, "cell": str(k)})
+            leaf_sample_count.append(counts_by_label[label][p])
+        for pos, i in enumerate(idxs):
+            if i in forced:
+                continue
+            children = [cell_leaf[p] for p in cells if p[pos] == "1"]
+            n_children = sum(counts_by_label[label][p] for p in cells if p[pos] == "1")
+            if n_children != freq_meta_sample_count[i]:
+                raise ValueError(
+                    f"Cells of group {freq_meta[i]} sum to {n_children} samples,"
+                    f" expected {freq_meta_sample_count[i]}."
+                )
+            decomposition[i] = children
+        if cells:
+            cell_of_sample = hl.literal({p: k for k, p in enumerate(cells)}).get(
+                _pattern_expr(label)
+            )
+            membership_exprs.extend(
+                hl.coalesce(cell_of_sample == k, False) for k in range(len(cells))
+            )
+        next_leaf += len(cells)
+
+    logger.info(
+        "Reducing freq_meta from %d groups to %d cells (%s) plus %d forced leaves.",
+        n_full,
+        next_leaf - n_full,
+        ", ".join(f"{label}: {len(idx_by_label[label])} groups" for label in labels),
+        len(forced),
+    )
+
+    return (
+        leaf_indices,
+        decomposition,
+        leaf_meta,
+        leaf_sample_count,
+        hl.array(membership_exprs),
+    )
+
+
 def expand_strata_array_from_leaves(
     leaf_array: hl.expr.ArrayExpression,
     leaf_indices: List[int],
@@ -2415,7 +2550,9 @@ def expand_strata_array_from_leaves(
     :param leaf_array: Hail array expression of length `len(leaf_indices)`
         produced by aggregating only the leaf groups.
     :param leaf_indices: Indices into the original `freq_meta` marking the
-        leaves, in the same order as `leaf_array`.
+        leaves, in the same order as `leaf_array`. Synthetic leaves (cells
+        from `find_strata_cells`) use indices >= `n_full`; they only ever
+        appear as children in `decomposition`.
     :param decomposition: Map from non-leaf original index to the list of
         original leaf indices that sum to it.
     :param n_full: Length of the original (full) `freq_meta`.
@@ -2499,6 +2636,7 @@ def generate_freq_group_membership_array(
     non_summable_strata: Optional[Set[str]] = None,
     force_leaf_groups: Optional[List[Dict[str, str]]] = None,
     group_label: str = "adj",
+    reduce_to_cells: bool = False,
 ) -> hl.Table:
     """
     Generate a Table with a 'group_membership' array for each sample indicating whether the sample belongs to specific stratification groups.
@@ -2532,15 +2670,18 @@ def generate_freq_group_membership_array(
         - `freq_meta_full`: original full `freq_meta` before reduction.
         - `freq_meta_sample_count_full`: original full sample counts.
         - `freq_leaf_indices`: indices into `freq_meta_full` marking the
-          leaves, in the same order as the reduced `freq_meta`.
+          leaves, in the same order as the reduced `freq_meta`. Under
+          `reduce_to_cells`, cell leaves are synthetic and numbered from
+          `len(freq_meta_full)` onward; their metadata exists only in the
+          reduced `freq_meta`.
         - `freq_group_decomposition`: list of length
-          `len(freq_meta_full)` where each element is the list of
-          `freq_meta_full` indices that sum to that position. Leaves get
-          an empty list.
+          `len(freq_meta_full)` where each element is the list of leaf
+          indices that sum to that position. Leaves get an empty list.
         - `freq_reduced`: True, signalling that the reduction has been
           applied.
 
-    See `find_minimal_strata_groups` for the leaf-detection algorithm and
+    See `find_minimal_strata_groups` for the leaf-detection algorithm,
+    `find_strata_cells` for the cell-based alternative, and
     `expand_strata_array_from_leaves` for the reconstruction step.
 
     :param ht: Input Table that contains Expressions specified by `strata_expr`.
@@ -2573,8 +2714,20 @@ def generate_freq_group_membership_array(
         constructed `freq_meta` entry. Default is `"adj"`. Set to `"raw"`
         for callers that don't apply any genotype-level filtering (e.g.,
         `compute_stats_per_ref_site`).
+    :param reduce_to_cells: Whether to reduce to "cells" -- the distinct
+        per-sample membership patterns within each `"group"` label -- instead
+        of leaf groups (see `find_strata_cells`). Every group, including the
+        downsampling groups that leaf reduction must compute directly, is then
+        reconstructed by summing its cells, so each sample is aggregated once
+        per label. The same reduction-tracking globals are written. Mutually
+        exclusive with `reduce_to_minimal_groups`; `non_summable_strata` is
+        unused. Default is False.
     :return: Table with the 'group_membership' array annotation.
     """
+    if reduce_to_minimal_groups and reduce_to_cells:
+        raise ValueError(
+            "`reduce_to_minimal_groups` and `reduce_to_cells` are mutually exclusive."
+        )
     errors = []
     ds_in_strata = any("downsampling" in s for s in strata_expr)
     global_idx_in_ds_expr = any(
@@ -2719,7 +2872,7 @@ def generate_freq_group_membership_array(
         "freq_meta_sample_count": freq_meta_sample_count,
     }
 
-    if reduce_to_minimal_groups:
+    if reduce_to_minimal_groups or reduce_to_cells:
         # `freq_meta_sample_count` may be a Hail expression at this point (it
         # is wrapped in `hl.array(...).extend(...)` above when raw is
         # prepended). Materialize it back to a Python list so we can slice
@@ -2730,32 +2883,45 @@ def generate_freq_group_membership_array(
             freq_meta_sample_count_full = list(hl.eval(freq_meta_sample_count))
 
         freq_meta_full = [dict(m) for m in freq_meta]
-        leaf_indices, decomposition = find_minimal_strata_groups(
-            freq_meta_full,
-            freq_meta_sample_count_full,
-            non_summable_strata=non_summable_strata,
-            force_leaf_groups=force_leaf_groups,
-        )
-
         n_full = len(freq_meta_full)
+        if reduce_to_cells:
+            (
+                leaf_indices,
+                decomposition,
+                freq_meta,
+                freq_meta_sample_count,
+                leaf_membership,
+            ) = find_strata_cells(
+                ht,
+                freq_meta_full,
+                freq_meta_sample_count_full,
+                force_leaf_groups=force_leaf_groups,
+            )
+        else:
+            leaf_indices, decomposition = find_minimal_strata_groups(
+                freq_meta_full,
+                freq_meta_sample_count_full,
+                non_summable_strata=non_summable_strata,
+                force_leaf_groups=force_leaf_groups,
+            )
+            logger.info(
+                "Reducing freq_meta from %d to %d groups (leaf-only).",
+                n_full,
+                len(leaf_indices),
+            )
+            # Slice freq_meta, sample counts, and the per-sample
+            # group_membership array down to the leaves.
+            freq_meta = [freq_meta_full[i] for i in leaf_indices]
+            freq_meta_sample_count = [
+                freq_meta_sample_count_full[i] for i in leaf_indices
+            ]
+            leaf_membership = hl.array([ht.group_membership[i] for i in leaf_indices])
+
         # Serialize the decomposition as a list of length `n_full`, indexed
         # by the original freq_meta position. Leaves get an empty list.
         freq_group_decomposition = [decomposition.get(i, []) for i in range(n_full)]
 
-        logger.info(
-            "Reducing freq_meta from %d to %d groups (leaf-only).",
-            n_full,
-            len(leaf_indices),
-        )
-
-        # Slice freq_meta and sample counts down to the leaves.
-        freq_meta = [freq_meta_full[i] for i in leaf_indices]
-        freq_meta_sample_count = [freq_meta_sample_count_full[i] for i in leaf_indices]
-
-        # Slice the per-sample group_membership array to the leaf positions.
-        ht = ht.annotate(
-            group_membership=hl.array([ht.group_membership[i] for i in leaf_indices])
-        )
+        ht = ht.annotate(group_membership=leaf_membership)
 
         # Replace freq_meta and sample counts with their leaf-only versions.
         global_expr["freq_meta"] = freq_meta

--- a/gnomad/utils/sparse_mt.py
+++ b/gnomad/utils/sparse_mt.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import hail as hl
 
-from gnomad.sample_qc.sex import adjusted_sex_ploidy_expr
+from gnomad.sample_qc.sex import adjust_sex_ploidy
 from gnomad.utils.annotations import (
     COVERAGE_OVER_X_BINS,
     _read_reduction_globals,
@@ -1360,17 +1360,13 @@ def compute_stats_per_ref_site(
 
     if sex_karyotype_ht is not None:
         logger.info("Adjusting genotype ploidy based on sex karyotype.")
-        gt_field = gt_field.pop()
         mt = mt.annotate_cols(
             sex_karyotype=sex_karyotype_ht[mt.col_key][sex_karyotype_field]
         )
-        mt = mt.annotate_entries(
-            **{
-                gt_field: adjusted_sex_ploidy_expr(
-                    mt.locus, mt[gt_field], mt.sex_karyotype
-                )
-            }
-        )
+        # `adjust_sex_ploidy` annotates the sample/locus flags in place;
+        # `adjusted_sex_ploidy_expr` would index them back from this densified
+        # MT's cols()/rows(), which Hail runs as a second full densify.
+        mt = adjust_sex_ploidy(mt, mt.sex_karyotype, gt_field=gt_field.pop())
 
     # Annotate with adj if needed.
     if adj and "adj" not in mt.entry:

--- a/tests/sample_qc/test_sex.py
+++ b/tests/sample_qc/test_sex.py
@@ -1,0 +1,102 @@
+"""Tests for the sex ploidy adjustment functions in gnomad.sample_qc.sex."""
+
+import hail as hl
+import pytest
+
+from gnomad.sample_qc.sex import adjust_sex_ploidy, adjusted_sex_ploidy_expr
+
+
+class TestAdjustSexPloidy:
+    """Test that `adjust_sex_ploidy` matches `adjusted_sex_ploidy_expr`."""
+
+    @pytest.fixture
+    def mt(self):
+        """
+        Build an MT covering every branch of the sex ploidy adjustment.
+
+        Loci: an autosome, chrX PAR1 / non-PAR (x2) / PAR2, chrY PAR1 / non-PAR.
+        Samples: XX, XY, lowercase "xy" (matched case-insensitively), an
+        unrecognized karyotype and a missing one. Genotypes cycle through
+        hom-ref, het, hom-var and missing.
+        """
+        loci = [
+            hl.locus("chr1", 1000, reference_genome="GRCh38"),
+            hl.locus("chrX", 20000, reference_genome="GRCh38"),
+            hl.locus("chrX", 5000000, reference_genome="GRCh38"),
+            hl.locus("chrX", 100000000, reference_genome="GRCh38"),
+            hl.locus("chrY", 20000, reference_genome="GRCh38"),
+            hl.locus("chrY", 5000000, reference_genome="GRCh38"),
+            hl.locus("chrX", 155800000, reference_genome="GRCh38"),
+        ]
+        samples = [
+            ("s1", "XX"),
+            ("s2", "XY"),
+            ("s3", "xy"),
+            ("s4", "XXY"),
+            ("s5", None),
+        ]
+        gts = [(0, 0), (0, 1), (1, 1), None]
+        entries = []
+        for l_idx, locus in enumerate(loci):
+            for s_idx, (s, _) in enumerate(samples):
+                gt = gts[(l_idx + s_idx) % len(gts)]
+                entries.append(
+                    {
+                        "locus": locus,
+                        "s": s,
+                        "GT": hl.call(*gt) if gt is not None else hl.missing(hl.tcall),
+                    }
+                )
+        mt = hl.Table.parallelize(
+            entries, hl.tstruct(locus=hl.tlocus("GRCh38"), s=hl.tstr, GT=hl.tcall)
+        ).to_matrix_table(row_key=["locus"], col_key=["s"])
+        karyotype = hl.literal(dict(samples), hl.tdict(hl.tstr, hl.tstr))
+        return mt.annotate_cols(sex_karyotype=karyotype.get(mt.s))
+
+    @staticmethod
+    def _entries(mt, gt_field):
+        return sorted(
+            (e.locus.contig, e.locus.position, e.s, e[gt_field])
+            for e in mt.entries().collect()
+        )
+
+    def test_matches_expr_version(self, mt):
+        """The in-place adjustment matches `adjusted_sex_ploidy_expr` entry for entry."""
+        expected = mt.annotate_entries(
+            GT=adjusted_sex_ploidy_expr(mt.locus, mt.GT, mt.sex_karyotype)
+        )
+        actual = adjust_sex_ploidy(mt, mt.sex_karyotype)
+        assert self._entries(actual, "GT") == self._entries(expected, "GT")
+        # The temporary flag fields must not leak into the output.
+        assert set(actual.row) == set(mt.row)
+        assert set(actual.col) == set(mt.col)
+
+    def test_adjusts_expected_entries(self, mt):
+        """Spot-check every branch of the adjustment on known entries."""
+        actual = self._entries(adjust_sex_ploidy(mt, mt.sex_karyotype), "GT")
+        by_key = {(c, p, s): gt for c, p, s, gt in actual}
+        # Genotype of sample s_idx at locus l_idx is gts[(l_idx + s_idx) % 4].
+        # Autosome and PAR genotypes are untouched (XY, PAR1 and PAR2).
+        assert by_key[("chr1", 1000, "s2")] == hl.Call([0, 1])
+        assert by_key[("chrX", 20000, "s2")] == hl.Call([1, 1])
+        assert by_key[("chrX", 155800000, "s3")] == hl.Call([0, 0])
+        # XY on non-PAR X/Y: het -> missing, hom -> haploid, missing stays missing.
+        assert by_key[("chrX", 100000000, "s3")] is None  # het, lowercase "xy"
+        assert by_key[("chrX", 100000000, "s2")] == hl.Call([0])
+        assert by_key[("chrX", 5000000, "s2")] is None
+        assert by_key[("chrY", 5000000, "s2")] == hl.Call([1])
+        # XX on Y (PAR or not) -> missing regardless of the genotype.
+        assert by_key[("chrY", 20000, "s1")] is None
+        assert by_key[("chrY", 5000000, "s1")] is None
+        # Unrecognized or missing karyotypes are left alone.
+        assert by_key[("chrX", 5000000, "s4")] == hl.Call([0, 1])
+        assert by_key[("chrY", 5000000, "s5")] == hl.Call([0, 1])
+
+    def test_gt_field(self, mt):
+        """`gt_field` selects a non-default genotype entry field."""
+        mt = mt.rename({"GT": "LGT"})
+        expected = mt.annotate_entries(
+            LGT=adjusted_sex_ploidy_expr(mt.locus, mt.LGT, mt.sex_karyotype)
+        )
+        actual = adjust_sex_ploidy(mt, mt.sex_karyotype, gt_field="LGT")
+        assert self._entries(actual, "LGT") == self._entries(expected, "LGT")

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -17,6 +17,7 @@ from gnomad.utils.annotations import (
     expand_strata_array_from_leaves,
     fill_missing_key_combinations,
     find_minimal_strata_groups,
+    find_strata_cells,
     generate_freq_group_membership_array,
     get_copy_state_by_sex,
     merge_array_expressions,
@@ -2750,6 +2751,71 @@ class TestFindMinimalStrataGroups:
         """Length-mismatched sample_count is a programmer error."""
         with pytest.raises(ValueError, match="aligned"):
             find_minimal_strata_groups([{"group": "adj"}], [1, 2])
+
+
+class TestFindStrataCells:
+    """Test the find_strata_cells function."""
+
+    @staticmethod
+    def _membership_ht(n_samples: int, n_downsamplings: int = 3) -> hl.Table:
+        """Return a Table with a full ``group_membership`` array for `n_samples` samples spread over gen_anc, sex, and `n_downsamplings` downsampling thresholds on a per-sample rank."""
+        ht = hl.utils.range_table(n_samples)
+        ht = ht.annotate(
+            gen_anc=hl.array(["afr", "nfe", "eas"])[ht.idx % 3],
+            sex=hl.array(["XX", "XY"])[ht.idx % 2],
+            rank=(ht.idx * 7) % n_samples,
+        )
+        ds = [n_samples * (d + 1) // n_downsamplings for d in range(n_downsamplings)]
+        freq_meta = [{"group": "adj"}, {"group": "raw"}]
+        exprs = [hl.literal(True), hl.literal(True)]
+        for ga in ["afr", "nfe", "eas"]:
+            for sx in ["XX", "XY"]:
+                freq_meta.append({"group": "adj", "gen_anc": ga, "sex": sx})
+                exprs.append((ht.gen_anc == ga) & (ht.sex == sx))
+        for d in ds:
+            freq_meta.append({"group": "adj", "downsampling": str(d)})
+            exprs.append(ht.rank < d)
+        ht = ht.annotate(group_membership=hl.array(exprs))
+        counts = ht.aggregate(
+            hl.agg.array_agg(lambda x: hl.agg.count_where(x), ht.group_membership)
+        )
+        return ht.annotate_globals(freq_meta=freq_meta, freq_meta_sample_count=counts)
+
+    def test_cells_partition_samples_and_rebuild_groups(self) -> None:
+        """Every sample lands in exactly one cell per label and each group's cells sum to its sample count."""
+        ht = self._membership_ht(48)
+        freq_meta = [dict(m) for m in hl.eval(ht.freq_meta)]
+        counts = list(hl.eval(ht.freq_meta_sample_count))
+        leaves, decomp, leaf_meta, leaf_counts, membership = find_strata_cells(
+            ht, freq_meta, counts
+        )
+        assert leaves == list(range(len(freq_meta), len(freq_meta) + len(leaf_meta)))
+        rows = ht.annotate(m=membership).m.collect()
+        assert all(len(m) == len(leaf_meta) for m in rows)
+        # One adj cell and the single raw cell per sample.
+        assert all(sum(m) == 2 for m in rows)
+        assert sum(leaf_counts) == 2 * 48
+        for i, children in decomp.items():
+            assert sum(leaf_counts[leaves.index(c)] for c in children) == counts[i]
+
+    def test_membership_ir_is_linear_in_cell_count(self) -> None:
+        """The returned membership expression embeds each label's cell lookup once, so its IR grows linearly with the number of cells rather than quadratically."""
+        sizes = {}
+        for n_ds in (2, 10):
+            ht = self._membership_ht(96, n_downsamplings=n_ds)
+            freq_meta = [dict(m) for m in hl.eval(ht.freq_meta)]
+            counts = list(hl.eval(ht.freq_meta_sample_count))
+            _, _, leaf_meta, _, membership = find_strata_cells(ht, freq_meta, counts)
+            ir = str(membership._ir)
+            # Every cell key is a distinct 0/1 pattern; the adj lookup dict must
+            # appear exactly once, not once per cell.
+            n_adj_cells = sum(m["group"] == "adj" for m in leaf_meta)
+            assert n_adj_cells > 1
+            sizes[n_ds] = (n_adj_cells, len(ir))
+        (c_small, ir_small), (c_large, ir_large) = sizes[2], sizes[10]
+        assert c_large > c_small
+        # Quadratic growth would scale the IR by roughly (c_large / c_small) ** 2.
+        assert ir_large / ir_small < 2 * (c_large / c_small)
 
 
 class TestExpandStrataArrayFromLeaves:

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -2798,6 +2798,34 @@ class TestFindStrataCells:
         for i, children in decomp.items():
             assert sum(leaf_counts[leaves.index(c)] for c in children) == counts[i]
 
+    def test_missing_membership_bit_means_not_a_member(self) -> None:
+        """A missing membership bit (a sample without a stratification value) is treated as False, matching `count_where` and `agg.filter` semantics."""
+        ht = self._membership_ht(48)
+        freq_meta = [dict(m) for m in hl.eval(ht.freq_meta)]
+        # Blank the gen_anc/sex bits for every afr sample, as an `hl.all([...])`
+        # over a missing strata value would. That also empties both afr groups,
+        # so the zero-sample leaf path sees missing bits too.
+        ht = ht.annotate(
+            group_membership=hl.enumerate(ht.group_membership).map(
+                lambda x: hl.if_else(
+                    (x[0] >= 2) & (x[0] < 8) & (ht.idx % 3 == 0),
+                    hl.missing(hl.tbool),
+                    x[1],
+                )
+            )
+        )
+        counts = ht.aggregate(
+            hl.agg.array_agg(lambda x: hl.agg.count_where(x), ht.group_membership)
+        )
+        leaves, decomp, leaf_meta, leaf_counts, membership = find_strata_cells(
+            ht, freq_meta, counts
+        )
+        rows = ht.annotate(m=membership).m.collect()
+        assert all(None not in m for m in rows)
+        assert all(sum(m) == 2 for m in rows)
+        for i, children in decomp.items():
+            assert sum(leaf_counts[leaves.index(c)] for c in children) == counts[i]
+
     def test_membership_ir_is_linear_in_cell_count(self) -> None:
         """The returned membership expression embeds each label's cell lookup once, so its IR grows linearly with the number of cells rather than quadratically."""
         sizes = {}

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -1024,6 +1024,49 @@ class TestComputeStatsPerRefSiteReduceToCells:
         assert decomposition[raw_idx] == []
         assert all(c for i, c in enumerate(decomposition) if i != raw_idx)
 
+    def test_zero_sample_group_kept_as_real_leaf(self, synthetic_vds, reference_ht):
+        """A gen_anc×sex group with no samples is kept as a real leaf (no cell covers it) and still expands to AN 0."""
+        vds = synthetic_vds
+        # Make every afr sample XX so the afr×XY group has zero samples.
+        vd = vds.variant_data
+        vd = vd.annotate_cols(sex=hl.if_else(vd.gen_anc == "afr", "XX", vd.sex))
+        vds = hl.vds.VariantDataset(vds.reference_data, vd)
+        full_gmh = self._build_group_membership_ht(vd)
+        cells_gmh = self._build_group_membership_ht(vd, reduce_to_cells=True)
+
+        full_meta = [dict(m) for m in hl.eval(cells_gmh.freq_meta_full)]
+        zero_idx = full_meta.index({"group": "adj", "gen_anc": "afr", "sex": "XY"})
+        assert list(hl.eval(cells_gmh.freq_meta_sample_count_full))[zero_idx] == 0
+        leaf_indices = list(hl.eval(cells_gmh.freq_leaf_indices))
+        assert zero_idx in leaf_indices
+        leaf_pos = leaf_indices.index(zero_idx)
+        assert dict(hl.eval(cells_gmh.freq_meta)[leaf_pos]) == full_meta[zero_idx]
+        assert list(hl.eval(cells_gmh.freq_meta_sample_count))[leaf_pos] == 0
+        decomposition = [list(c) for c in hl.eval(cells_gmh.freq_group_decomposition)]
+        assert decomposition[zero_idx] == []
+        assert all(c for i, c in enumerate(decomposition) if i != zero_idx)
+        assert not any(m[leaf_pos] for m in cells_gmh.group_membership.collect())
+
+        entry_agg_funcs = {"AN": (lambda t: t.GT.ploidy, hl.agg.sum)}
+        full_ht = compute_stats_per_ref_site(
+            vds, reference_ht, entry_agg_funcs, group_membership_ht=full_gmh
+        )
+        cells_ht = compute_stats_per_ref_site(
+            vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=cells_gmh,
+            reducible_aggs={"AN"},
+        )
+        assert hl.eval(cells_ht.strata_meta) == hl.eval(full_ht.strata_meta)
+        full_an = self._index(full_ht, "AN")
+        cells_an = self._index(cells_ht, "AN")
+        assert set(full_an) == set(cells_an)
+        for k in full_an:
+            assert full_an[k] == cells_an[k], k
+        zero_key = tuple(sorted(full_meta[zero_idx].items()))
+        assert cells_an[zero_key] == [0, 0, 0, 0]
+
     def test_reduce_modes_are_mutually_exclusive(self, synthetic_vds):
         """Requesting both leaf and cell reduction raises."""
         vd = synthetic_vds.variant_data

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -1010,7 +1010,7 @@ class TestComputeStatsPerRefSiteReduceToCells:
         assert full_max == cells_max
 
     def test_force_leaf_groups_kept_as_real_leaves(self, synthetic_vds):
-        """A forced leaf keeps its own `freq_meta` index ahead of the cells and is not decomposed."""
+        """A forced leaf keeps its own `freq_meta` index ahead of the cells, is not decomposed, and leaves no orphan cell behind for its label."""
         vd = synthetic_vds.variant_data
         gmh = self._build_group_membership_ht(
             vd, reduce_to_cells=True, force_leaf_groups=[{"group": "raw"}]
@@ -1019,10 +1019,17 @@ class TestComputeStatsPerRefSiteReduceToCells:
         raw_idx = full_meta.index({"group": "raw"})
         leaf_indices = list(hl.eval(gmh.freq_leaf_indices))
         assert leaf_indices[0] == raw_idx
-        assert dict(hl.eval(gmh.freq_meta)[0]) == {"group": "raw"}
+        leaf_meta = [dict(m) for m in hl.eval(gmh.freq_meta)]
+        assert leaf_meta[0] == {"group": "raw"}
         decomposition = [list(c) for c in hl.eval(gmh.freq_group_decomposition)]
         assert decomposition[raw_idx] == []
         assert all(c for i, c in enumerate(decomposition) if i != raw_idx)
+        # The raw label's only group is forced, so it must not also get a
+        # cell: every leaf is either the forced leaf or an adj cell, and every
+        # cell is referenced by some decomposition.
+        assert all(m["group"] == "adj" for m in leaf_meta[1:])
+        referenced = {c for children in decomposition for c in children}
+        assert set(leaf_indices[1:]) == referenced
 
     def test_zero_sample_group_kept_as_real_leaf(self, synthetic_vds, reference_ht):
         """A gen_anc×sex group with no samples is kept as a real leaf (no cell covers it) and still expands to AN 0."""

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -511,89 +511,93 @@ class TestComputeAlleleNumberPerRefSiteReduceToMinimalGroups:
         assert full_indexed[(("group", "raw"),)] == leaf_sums
 
 
+def _synthetic_8x4_vds() -> hl.vds.VariantDataset:
+    """Build an 8 samples × 4 sites VDS with `gen_anc`/`sex` column annotations and `adj=True` on every variant entry."""
+    samples = [
+        ("s1", "afr", "XX"),
+        ("s2", "afr", "XY"),
+        ("s3", "afr", "XX"),
+        ("s4", "afr", "XY"),
+        ("s5", "nfe", "XX"),
+        ("s6", "nfe", "XY"),
+        ("s7", "nfe", "XX"),
+        ("s8", "nfe", "XY"),
+    ]
+    positions = [1000, 2000, 3000, 4000]
+    variants = [
+        (hl.locus("chr1", p, reference_genome="GRCh38"), ["A", "T"]) for p in positions
+    ]
+    gt_patterns = [
+        [(0, 0), (0, 1), (1, 1), (0, 1), (0, 0), (0, 1), (1, 1), (0, 1)],
+        [(0, 1), None, (0, 0), (0, 1), (0, 1), (1, 1), None, (0, 1)],
+        [None, (0, 0), (0, 1), (1, 1), (0, 0), (0, 0), (0, 1), (1, 1)],
+        [(1, 1), (0, 1), (0, 1), None, (1, 1), (0, 1), (0, 1), (0, 0)],
+    ]
+
+    sample_table = hl.Table.parallelize(
+        [{"s": s, "gen_anc": g, "sex": x} for s, g, x in samples],
+        hl.tstruct(s=hl.tstr, gen_anc=hl.tstr, sex=hl.tstr),
+    ).key_by("s")
+
+    vd_entries = []
+    for v_idx, (locus, alleles) in enumerate(variants):
+        for s_idx, (sample_id, _, _) in enumerate(samples):
+            gt = gt_patterns[v_idx][s_idx]
+            vd_entries.append(
+                {
+                    "locus": locus,
+                    "alleles": alleles,
+                    "s": sample_id,
+                    "GT": hl.call(*gt) if gt is not None else hl.missing(hl.tcall),
+                    # `adj=True` for every (variant, sample) so we can build
+                    # group_membership_hts with `group_label="adj"` (the
+                    # default) and exercise non-leaf parent targets like
+                    # `{"group": "adj"}` without needing the AD/DP/GQ
+                    # fields the auto-adj path would otherwise demand.
+                    "adj": True,
+                }
+            )
+    vd = hl.Table.parallelize(
+        vd_entries,
+        hl.tstruct(
+            locus=hl.tlocus("GRCh38"),
+            alleles=hl.tarray(hl.tstr),
+            s=hl.tstr,
+            GT=hl.tcall,
+            adj=hl.tbool,
+        ),
+    ).to_matrix_table(row_key=["locus", "alleles"], col_key=["s"])
+    vd = vd.annotate_cols(
+        gen_anc=sample_table[vd.s].gen_anc,
+        sex=sample_table[vd.s].sex,
+    )
+
+    rd_entries = []
+    for locus, _ in variants:
+        for sample_id, _, _ in samples:
+            rd_entries.append(
+                {"locus": locus, "s": sample_id, "END": locus.position, "LEN": 1}
+            )
+    rd = hl.Table.parallelize(
+        rd_entries,
+        hl.tstruct(
+            locus=hl.tlocus("GRCh38"),
+            s=hl.tstr,
+            END=hl.tint32,
+            LEN=hl.tint32,
+        ),
+    ).to_matrix_table(row_key=["locus"], col_key=["s"])
+
+    return hl.vds.VariantDataset(reference_data=rd, variant_data=vd)
+
+
 class TestComputeStatsPerRefSiteReducibleAggs:
     """Test `reducible_aggs` mixes summable and non-summable aggregations under leaf reduction."""
 
     @pytest.fixture
     def synthetic_vds(self):
         """8 samples × 4 sites VDS — same shape as the AN reduction test."""
-        samples = [
-            ("s1", "afr", "XX"),
-            ("s2", "afr", "XY"),
-            ("s3", "afr", "XX"),
-            ("s4", "afr", "XY"),
-            ("s5", "nfe", "XX"),
-            ("s6", "nfe", "XY"),
-            ("s7", "nfe", "XX"),
-            ("s8", "nfe", "XY"),
-        ]
-        positions = [1000, 2000, 3000, 4000]
-        variants = [
-            (hl.locus("chr1", p, reference_genome="GRCh38"), ["A", "T"])
-            for p in positions
-        ]
-        gt_patterns = [
-            [(0, 0), (0, 1), (1, 1), (0, 1), (0, 0), (0, 1), (1, 1), (0, 1)],
-            [(0, 1), None, (0, 0), (0, 1), (0, 1), (1, 1), None, (0, 1)],
-            [None, (0, 0), (0, 1), (1, 1), (0, 0), (0, 0), (0, 1), (1, 1)],
-            [(1, 1), (0, 1), (0, 1), None, (1, 1), (0, 1), (0, 1), (0, 0)],
-        ]
-
-        sample_table = hl.Table.parallelize(
-            [{"s": s, "gen_anc": g, "sex": x} for s, g, x in samples],
-            hl.tstruct(s=hl.tstr, gen_anc=hl.tstr, sex=hl.tstr),
-        ).key_by("s")
-
-        vd_entries = []
-        for v_idx, (locus, alleles) in enumerate(variants):
-            for s_idx, (sample_id, _, _) in enumerate(samples):
-                gt = gt_patterns[v_idx][s_idx]
-                vd_entries.append(
-                    {
-                        "locus": locus,
-                        "alleles": alleles,
-                        "s": sample_id,
-                        "GT": hl.call(*gt) if gt is not None else hl.missing(hl.tcall),
-                        # `adj=True` for every (variant, sample) so we can build
-                        # group_membership_hts with `group_label="adj"` (the
-                        # default) and exercise non-leaf parent targets like
-                        # `{"group": "adj"}` without needing the AD/DP/GQ
-                        # fields the auto-adj path would otherwise demand.
-                        "adj": True,
-                    }
-                )
-        vd = hl.Table.parallelize(
-            vd_entries,
-            hl.tstruct(
-                locus=hl.tlocus("GRCh38"),
-                alleles=hl.tarray(hl.tstr),
-                s=hl.tstr,
-                GT=hl.tcall,
-                adj=hl.tbool,
-            ),
-        ).to_matrix_table(row_key=["locus", "alleles"], col_key=["s"])
-        vd = vd.annotate_cols(
-            gen_anc=sample_table[vd.s].gen_anc,
-            sex=sample_table[vd.s].sex,
-        )
-
-        rd_entries = []
-        for locus, _ in variants:
-            for sample_id, _, _ in samples:
-                rd_entries.append(
-                    {"locus": locus, "s": sample_id, "END": locus.position, "LEN": 1}
-                )
-        rd = hl.Table.parallelize(
-            rd_entries,
-            hl.tstruct(
-                locus=hl.tlocus("GRCh38"),
-                s=hl.tstr,
-                END=hl.tint32,
-                LEN=hl.tint32,
-            ),
-        ).to_matrix_table(row_key=["locus"], col_key=["s"])
-
-        return hl.vds.VariantDataset(reference_data=rd, variant_data=vd)
+        return _synthetic_8x4_vds()
 
     @pytest.fixture
     def reference_ht(self):
@@ -864,6 +868,169 @@ class TestComputeStatsPerRefSiteReducibleAggs:
         assert all(len(v) == 1 for v in full_max)
         assert all(len(v) == 1 for v in reduced_max)
         assert full_max == reduced_max
+
+
+class TestComputeStatsPerRefSiteReduceToCells:
+    """Test that the cell-based reduction (`reduce_to_cells`) preserves every per-strata value, downsamplings included."""
+
+    @pytest.fixture
+    def synthetic_vds(self):
+        """8 samples × 4 sites VDS with per-sample downsampling ranks (global and per gen_anc)."""
+        vds = _synthetic_8x4_vds()
+        vd = vds.variant_data
+        # Ranks are a fixed permutation so the downsampling groups are neither
+        # nested in nor aligned with the gen_anc/sex groups.
+        ranks = hl.literal(
+            {
+                "s1": (5, 3),
+                "s2": (0, 0),
+                "s3": (7, 2),
+                "s4": (2, 1),
+                "s5": (1, 0),
+                "s6": (6, 3),
+                "s7": (3, 1),
+                "s8": (4, 2),
+            }
+        )
+        vd = vd.annotate_cols(
+            downsampling=hl.struct(
+                global_idx=ranks[vd.s][0], gen_anc_idx=ranks[vd.s][1]
+            )
+        )
+        return hl.vds.VariantDataset(reference_data=vds.reference_data, variant_data=vd)
+
+    @pytest.fixture
+    def reference_ht(self):
+        """Return a reference HT covering the four variant loci."""
+        return hl.Table.parallelize(
+            [
+                {"locus": hl.locus("chr1", p, reference_genome="GRCh38")}
+                for p in [1000, 2000, 3000, 4000]
+            ],
+            hl.tstruct(locus=hl.tlocus("GRCh38")),
+        ).key_by("locus")
+
+    @staticmethod
+    def _index(ht, ann):
+        meta = hl.eval(ht.strata_meta)
+        rows = ht.collect()
+        return {
+            tuple(sorted(m.items())): [r[ann][i] for r in rows]
+            for i, m in enumerate(meta)
+        }
+
+    def _build_group_membership_ht(self, vd, **kwargs):
+        """Build a group_membership_ht with gen_anc, sex, gen_anc×sex, and global + per-gen_anc downsampling strata (adj label, raw group kept)."""
+        cols_ht = vd.cols()
+        strata_expr = [
+            {"gen_anc": cols_ht.gen_anc},
+            {"sex": cols_ht.sex},
+            {"gen_anc": cols_ht.gen_anc, "sex": cols_ht.sex},
+            {"downsampling": cols_ht.downsampling, "gen_anc": cols_ht.gen_anc},
+        ]
+        return generate_freq_group_membership_array(
+            cols_ht,
+            strata_expr,
+            downsamplings=[2, 4, 6],
+            ds_gen_anc_counts={"afr": 4, "nfe": 4},
+            **kwargs,
+        )
+
+    def test_cells_match_full_and_expose_cell_globals(
+        self, synthetic_vds, reference_ht
+    ):
+        """Cell-reduced AN equals the un-reduced AN for every group, including the downsampling groups leaf reduction has to compute directly; the reduced `freq_meta` holds only cells and the raw group resolves to one cell."""
+        vd = synthetic_vds.variant_data
+        full_gmh = self._build_group_membership_ht(vd)
+        cells_gmh = self._build_group_membership_ht(vd, reduce_to_cells=True)
+
+        full_meta = [dict(m) for m in hl.eval(full_gmh.freq_meta)]
+        cells_meta = [dict(m) for m in hl.eval(cells_gmh.freq_meta)]
+        n_full = len(full_meta)
+        assert [dict(m) for m in hl.eval(cells_gmh.freq_meta_full)] == full_meta
+        assert all(set(m) == {"group", "cell"} for m in cells_meta)
+        assert [m for m in cells_meta if m["group"] == "raw"] == [
+            {"group": "raw", "cell": "0"}
+        ]
+        # Every cell leaf is synthetic and every full group decomposes into cells.
+        leaf_indices = list(hl.eval(cells_gmh.freq_leaf_indices))
+        assert leaf_indices == list(range(n_full, n_full + len(cells_meta)))
+        decomposition = [list(c) for c in hl.eval(cells_gmh.freq_group_decomposition)]
+        assert all(decomposition)
+        # Cells partition the samples within each label, and the cell sample
+        # counts sum to each group's full sample count.
+        cell_counts = list(hl.eval(cells_gmh.freq_meta_sample_count))
+        full_counts = list(hl.eval(cells_gmh.freq_meta_sample_count_full))
+        for i, children in enumerate(decomposition):
+            assert (
+                sum(cell_counts[c - n_full] for c in children) == full_counts[i]
+            ), full_meta[i]
+        assert (
+            sum(c for c, m in zip(cell_counts, cells_meta) if m["group"] == "adj") == 8
+        )
+        membership = cells_gmh.group_membership.collect()
+        # Each sample is in exactly one adj cell and the raw cell.
+        assert all(sum(m) == 2 for m in membership)
+
+        entry_agg_funcs = {
+            "AN": (lambda t: t.GT.ploidy, hl.agg.sum),
+            "max_called": (lambda t: hl.int32(hl.is_defined(t.GT)), hl.agg.max),
+        }
+        raw_target = {"group": "raw"}
+        full_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=full_gmh,
+            entry_agg_group_membership={"max_called": [raw_target]},
+        )
+        cells_ht = compute_stats_per_ref_site(
+            synthetic_vds,
+            reference_ht,
+            entry_agg_funcs,
+            group_membership_ht=cells_gmh,
+            reducible_aggs={"AN"},
+            entry_agg_group_membership={"max_called": [raw_target]},
+        )
+
+        assert hl.eval(cells_ht.strata_meta) == hl.eval(full_ht.strata_meta)
+        assert hl.eval(cells_ht.strata_sample_count) == hl.eval(
+            full_ht.strata_sample_count
+        )
+        full_an = self._index(full_ht, "AN")
+        cells_an = self._index(cells_ht, "AN")
+        assert set(full_an) == set(cells_an)
+        assert any("downsampling" in dict(k) for k in full_an)
+        for k in full_an:
+            assert full_an[k] == cells_an[k], k
+
+        full_max = [r.max_called for r in full_ht.collect()]
+        cells_max = [r.max_called for r in cells_ht.collect()]
+        assert all(len(v) == 1 for v in cells_max)
+        assert full_max == cells_max
+
+    def test_force_leaf_groups_kept_as_real_leaves(self, synthetic_vds):
+        """A forced leaf keeps its own `freq_meta` index ahead of the cells and is not decomposed."""
+        vd = synthetic_vds.variant_data
+        gmh = self._build_group_membership_ht(
+            vd, reduce_to_cells=True, force_leaf_groups=[{"group": "raw"}]
+        )
+        full_meta = [dict(m) for m in hl.eval(gmh.freq_meta_full)]
+        raw_idx = full_meta.index({"group": "raw"})
+        leaf_indices = list(hl.eval(gmh.freq_leaf_indices))
+        assert leaf_indices[0] == raw_idx
+        assert dict(hl.eval(gmh.freq_meta)[0]) == {"group": "raw"}
+        decomposition = [list(c) for c in hl.eval(gmh.freq_group_decomposition)]
+        assert decomposition[raw_idx] == []
+        assert all(c for i, c in enumerate(decomposition) if i != raw_idx)
+
+    def test_reduce_modes_are_mutually_exclusive(self, synthetic_vds):
+        """Requesting both leaf and cell reduction raises."""
+        vd = synthetic_vds.variant_data
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            self._build_group_membership_ht(
+                vd, reduce_to_cells=True, reduce_to_minimal_groups=True
+            )
 
 
 class TestComputeStatsPerRefSiteSexKaryotype:

--- a/tests/utils/test_sparse_mt.py
+++ b/tests/utils/test_sparse_mt.py
@@ -864,3 +864,86 @@ class TestComputeStatsPerRefSiteReducibleAggs:
         assert all(len(v) == 1 for v in full_max)
         assert all(len(v) == 1 for v in reduced_max)
         assert full_max == reduced_max
+
+
+class TestComputeStatsPerRefSiteSexKaryotype:
+    """Test the `sex_karyotype_field` genotype ploidy adjustment."""
+
+    @pytest.fixture
+    def sex_chrom_vds(self):
+        """
+        Build a VDS of 4 samples (2 XX, 2 XY) at chrX PAR1, chrX non-PAR and chrY non-PAR.
+
+        Every sample carries a called het genotype at every site (the
+        variant_data covers each locus, so the 1-base ref blocks are not
+        needed for densification), giving diploid AN = 2 per sample before
+        the ploidy adjustment.
+        """
+        samples = [("s1", "XX"), ("s2", "XX"), ("s3", "XY"), ("s4", "XY")]
+        loci = [
+            hl.locus("chrX", 20000, reference_genome="GRCh38"),
+            hl.locus("chrX", 5000000, reference_genome="GRCh38"),
+            hl.locus("chrY", 5000000, reference_genome="GRCh38"),
+        ]
+        vd = hl.Table.parallelize(
+            [
+                {"locus": l, "alleles": ["A", "T"], "s": s, "GT": hl.call(0, 1)}
+                for l in loci
+                for s, _ in samples
+            ],
+            hl.tstruct(
+                locus=hl.tlocus("GRCh38"),
+                alleles=hl.tarray(hl.tstr),
+                s=hl.tstr,
+                GT=hl.tcall,
+            ),
+        ).to_matrix_table(row_key=["locus", "alleles"], col_key=["s"])
+        karyotype = hl.literal(dict(samples), hl.tdict(hl.tstr, hl.tstr))
+        vd = vd.annotate_cols(sex_karyotype=karyotype.get(vd.s))
+        rd = hl.Table.parallelize(
+            [
+                {"locus": l, "s": s, "END": l.position, "LEN": 1}
+                for l in loci
+                for s, _ in samples
+            ],
+            hl.tstruct(
+                locus=hl.tlocus("GRCh38"), s=hl.tstr, END=hl.tint32, LEN=hl.tint32
+            ),
+        ).to_matrix_table(row_key=["locus"], col_key=["s"])
+        return hl.vds.VariantDataset(reference_data=rd, variant_data=vd)
+
+    @pytest.fixture
+    def reference_ht(self):
+        """Return a reference HT covering the three sex-chromosome loci."""
+        return hl.Table.parallelize(
+            [
+                {"locus": hl.locus(c, p, reference_genome="GRCh38")}
+                for c, p in [("chrX", 20000), ("chrX", 5000000), ("chrY", 5000000)]
+            ],
+            hl.tstruct(locus=hl.tlocus("GRCh38")),
+        ).key_by("locus")
+
+    def test_an_adjusted_for_sex_karyotype(self, sex_chrom_vds, reference_ht):
+        """XY het calls on non-PAR X/Y become missing and XX calls on Y are dropped."""
+        an_agg = (
+            lambda t: t.GT,
+            lambda gt: hl.agg.sum(gt.ploidy),
+        )
+        ht = compute_stats_per_ref_site(
+            sex_chrom_vds,
+            reference_ht,
+            {"AN": an_agg},
+            sex_karyotype_field="sex_karyotype",
+        )
+        an = {(r.locus.contig, r.locus.position): r.AN for r in ht.collect()}
+        # PAR: all 4 samples stay diploid.
+        assert an[("chrX", 20000)] == 8
+        # Non-PAR X: XX diploid (2 x 2); XY hets are set to missing.
+        assert an[("chrX", 5000000)] == 4
+        # Non-PAR Y: XX set to missing; XY hets set to missing.
+        assert an[("chrY", 5000000)] == 0
+
+        unadjusted = compute_stats_per_ref_site(
+            sex_chrom_vds, reference_ht, {"AN": an_agg}
+        )
+        assert all(r.AN == 8 for r in unadjusted.collect())


### PR DESCRIPTION
Two changes that make compute_stats_per_ref_site (per-reference-site AN and coverage over a densified VDS) cheaper to run without changing its output. Both are needed by the gnomAD v5 AoU coverage/AN pipeline.

**Breaking change:** `annotate_and_index_source_mt_for_sex_ploidy` now takes the MatrixTable and karyotype expression and returns the annotated MT plus its column and row flag structs, instead of taking a locus expression and indexing the flags back through a `cols()`/`rows()` self-join. The only downstream caller is gnomad_qc v4 `fix_freq_an.py` (line 217). The old behavior is available unchanged under the new public name `index_sex_ploidy_flags`, so that call can be fixed by renaming it. `adjust_sex_ploidy` and `adjusted_sex_ploidy_expr` keep their signatures.

1. **Sex-ploidy adjustment without a second densify.** `adjusted_sex_ploidy_expr` looks up each sample's karyotype and each locus's PAR status by reaching back into the source MatrixTable's columns and rows, which Hail evaluates as a second full densify on a densified VDS. `annotate_and_index_source_mt_for_sex_ploidy` now annotates those flags directly onto the MT it is given, `adjust_sex_ploidy` is a thin wrapper over it, and `compute_stats_per_ref_site` uses that path. The flags themselves are defined once in `get_sex_ploidy_col_flags_expr` / `get_sex_ploidy_row_flags_expr`, and the genotype rules are shared with `adjusted_sex_ploidy_expr` via `_sex_ploidy_case_expr`. Temporary flag fields use collision-safe names.

2. **Aggregate once per "cell" instead of once per group.** Allele-number aggregation previously ran once for every `freq_meta` group, and the minimal-groups reduction could not help with downsampling groups. The new `reduce_to_cells` option groups samples by their exact pattern of group memberships. Cells don't overlap and every group is exactly a set of cells, so every group's value, downsamplings included, is recovered by summing its cells. It uses the same reduction globals as before. `force_leaf_groups` still works, groups with no samples are kept as real leaves, and a `freq_meta` entry without a `"group"` key or a `force_leaf_groups` target not in `freq_meta` raises up front.

Tests cover both changes, including that cell reconstruction matches both the full aggregation and `find_minimal_strata_groups`. The `/review` skill was run with Opus and Sonnet 5; both of its findings were accepted and addressed (the breaking change above is documented, and `index_sex_ploidy_flags` was made public).
