### PR TITLE
Set hail!=0.2.139 in requirements.txt to avoid array-literal contains memory regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 annoy
 ga4gh.vrs==2.2.0
-hail
+# TODO: Remove this exclusion once Hail fixes the 0.2.139 memory regression where
+# an array literal's .contains() inside a Table filter (e.g. filter_gencode_ht)
+# leaks region memory, OOMs the driver, and hangs pytest. This pin lifts itself
+# on 0.2.140; check that release's change log for the fix, and if the tests
+# hang again in test_transcript_annotation.py, exclude 0.2.140 too.
+hail!=0.2.139
 hdbscan
 ipywidgets
 networkx

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,22 @@
 """Setup script."""
 
+import re
+
 import setuptools
 
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()
 
+# Hail is deliberately excluded from install_requires: users install the Hail
+# version that matches their cluster. Match the name only so that a version
+# specifier on the requirements.txt line (e.g. ``hail!=0.2.139``) is still excluded.
 install_requires = []
 with open("requirements.txt", "r") as requirements_file:
     for req in (line.strip() for line in requirements_file):
-        if req != "hail":
+        if not req or req.startswith("#"):
+            continue
+        if re.split(r"[<>=!~\[; ]", req, maxsplit=1)[0] != "hail":
             install_requires.append(req)
 
 


### PR DESCRIPTION
Hail 0.2.139 leaks region memory when an array literal's .contains() is used inside a Table filter (e.g. filter_gencode_ht's hl.literal(feature).contains(...). In CI the 1 GB driver JVM runs out of heap during test_filter_to_cds, dies, and pytest hangs on the dead py4j connection until the job is cancelled. Set-based membership and Hail 0.2.138 are unaffected.

setup.py has excluded hail from install_requires since 2020 by matching the exact string hail, the edits to set up now get around the < version bit. We will revert to an unpinned version once the 139 bugs are fixed. 

I chose to update requirements since the test suite will fail locally for anyone trying to run it on 0.2.139 as opposed to updating just the way git actions was installing hail.